### PR TITLE
feat: parse cache — instant repeat book opens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,6 +21,8 @@ android {
         versionCode = 14
         versionName = "1.8.0"
 
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
         vectorDrawables {
             useSupportLibrary = true
         }
@@ -189,4 +191,9 @@ dependencies {
 
     // Json
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+
+    // Instrumented tests
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test:runner:1.6.2")
+    androidTestImplementation("androidx.test:core:1.6.1")
 }

--- a/app/src/androidTest/java/ua/acclorite/book_story/data/cache/AnnotatedStringCodecTest.kt
+++ b/app/src/androidTest/java/ua/acclorite/book_story/data/cache/AnnotatedStringCodecTest.kt
@@ -1,0 +1,201 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.cache
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.BaselineShift
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.em
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Round-trips every span/link shape the parser emits through
+ * [AnnotatedStringCodec] and asserts the result equals the original. The styles
+ * below mirror [ua.acclorite.book_story.data.parser.document.MarkdownParser].
+ */
+@RunWith(AndroidJUnit4::class)
+class AnnotatedStringCodecTest {
+
+    private fun roundTrip(value: AnnotatedString) {
+        val restored = AnnotatedStringCodec.decodeFromBytes(
+            AnnotatedStringCodec.encodeToBytes(value)
+        )
+        // Compare what the cache must preserve — the rendered result: text, span
+        // styles and link annotations. Not AnnotatedString.equals(), which is
+        // sensitive to the insertion order of overlapping annotations (an internal
+        // detail that does not affect rendering and is not part of the contract).
+        assertEquals("text", value.text, restored.text)
+        assertEquals("spanStyles", value.spanStyles, restored.spanStyles)
+        assertEquals(
+            "links",
+            value.getLinkAnnotations(0, value.length),
+            restored.getLinkAnnotations(0, restored.length)
+        )
+    }
+
+    @Test
+    fun plainText() = roundTrip(AnnotatedString("Just plain text, кирилиця, 123."))
+
+    @Test
+    fun emptyText() = roundTrip(AnnotatedString(""))
+
+    @Test
+    fun bold() = roundTrip(
+        buildAnnotatedString {
+            append("a ")
+            withStyle(SpanStyle(fontWeight = FontWeight.Medium)) { append("bold") }
+            append(" b")
+        }
+    )
+
+    @Test
+    fun italic() = roundTrip(
+        buildAnnotatedString {
+            withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append("italic") }
+        }
+    )
+
+    @Test
+    fun monospace() = roundTrip(
+        buildAnnotatedString {
+            withStyle(SpanStyle(fontFamily = FontFamily.Monospace)) { append("code()") }
+        }
+    )
+
+    @Test
+    fun strikethrough() = roundTrip(
+        buildAnnotatedString {
+            withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) { append("gone") }
+        }
+    )
+
+    @Test
+    fun subscript() = roundTrip(
+        buildAnnotatedString {
+            append("H")
+            withStyle(SpanStyle(baselineShift = BaselineShift.Subscript, fontSize = 0.75.em)) {
+                append("2")
+            }
+            append("O")
+        }
+    )
+
+    @Test
+    fun superscript() = roundTrip(
+        buildAnnotatedString {
+            append("x")
+            withStyle(SpanStyle(baselineShift = BaselineShift.Superscript, fontSize = 0.75.em)) {
+                append("2")
+            }
+        }
+    )
+
+    @Test
+    fun boldItalicComposed() = roundTrip(
+        buildAnnotatedString {
+            withStyle(SpanStyle(fontWeight = FontWeight.Medium)) {
+                append("bold ")
+                withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append("and italic") }
+            }
+        }
+    )
+
+    @Test
+    fun externalLink() = roundTrip(
+        buildAnnotatedString {
+            append("see ")
+            withLink(
+                LinkAnnotation.Url(
+                    "https://example.com",
+                    styles = TextLinkStyles(SpanStyle(textDecoration = TextDecoration.Underline))
+                )
+            ) { append("here") }
+        }
+    )
+
+    @Test
+    fun noteReference() = roundTrip(
+        buildAnnotatedString {
+            append("text")
+            withLink(
+                LinkAnnotation.Clickable(
+                    tag = "note:6162",
+                    styles = TextLinkStyles(
+                        SpanStyle(baselineShift = BaselineShift.Superscript, fontSize = 0.75.em)
+                    ),
+                    linkInteractionListener = null
+                )
+            ) { append("[1]") }
+        }
+    )
+
+    @Test
+    fun anchorReference() = roundTrip(
+        buildAnnotatedString {
+            withLink(
+                LinkAnnotation.Clickable(
+                    tag = "anchor:6162",
+                    styles = TextLinkStyles(SpanStyle(textDecoration = TextDecoration.Underline)),
+                    linkInteractionListener = null
+                )
+            ) { append("jump") }
+            append(" back")
+        }
+    )
+
+    @Test
+    fun styledTextInsideLink() = roundTrip(
+        buildAnnotatedString {
+            withLink(
+                LinkAnnotation.Url(
+                    "https://example.com",
+                    styles = TextLinkStyles(SpanStyle(textDecoration = TextDecoration.Underline))
+                )
+            ) {
+                withStyle(SpanStyle(fontWeight = FontWeight.Medium)) { append("bold link") }
+            }
+        }
+    )
+
+    @Test
+    fun everythingCombined() = roundTrip(
+        buildAnnotatedString {
+            append("intro ")
+            withStyle(SpanStyle(fontWeight = FontWeight.Medium)) { append("bold ") }
+            withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append("italic ") }
+            withStyle(SpanStyle(fontFamily = FontFamily.Monospace)) { append("mono ") }
+            withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) { append("struck ") }
+            append("water H")
+            withStyle(SpanStyle(baselineShift = BaselineShift.Subscript, fontSize = 0.75.em)) {
+                append("2")
+            }
+            append("O and note")
+            withLink(
+                LinkAnnotation.Clickable(
+                    tag = "note:99",
+                    styles = TextLinkStyles(
+                        SpanStyle(baselineShift = BaselineShift.Superscript, fontSize = 0.75.em)
+                    ),
+                    linkInteractionListener = null
+                )
+            ) { append("[2]") }
+            append(" end")
+        }
+    )
+}

--- a/app/src/androidTest/java/ua/acclorite/book_story/data/cache/ParseCacheTest.kt
+++ b/app/src/androidTest/java/ua/acclorite/book_story/data/cache/ParseCacheTest.kt
@@ -1,0 +1,233 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.cache
+
+import android.app.Application
+import androidx.compose.ui.text.AnnotatedString
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import ua.acclorite.book_story.domain.model.reader.ParsedText
+import ua.acclorite.book_story.domain.model.reader.ReaderText
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class ParseCacheTest {
+
+    private lateinit var app: Application
+    private lateinit var cache: ParseCache
+
+    private val sample = ParsedText(
+        text = listOf(
+            ReaderText.Chapter(title = "Chapter"),
+            ReaderText.Text(AnnotatedString("Hello world")),
+            ReaderText.Text(AnnotatedString("Second line"))
+        ),
+        notes = mapOf("n" to AnnotatedString("a note"))
+    )
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        cache = ParseCache(app)
+        cache.clear()
+    }
+
+    @Test
+    fun writeThenReadHit() {
+        cache.write(PATH, SIZE, MODIFIED, sample)
+        val restored = cache.read(PATH, SIZE, MODIFIED)
+
+        assertNotNull(restored)
+        assertEquals(3, restored!!.text.size)
+        assertEquals("Hello world", (restored.text[1] as ReaderText.Text).line.text)
+        assertEquals(setOf("n"), restored.notes.keys)
+    }
+
+    @Test
+    fun missBeforeWrite() {
+        assertNull(cache.read("never-written", SIZE, MODIFIED))
+    }
+
+    @Test
+    fun missOnDifferentIdentity() {
+        cache.write(PATH, SIZE, MODIFIED, sample)
+
+        assertNull("different size is a miss", cache.read(PATH, SIZE + 1, MODIFIED))
+        assertNull("different mtime is a miss", cache.read(PATH, SIZE, MODIFIED + 1))
+        assertNull("different path is a miss", cache.read("$PATH.other", SIZE, MODIFIED))
+    }
+
+    @Test
+    fun removeThenMiss() {
+        cache.write(PATH, SIZE, MODIFIED, sample)
+        cache.remove(PATH, SIZE, MODIFIED)
+
+        assertNull(cache.read(PATH, SIZE, MODIFIED))
+    }
+
+    @Test
+    fun clearRemovesAll() {
+        cache.write(PATH, SIZE, MODIFIED, sample)
+        cache.write("$PATH.2", SIZE, MODIFIED, sample)
+
+        cache.clear()
+
+        assertNull(cache.read(PATH, SIZE, MODIFIED))
+        assertNull(cache.read("$PATH.2", SIZE, MODIFIED))
+    }
+
+    @Test
+    fun totalSizeBytesSumsEntries() {
+        cache.write(PATH, SIZE, MODIFIED, sample)
+        cache.write("$PATH.2", SIZE, MODIFIED, sample)
+
+        val one = cache.entrySizeBytes(PATH, SIZE, MODIFIED)
+        assertEquals(2 * one, cache.totalSizeBytes())
+    }
+
+    @Test
+    fun writeEvictsOldestOverCap() {
+        // Two entries, A older than B, then a capped write of C.
+        cache.write(PATH, SIZE, MODIFIED, sample)
+        val fileA = entries().single()
+        fileA.setLastModified(1_000)
+        cache.write("$PATH.2", SIZE, MODIFIED, sample)
+        (entries() - fileA).single().setLastModified(2_000)
+
+        val one = cache.entrySizeBytes(PATH, SIZE, MODIFIED)
+        // Cap holds two entries; writing a third must evict exactly the oldest (A).
+        cache.write("$PATH.3", SIZE, MODIFIED, sample, maxBytes = 2 * one)
+
+        assertNull("oldest is evicted", cache.read(PATH, SIZE, MODIFIED))
+        assertNotNull(cache.read("$PATH.2", SIZE, MODIFIED))
+        assertNotNull("just-written entry is never evicted", cache.read("$PATH.3", SIZE, MODIFIED))
+    }
+
+    @Test
+    fun readTouchesEntryForLru() {
+        cache.write(PATH, SIZE, MODIFIED, sample)
+        val fileA = entries().single()
+        fileA.setLastModified(1_000)
+        cache.write("$PATH.2", SIZE, MODIFIED, sample)
+        (entries() - fileA).single().setLastModified(2_000)
+
+        // Reading A makes it most-recently-used, so B becomes the eviction target.
+        cache.read(PATH, SIZE, MODIFIED)
+
+        val one = cache.entrySizeBytes(PATH, SIZE, MODIFIED)
+        cache.write("$PATH.3", SIZE, MODIFIED, sample, maxBytes = 2 * one)
+
+        assertNotNull("touched entry survives", cache.read(PATH, SIZE, MODIFIED))
+        assertNull("untouched entry is evicted", cache.read("$PATH.2", SIZE, MODIFIED))
+        assertNotNull(cache.read("$PATH.3", SIZE, MODIFIED))
+    }
+
+    @Test
+    fun trimToSizeEvictsOldest() {
+        cache.write(PATH, SIZE, MODIFIED, sample)
+        val fileA = entries().single()
+        fileA.setLastModified(1_000)
+        cache.write("$PATH.2", SIZE, MODIFIED, sample)
+        (entries() - fileA).single().setLastModified(2_000)
+
+        val one = cache.entrySizeBytes(PATH, SIZE, MODIFIED)
+        cache.trimToSize(one) // room for a single entry — the newest.
+
+        assertNull(cache.read(PATH, SIZE, MODIFIED))
+        assertNotNull(cache.read("$PATH.2", SIZE, MODIFIED))
+    }
+
+    @Test
+    fun corruptEntryIsTreatedAsMiss() {
+        cache.write(PATH, SIZE, MODIFIED, sample)
+
+        // Corrupt the stored text blob on disk.
+        val dir = File(app.cacheDir, "parsed_books")
+        val entry = dir.listFiles()!!.first { it.isDirectory }
+        File(entry, "text").writeBytes(byteArrayOf(0, 1, 2, 3, 4, 5))
+
+        assertNull(cache.read(PATH, SIZE, MODIFIED))
+        // A corrupt entry is dropped (whole book dir), not left behind.
+        assertNull(dir.listFiles()?.firstOrNull { it.name == entry.name })
+    }
+
+    @Test
+    fun writeImagesThenReadBlobs() {
+        val images = mapOf(
+            "cover.jpg" to byteArrayOf(1, 2, 3, 4),
+            "fig1.png" to byteArrayOf(5, 6, 7)
+        )
+        cache.write(PATH, SIZE, MODIFIED, sample, images = images)
+
+        val blobs = cache.readImageBlobs(PATH, SIZE, MODIFIED, images.keys)
+        assertEquals(setOf("cover.jpg", "fig1.png"), blobs.keys)
+        assertArrayEquals(images["cover.jpg"], blobs["cover.jpg"])
+        assertArrayEquals(images["fig1.png"], blobs["fig1.png"])
+    }
+
+    @Test
+    fun readImageBlobsIgnoresAbsentSrcs() {
+        cache.write(
+            PATH, SIZE, MODIFIED, sample,
+            images = mapOf("present.jpg" to byteArrayOf(9))
+        )
+
+        val blobs = cache.readImageBlobs(PATH, SIZE, MODIFIED, setOf("present.jpg", "absent.jpg"))
+        assertEquals(setOf("present.jpg"), blobs.keys)
+    }
+
+    @Test
+    fun writeImageBlobsRequiresExistingBook() {
+        // No text entry written first → blobs must not be persisted on their own.
+        cache.writeImageBlobs(PATH, SIZE, MODIFIED, mapOf("x.jpg" to byteArrayOf(1)))
+
+        assertNull(cache.read(PATH, SIZE, MODIFIED))
+        assertEquals(emptySet<String>(), cache.readImageBlobs(PATH, SIZE, MODIFIED, setOf("x.jpg")).keys)
+    }
+
+    @Test
+    fun capCountsImageBlobsWhenEvicting() {
+        // A carries a large blob; B is text-only. A is older, so a capped write
+        // of C must evict A once its blob is counted in the total.
+        val bigBlob = ByteArray(4096) { 1 }
+        cache.write(PATH, SIZE, MODIFIED, sample, images = mapOf("big.jpg" to bigBlob))
+        val fileA = entries().single()
+        fileA.setLastModified(1_000)
+
+        val textOnly = cache.entrySizeBytes("$PATH.2", SIZE, MODIFIED) // 0, not written yet
+        cache.write("$PATH.2", SIZE, MODIFIED, sample)
+        (entries() - fileA).single().setLastModified(2_000)
+
+        val bText = cache.entrySizeBytes("$PATH.2", SIZE, MODIFIED)
+        assertEquals(0, textOnly)
+        // Cap = two text-only books' worth; A (text + 4 KB blob) blows past it and,
+        // being oldest, is the one evicted.
+        cache.write("$PATH.3", SIZE, MODIFIED, sample, maxBytes = 2 * bText)
+
+        assertNull("book with the large blob is evicted", cache.read(PATH, SIZE, MODIFIED))
+        assertNotNull(cache.read("$PATH.2", SIZE, MODIFIED))
+        assertNotNull(cache.read("$PATH.3", SIZE, MODIFIED))
+    }
+
+    /** Committed cache book directories on disk. */
+    private fun entries(): List<File> =
+        File(app.cacheDir, "parsed_books")
+            .listFiles()?.filter { it.isDirectory } ?: emptyList()
+
+    private companion object {
+        const val PATH = "/tree/primary:Books/document/primary:Books%2Fbook.fb2"
+        const val SIZE = 123_456L
+        const val MODIFIED = 1_700_000_000_000L
+    }
+}

--- a/app/src/androidTest/java/ua/acclorite/book_story/data/cache/ParsedTextCodecTest.kt
+++ b/app/src/androidTest/java/ua/acclorite/book_story/data/cache/ParsedTextCodecTest.kt
@@ -1,0 +1,210 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.cache
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.BaselineShift
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.em
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import ua.acclorite.book_story.domain.model.reader.ParsedText
+import ua.acclorite.book_story.domain.model.reader.ReaderImage
+import ua.acclorite.book_story.domain.model.reader.ReaderText
+import ua.acclorite.book_story.domain.model.reader.ReaderTextRole
+
+@RunWith(AndroidJUnit4::class)
+class ParsedTextCodecTest {
+
+    @Test
+    fun empty() = roundTrip(ParsedText.EMPTY)
+
+    @Test
+    fun allElementTypes() {
+        val linkedText = buildAnnotatedString {
+            append("see ")
+            withLink(
+                LinkAnnotation.Url(
+                    "https://example.com",
+                    styles = TextLinkStyles(SpanStyle(textDecoration = TextDecoration.Underline))
+                )
+            ) {
+                // bold inside a link — exercises overlapping annotations
+                withStyle(SpanStyle(fontWeight = FontWeight.Medium)) { append("bold link") }
+            }
+        }
+
+        val parsed = ParsedText(
+            text = listOf(
+                ReaderText.Chapter(title = "Розділ 1", depth = 0),
+                ReaderText.Chapter(title = "Nested", depth = 2),
+                ReaderText.Text(
+                    line = buildAnnotatedString {
+                        append("A ")
+                        withStyle(SpanStyle(fontWeight = FontWeight.Medium)) { append("bold") }
+                        append(" paragraph.")
+                    },
+                    role = ReaderTextRole.Paragraph
+                ),
+                ReaderText.Text(line = linkedText, role = ReaderTextRole.Title),
+                ReaderText.Separator,
+                ReaderText.Poem(
+                    lines = listOf(
+                        ReaderText.Text(AnnotatedString("First verse")),
+                        ReaderText.Text(
+                            line = buildAnnotatedString {
+                                withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append("Author") }
+                            },
+                            role = ReaderTextRole.TextAuthor
+                        )
+                    )
+                ),
+                ReaderText.Table(
+                    rows = listOf(
+                        listOf(
+                            AnnotatedString("H1"),
+                            buildAnnotatedString {
+                                withStyle(SpanStyle(fontWeight = FontWeight.Medium)) { append("H2") }
+                            }
+                        ),
+                        listOf(AnnotatedString("a"), AnnotatedString("b"))
+                    ),
+                    hasHeader = true
+                ),
+                ReaderText.Image(
+                    image = ReaderImage(
+                        id = "cover.jpg-3-42",
+                        src = "cover.jpg",
+                        bytes = byteArrayOf(1, 2, 3),
+                        width = 100,
+                        height = 200
+                    ),
+                    caption = ReaderText.Text(
+                        buildAnnotatedString {
+                            withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append("A caption") }
+                        }
+                    )
+                ),
+                ReaderText.Image(
+                    image = ReaderImage(
+                        id = "pic.png-1-7",
+                        src = "pic.png",
+                        bytes = byteArrayOf(9),
+                        width = 10,
+                        height = 20
+                    ),
+                    caption = null
+                )
+            ),
+            notes = mapOf(
+                "n1" to AnnotatedString("A plain note."),
+                "n2" to buildAnnotatedString {
+                    append("H")
+                    withStyle(
+                        SpanStyle(baselineShift = BaselineShift.Subscript, fontSize = 0.75.em)
+                    ) { append("2") }
+                    append("O note")
+                }
+            )
+        )
+
+        roundTrip(parsed)
+    }
+
+    // --- helpers: compare the render-relevant contract, not order-sensitive equals ---
+
+    private fun roundTrip(parsed: ParsedText) {
+        val restored = ParsedTextCodec.decodeFromBytes(ParsedTextCodec.encodeToBytes(parsed))
+        assertParsedTextEquals(parsed, restored)
+    }
+
+    private fun assertParsedTextEquals(expected: ParsedText, actual: ParsedText) {
+        assertEquals("text size", expected.text.size, actual.text.size)
+        expected.text.forEachIndexed { i, element ->
+            assertElementEquals("text[$i]", element, actual.text[i])
+        }
+        assertEquals("note keys", expected.notes.keys, actual.notes.keys)
+        expected.notes.forEach { (key, value) ->
+            assertAnnotatedEquals("note[$key]", value, actual.notes.getValue(key))
+        }
+    }
+
+    private fun assertElementEquals(msg: String, expected: ReaderText, actual: ReaderText) {
+        assertEquals("$msg type", expected::class, actual::class)
+        when (expected) {
+            is ReaderText.Chapter -> {
+                actual as ReaderText.Chapter
+                assertEquals("$msg id", expected.id, actual.id)
+                assertEquals("$msg title", expected.title, actual.title)
+                assertEquals("$msg depth", expected.depth, actual.depth)
+            }
+
+            is ReaderText.Text -> assertTextEquals(msg, expected, actual as ReaderText.Text)
+
+            is ReaderText.Poem -> {
+                actual as ReaderText.Poem
+                assertEquals("$msg poem size", expected.lines.size, actual.lines.size)
+                expected.lines.forEachIndexed { i, line ->
+                    assertTextEquals("$msg line[$i]", line, actual.lines[i])
+                }
+            }
+
+            is ReaderText.Table -> {
+                actual as ReaderText.Table
+                assertEquals("$msg hasHeader", expected.hasHeader, actual.hasHeader)
+                assertEquals("$msg rows", expected.rows.size, actual.rows.size)
+                expected.rows.forEachIndexed { r, row ->
+                    assertEquals("$msg row[$r] size", row.size, actual.rows[r].size)
+                    row.forEachIndexed { c, cell ->
+                        assertAnnotatedEquals("$msg cell[$r,$c]", cell, actual.rows[r][c])
+                    }
+                }
+            }
+
+            is ReaderText.Separator -> Unit
+
+            is ReaderText.Image -> {
+                actual as ReaderText.Image
+                assertEquals("$msg image id", expected.image.id, actual.image.id)
+                assertEquals("$msg image src", expected.image.src, actual.image.src)
+                assertEquals("$msg image width", expected.image.width, actual.image.width)
+                assertEquals("$msg image height", expected.image.height, actual.image.height)
+                val expectedCaption = expected.caption
+                if (expectedCaption == null) {
+                    assertEquals("$msg caption", null, actual.caption)
+                } else {
+                    assertTextEquals("$msg caption", expectedCaption, actual.caption!!)
+                }
+            }
+        }
+    }
+
+    private fun assertTextEquals(msg: String, expected: ReaderText.Text, actual: ReaderText.Text) {
+        assertEquals("$msg role", expected.role, actual.role)
+        assertAnnotatedEquals(msg, expected.line, actual.line)
+    }
+
+    private fun assertAnnotatedEquals(msg: String, expected: AnnotatedString, actual: AnnotatedString) {
+        assertEquals("$msg text", expected.text, actual.text)
+        assertEquals("$msg spanStyles", expected.spanStyles, actual.spanStyles)
+        assertEquals(
+            "$msg links",
+            expected.getLinkAnnotations(0, expected.length),
+            actual.getLinkAnnotations(0, actual.length)
+        )
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/core/helpers/PrimitiveHelpers.kt
+++ b/app/src/main/java/ua/acclorite/book_story/core/helpers/PrimitiveHelpers.kt
@@ -30,12 +30,17 @@ fun Float?.coerceAndPreventNaN(): Float {
     return this.coerceIn(0f, 1f)
 }
 
+// Compiled once — these run in the per-line hot loop of DocumentParser, several
+// times per line, so per-call Regex() compilation dominated parse time.
+private val MARKDOWN_MARKS_REGEX = Regex("(_+)|(\\*+)")
+private val ALL_MARKDOWN_MARKS_REGEX = Regex("(_+)|(\\*+)|(#+)")
+
 fun String.clearMarkdown(): String {
-    return replace(Regex("(_+)|(\\*+)"), "")
+    return replace(MARKDOWN_MARKS_REGEX, "")
 }
 
 fun String.clearAllMarkdown(): String {
-    return replace(Regex("(_+)|(\\*+)|(#+)"), "").trim()
+    return replace(ALL_MARKDOWN_MARKS_REGEX, "").trim()
 }
 
 fun String.containsVisibleText(): Boolean {

--- a/app/src/main/java/ua/acclorite/book_story/data/cache/AnnotatedStringCodec.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/cache/AnnotatedStringCodec.kt
@@ -1,0 +1,181 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.cache
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.BaselineShift
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.em
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInput
+import java.io.DataInputStream
+import java.io.DataOutput
+import java.io.DataOutputStream
+
+/**
+ * Binary (de)serializer for the [AnnotatedString]s produced by the book parser.
+ *
+ * The parser emits only a small, fixed set of inline styles, so every
+ * [SpanStyle] it can produce packs losslessly into a single [Int] bitmask
+ * ([toStyleMask]). This keeps the cache compact — text as UTF-8 plus 12 bytes
+ * per span — and avoids a general (and heavy) style serializer.
+ *
+ * Writes/reads through [DataOutput]/[DataInput] so it composes into the larger
+ * `ParsedText` cache format. IMPORTANT: this only covers the styles the parser
+ * actually emits; extend the mask (and bump the cache's parser version) if the
+ * parser starts producing new ones.
+ */
+object AnnotatedStringCodec {
+
+    private const val BOLD = 1 shl 0        // FontWeight.Medium
+    private const val ITALIC = 1 shl 1      // FontStyle.Italic
+    private const val MONOSPACE = 1 shl 2   // FontFamily.Monospace
+    private const val UNDERLINE = 1 shl 3   // TextDecoration.Underline
+    private const val LINE_THROUGH = 1 shl 4 // TextDecoration.LineThrough
+    private const val SUBSCRIPT = 1 shl 5   // BaselineShift.Subscript
+    private const val SUPERSCRIPT = 1 shl 6 // BaselineShift.Superscript
+    private const val SMALL_FONT = 1 shl 7  // fontSize 0.75.em (sub/sup, note refs)
+
+    private const val LINK_URL: Int = 0
+    private const val LINK_CLICKABLE: Int = 1
+
+    /** Font size the parser uses for sub/superscript and note markers. */
+    private val SMALL_EM = 0.75.em
+
+    fun encode(value: AnnotatedString, out: DataOutput) {
+        val bytes = value.text.toByteArray(Charsets.UTF_8)
+        out.writeInt(bytes.size)
+        out.write(bytes)
+
+        val spans = value.spanStyles
+        out.writeInt(spans.size)
+        spans.forEach { range ->
+            out.writeInt(range.start)
+            out.writeInt(range.end)
+            out.writeInt(range.item.toStyleMask())
+        }
+
+        val links = value.getLinkAnnotations(0, value.length)
+        out.writeInt(links.size)
+        links.forEach { range ->
+            out.writeInt(range.start)
+            out.writeInt(range.end)
+            when (val link = range.item) {
+                is LinkAnnotation.Url -> {
+                    out.writeByte(LINK_URL)
+                    out.writeUTF(link.url)
+                    out.writeInt(link.styles?.style.toStyleMask())
+                }
+
+                is LinkAnnotation.Clickable -> {
+                    out.writeByte(LINK_CLICKABLE)
+                    out.writeUTF(link.tag)
+                    out.writeInt(link.styles?.style.toStyleMask())
+                }
+
+                else -> throw IllegalArgumentException(
+                    "Unsupported link annotation: ${link::class.java}"
+                )
+            }
+        }
+    }
+
+    fun decode(input: DataInput): AnnotatedString {
+        val textBytes = ByteArray(input.readInt())
+        input.readFully(textBytes)
+        val text = String(textBytes, Charsets.UTF_8)
+
+        val spanCount = input.readInt()
+        return buildAnnotatedString {
+            append(text)
+
+            repeat(spanCount) {
+                val start = input.readInt()
+                val end = input.readInt()
+                val mask = input.readInt()
+                addStyle(mask.toSpanStyle(), start, end)
+            }
+
+            val linkCount = input.readInt()
+            repeat(linkCount) {
+                val start = input.readInt()
+                val end = input.readInt()
+                val kind = input.readByte().toInt()
+                val target = input.readUTF()
+                val styles = TextLinkStyles(input.readInt().toSpanStyle())
+                when (kind) {
+                    LINK_URL -> addLink(LinkAnnotation.Url(target, styles), start, end)
+                    LINK_CLICKABLE -> addLink(
+                        LinkAnnotation.Clickable(target, styles, linkInteractionListener = null),
+                        start, end
+                    )
+
+                    else -> throw IllegalArgumentException("Unknown link kind: $kind")
+                }
+            }
+        }
+    }
+
+    /** Convenience wrapper: whole [AnnotatedString] to a standalone byte array. */
+    fun encodeToBytes(value: AnnotatedString): ByteArray {
+        val bytes = ByteArrayOutputStream()
+        DataOutputStream(bytes).use { encode(value, it) }
+        return bytes.toByteArray()
+    }
+
+    /** Reverses [encodeToBytes]. */
+    fun decodeFromBytes(bytes: ByteArray): AnnotatedString =
+        DataInputStream(ByteArrayInputStream(bytes)).use { decode(it) }
+
+    private fun SpanStyle?.toStyleMask(): Int {
+        if (this == null) return 0
+        var mask = 0
+        if (fontWeight == FontWeight.Medium) mask = mask or BOLD
+        if (fontStyle == FontStyle.Italic) mask = mask or ITALIC
+        if (fontFamily == FontFamily.Monospace) mask = mask or MONOSPACE
+        textDecoration?.let { decoration ->
+            if (decoration.contains(TextDecoration.Underline)) mask = mask or UNDERLINE
+            if (decoration.contains(TextDecoration.LineThrough)) mask = mask or LINE_THROUGH
+        }
+        if (baselineShift == BaselineShift.Subscript) mask = mask or SUBSCRIPT
+        if (baselineShift == BaselineShift.Superscript) mask = mask or SUPERSCRIPT
+        if (fontSize == SMALL_EM) mask = mask or SMALL_FONT
+        return mask
+    }
+
+    private fun Int.toSpanStyle(): SpanStyle {
+        val decorations = buildList {
+            if (this@toSpanStyle and UNDERLINE != 0) add(TextDecoration.Underline)
+            if (this@toSpanStyle and LINE_THROUGH != 0) add(TextDecoration.LineThrough)
+        }
+        return SpanStyle(
+            fontWeight = if (this and BOLD != 0) FontWeight.Medium else null,
+            fontStyle = if (this and ITALIC != 0) FontStyle.Italic else null,
+            fontFamily = if (this and MONOSPACE != 0) FontFamily.Monospace else null,
+            textDecoration = when (decorations.size) {
+                0 -> null
+                1 -> decorations[0]
+                else -> TextDecoration.combine(decorations)
+            },
+            baselineShift = when {
+                this and SUBSCRIPT != 0 -> BaselineShift.Subscript
+                this and SUPERSCRIPT != 0 -> BaselineShift.Superscript
+                else -> null
+            },
+            fontSize = if (this and SMALL_FONT != 0) SMALL_EM else TextUnit.Unspecified
+        )
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/cache/ParseCache.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/cache/ParseCache.kt
@@ -1,0 +1,250 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.cache
+
+import android.app.Application
+import ua.acclorite.book_story.core.log.logE
+import ua.acclorite.book_story.domain.model.reader.ParsedText
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "ParseCache"
+
+/**
+ * On-disk cache of a parsed book ([ParsedText]) so repeat opens skip the parse.
+ *
+ * Lives in [Application.getCacheDir] — the OS may purge it under storage
+ * pressure, so it is strictly best-effort: a miss simply re-parses. Each book is
+ * a directory `parsed_books/<key>` keyed by the source file identity
+ * (path + size + last-modified) plus [VERSION]; bumping [VERSION] on any parser
+ * or format change invalidates every stale entry. The directory holds the parsed
+ * text ([TEXT_FILE]) and, when image caching is enabled, one file per image blob
+ * under [IMG_DIR]. The size cap ([enforceCap]) bounds the whole tree — a book is
+ * evicted (text + its blobs together) as a unit, least-recently-used first.
+ *
+ * The parsed text stores images as metadata only (see [ParsedTextCodec]); a
+ * restored image carries empty bytes. Its bytes are (re)loaded either from a
+ * cached blob ([readImageBlobs]) or from the source book file.
+ */
+@Singleton
+class ParseCache @Inject constructor(application: Application) {
+
+    private val dir = File(application.cacheDir, DIR_NAME)
+
+    /** Returns the cached [ParsedText] for this source, or null on a miss. */
+    fun read(path: String, size: Long, lastModified: Long): ParsedText? {
+        val entry = entryDir(path, size, lastModified)
+        val text = textFile(entry)
+        if (!text.exists()) return null
+        return try {
+            val parsed = DataInputStream(BufferedInputStream(FileInputStream(text))).use {
+                ParsedTextCodec.decode(it)
+            }
+            // Touch on a hit so eviction by oldest-modified is true LRU.
+            entry.setLastModified(System.currentTimeMillis())
+            parsed
+        } catch (e: Exception) {
+            // Corrupt/partial/old entry — drop it and treat as a miss.
+            logE(TAG, "Could not read cache entry, dropping it: ${e.message}")
+            entry.deleteRecursively()
+            null
+        }
+    }
+
+    /**
+     * Stores [parsed] (and, if given, its [images] blobs) for this source,
+     * overwriting any existing entry, then evicts least-recently-used books so
+     * the total stays within [maxBytes] (the entry just written is never
+     * evicted). Pass [Long.MAX_VALUE] for no cap.
+     */
+    fun write(
+        path: String,
+        size: Long,
+        lastModified: Long,
+        parsed: ParsedText,
+        maxBytes: Long = Long.MAX_VALUE,
+        images: Map<String, ByteArray>? = null
+    ) {
+        val entry = entryDir(path, size, lastModified)
+        if (!entry.exists() && !entry.mkdirs()) {
+            logE(TAG, "Could not create cache entry dir.")
+            return
+        }
+        val text = textFile(entry)
+        // Write to a temp file then rename, so a crash mid-write cannot leave a
+        // half-written entry that would later decode into garbage.
+        val tmp = File(entry, "$TEXT_FILE.tmp")
+        try {
+            DataOutputStream(BufferedOutputStream(FileOutputStream(tmp))).use {
+                ParsedTextCodec.encode(parsed, it)
+            }
+            if (!tmp.renameTo(text)) {
+                tmp.copyTo(text, overwrite = true)
+                tmp.delete()
+            }
+        } catch (e: Exception) {
+            logE(TAG, "Could not write cache entry: ${e.message}")
+            tmp.delete()
+            return
+        }
+        images?.forEach { (src, bytes) -> writeBlob(entry, src, bytes) }
+        entry.setLastModified(System.currentTimeMillis())
+        if (maxBytes != Long.MAX_VALUE) enforceCap(maxBytes, keep = entry)
+    }
+
+    /**
+     * Returns the cached image blobs for [srcs] that are present on disk, keyed
+     * by src. Missing srcs are simply absent from the result.
+     */
+    fun readImageBlobs(
+        path: String,
+        size: Long,
+        lastModified: Long,
+        srcs: Set<String>
+    ): Map<String, ByteArray> {
+        if (srcs.isEmpty()) return emptyMap()
+        val entry = entryDir(path, size, lastModified)
+        if (!entry.exists()) return emptyMap()
+        val result = HashMap<String, ByteArray>(srcs.size)
+        srcs.forEach { src ->
+            val blob = blobFile(entry, src)
+            if (blob.exists()) {
+                try {
+                    result[src] = blob.readBytes()
+                } catch (e: Exception) {
+                    logE(TAG, "Could not read image blob: ${e.message}")
+                }
+            }
+        }
+        if (result.isNotEmpty()) entry.setLastModified(System.currentTimeMillis())
+        return result
+    }
+
+    /**
+     * Persists [images] blobs for this source (only if a text entry already
+     * exists — blobs never live without their book), then enforces [maxBytes].
+     * Used on a cache hit after (re)loading bytes from the source book.
+     */
+    fun writeImageBlobs(
+        path: String,
+        size: Long,
+        lastModified: Long,
+        images: Map<String, ByteArray>,
+        maxBytes: Long = Long.MAX_VALUE
+    ) {
+        if (images.isEmpty()) return
+        val entry = entryDir(path, size, lastModified)
+        if (!textFile(entry).exists()) return
+        images.forEach { (src, bytes) -> writeBlob(entry, src, bytes) }
+        entry.setLastModified(System.currentTimeMillis())
+        if (maxBytes != Long.MAX_VALUE) enforceCap(maxBytes, keep = entry)
+    }
+
+    /**
+     * Evicts least-recently-used books until the cache is within [maxBytes].
+     * Best-effort; call e.g. when the size-cap setting is lowered.
+     */
+    fun trimToSize(maxBytes: Long) = enforceCap(maxBytes, keep = null)
+
+    /** Total size in bytes of every cached book (text + image blobs). */
+    fun totalSizeBytes(): Long =
+        entryDirs().sumOf { dirSize(it) }
+
+    /** Size in bytes of the cached book for this source, or 0 if there is none. */
+    fun entrySizeBytes(path: String, size: Long, lastModified: Long): Long =
+        dirSize(entryDir(path, size, lastModified))
+
+    /** Removes the cached book for this source, if any. */
+    fun remove(path: String, size: Long, lastModified: Long) {
+        entryDir(path, size, lastModified).deleteRecursively()
+    }
+
+    /** Deletes every cached book. */
+    fun clear() {
+        dir.listFiles()?.forEach { it.deleteRecursively() }
+    }
+
+    private fun writeBlob(entry: File, src: String, bytes: ByteArray) {
+        val imgDir = File(entry, IMG_DIR)
+        if (!imgDir.exists() && !imgDir.mkdirs()) {
+            logE(TAG, "Could not create image cache dir.")
+            return
+        }
+        val blob = blobFile(entry, src)
+        val tmp = File(imgDir, "${blob.name}.tmp")
+        try {
+            tmp.writeBytes(bytes)
+            if (!tmp.renameTo(blob)) {
+                tmp.copyTo(blob, overwrite = true)
+                tmp.delete()
+            }
+        } catch (e: Exception) {
+            logE(TAG, "Could not write image blob: ${e.message}")
+            tmp.delete()
+        }
+    }
+
+    /**
+     * Deletes oldest-modified books until the total is within [maxBytes], never
+     * touching [keep] (the book a caller just wrote and still needs).
+     */
+    private fun enforceCap(maxBytes: Long, keep: File?) {
+        val entries = entryDirs()
+        var total = entries.sumOf { dirSize(it) }
+        if (total <= maxBytes) return
+        entries.asSequence()
+            .filter { it != keep }
+            .sortedBy { it.lastModified() } // least-recently-used first
+            .forEach { entry ->
+                if (total <= maxBytes) return
+                val freed = dirSize(entry)
+                if (entry.deleteRecursively()) total -= freed
+            }
+    }
+
+    /** All committed book directories. */
+    private fun entryDirs(): List<File> =
+        dir.listFiles()?.filter { it.isDirectory } ?: emptyList()
+
+    private fun dirSize(entry: File): Long {
+        if (!entry.exists()) return 0
+        return entry.walkTopDown().filter { it.isFile }.sumOf { it.length() }
+    }
+
+    private fun entryDir(path: String, size: Long, lastModified: Long): File =
+        File(dir, sha256Hex("$VERSION|$path|$size|$lastModified"))
+
+    private fun textFile(entry: File): File = File(entry, TEXT_FILE)
+
+    private fun blobFile(entry: File, src: String): File =
+        File(File(entry, IMG_DIR), sha256Hex(src))
+
+    private fun sha256Hex(value: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString("") { byte -> "%02x".format(byte) }
+
+    companion object {
+        private const val DIR_NAME = "parsed_books"
+        private const val TEXT_FILE = "text"
+        private const val IMG_DIR = "img"
+
+        /**
+         * Bump on any change to parser output or [ParsedTextCodec] format so
+         * stale entries are ignored instead of rendering outdated text.
+         */
+        const val VERSION = 2
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/cache/ParsedTextCodec.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/cache/ParsedTextCodec.kt
@@ -1,0 +1,195 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.cache
+
+import androidx.compose.ui.text.AnnotatedString
+import ua.acclorite.book_story.domain.model.reader.ParsedText
+import ua.acclorite.book_story.domain.model.reader.ReaderImage
+import ua.acclorite.book_story.domain.model.reader.ReaderText
+import ua.acclorite.book_story.domain.model.reader.ReaderTextRole
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInput
+import java.io.DataInputStream
+import java.io.DataOutput
+import java.io.DataOutputStream
+import java.util.UUID
+
+/**
+ * Binary (de)serializer for a whole [ParsedText] — the parsed element map plus
+ * the footnote map — on top of [AnnotatedStringCodec].
+ *
+ * Images are stored as **metadata only** ([ReaderImage.id]/[ReaderImage.src] and
+ * dimensions); the encoded bytes are not cached (they already live in the book
+ * file and can be far larger than the text). A decoded image therefore carries
+ * empty [ReaderImage.bytes] until they are loaded lazily from the source.
+ *
+ * [VERSION] guards the format; the parse cache additionally keys on a parser
+ * version so a parser change invalidates stale entries.
+ */
+object ParsedTextCodec {
+
+    const val VERSION = 1
+
+    private const val TYPE_CHAPTER = 0
+    private const val TYPE_TEXT = 1
+    private const val TYPE_POEM = 2
+    private const val TYPE_TABLE = 3
+    private const val TYPE_SEPARATOR = 4
+    private const val TYPE_IMAGE = 5
+
+    fun encode(parsed: ParsedText, out: DataOutput) {
+        out.writeInt(VERSION)
+
+        out.writeInt(parsed.text.size)
+        parsed.text.forEach { element -> encodeElement(element, out) }
+
+        out.writeInt(parsed.notes.size)
+        parsed.notes.forEach { (key, value) ->
+            out.writeUTF(key)
+            AnnotatedStringCodec.encode(value, out)
+        }
+    }
+
+    fun decode(input: DataInput): ParsedText {
+        val version = input.readInt()
+        require(version == VERSION) { "Unsupported ParsedText cache version: $version" }
+
+        val textCount = input.readInt()
+        val text = ArrayList<ReaderText>(textCount)
+        repeat(textCount) { text.add(decodeElement(input)) }
+
+        val noteCount = input.readInt()
+        val notes = LinkedHashMap<String, AnnotatedString>(noteCount)
+        repeat(noteCount) {
+            val key = input.readUTF()
+            notes[key] = AnnotatedStringCodec.decode(input)
+        }
+
+        return ParsedText(text = text, notes = notes)
+    }
+
+    fun encodeToBytes(parsed: ParsedText): ByteArray {
+        val bytes = ByteArrayOutputStream()
+        DataOutputStream(bytes).use { encode(parsed, it) }
+        return bytes.toByteArray()
+    }
+
+    fun decodeFromBytes(bytes: ByteArray): ParsedText =
+        DataInputStream(ByteArrayInputStream(bytes)).use { decode(it) }
+
+    private fun encodeElement(element: ReaderText, out: DataOutput) {
+        when (element) {
+            is ReaderText.Chapter -> {
+                out.writeByte(TYPE_CHAPTER)
+                out.writeLong(element.id.mostSignificantBits)
+                out.writeLong(element.id.leastSignificantBits)
+                out.writeUTF(element.title)
+                out.writeInt(element.depth)
+            }
+
+            is ReaderText.Text -> {
+                out.writeByte(TYPE_TEXT)
+                encodeText(element, out)
+            }
+
+            is ReaderText.Poem -> {
+                out.writeByte(TYPE_POEM)
+                out.writeInt(element.lines.size)
+                element.lines.forEach { line -> encodeText(line, out) }
+            }
+
+            is ReaderText.Table -> {
+                out.writeByte(TYPE_TABLE)
+                out.writeBoolean(element.hasHeader)
+                out.writeInt(element.rows.size)
+                element.rows.forEach { row ->
+                    out.writeInt(row.size)
+                    row.forEach { cell -> AnnotatedStringCodec.encode(cell, out) }
+                }
+            }
+
+            is ReaderText.Separator -> out.writeByte(TYPE_SEPARATOR)
+
+            is ReaderText.Image -> {
+                out.writeByte(TYPE_IMAGE)
+                out.writeUTF(element.image.id)
+                out.writeUTF(element.image.src)
+                out.writeInt(element.image.width)
+                out.writeInt(element.image.height)
+                val caption = element.caption
+                out.writeBoolean(caption != null)
+                if (caption != null) encodeText(caption, out)
+            }
+        }
+    }
+
+    private fun decodeElement(input: DataInput): ReaderText {
+        return when (val type = input.readByte().toInt()) {
+            TYPE_CHAPTER -> ReaderText.Chapter(
+                id = UUID(input.readLong(), input.readLong()),
+                title = input.readUTF(),
+                depth = input.readInt()
+            )
+
+            TYPE_TEXT -> decodeText(input)
+
+            TYPE_POEM -> {
+                val count = input.readInt()
+                val lines = ArrayList<ReaderText.Text>(count)
+                repeat(count) { lines.add(decodeText(input)) }
+                ReaderText.Poem(lines)
+            }
+
+            TYPE_TABLE -> {
+                val hasHeader = input.readBoolean()
+                val rowCount = input.readInt()
+                val rows = ArrayList<List<AnnotatedString>>(rowCount)
+                repeat(rowCount) {
+                    val cellCount = input.readInt()
+                    val cells = ArrayList<AnnotatedString>(cellCount)
+                    repeat(cellCount) { cells.add(AnnotatedStringCodec.decode(input)) }
+                    rows.add(cells)
+                }
+                ReaderText.Table(rows = rows, hasHeader = hasHeader)
+            }
+
+            TYPE_SEPARATOR -> ReaderText.Separator
+
+            TYPE_IMAGE -> {
+                val id = input.readUTF()
+                val src = input.readUTF()
+                val width = input.readInt()
+                val height = input.readInt()
+                val caption = if (input.readBoolean()) decodeText(input) else null
+                ReaderText.Image(
+                    image = ReaderImage(
+                        id = id,
+                        src = src,
+                        // Loaded lazily from the source file on a cache hit.
+                        bytes = ByteArray(0),
+                        width = width,
+                        height = height
+                    ),
+                    caption = caption
+                )
+            }
+
+            else -> throw IllegalArgumentException("Unknown ReaderText type: $type")
+        }
+    }
+
+    private fun encodeText(text: ReaderText.Text, out: DataOutput) {
+        out.writeByte(text.role.ordinal)
+        AnnotatedStringCodec.encode(text.line, out)
+    }
+
+    private fun decodeText(input: DataInput): ReaderText.Text {
+        val role = ReaderTextRole.entries[input.readByte().toInt()]
+        return ReaderText.Text(line = AnnotatedStringCodec.decode(input), role = role)
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -87,6 +87,20 @@ const val REF_END_MARK = "\uE016"
 private val TABLE_DELIMITER_REGEX =
     Regex("""^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)*\|?\s*$""")
 
+// Compiled once — all of these run in the per-line hot loop over the whole book
+// (parseDocument), so per-line Regex() compilation added up to a large share of
+// parse time. Kept at file scope like TABLE_DELIMITER_REGEX above.
+private val BOLD_ITALIC_NORMALIZE_REGEX = Regex("""\*\*\*\s*(.*?)\s*\*\*\*""")
+private val BOLD_NORMALIZE_REGEX = Regex("""\*\*\s*(.*?)\s*\*\*""")
+private val ITALIC_NORMALIZE_REGEX = Regex("""_\s*(.*?)\s*_""")
+private val IMAGE_LINE_REGEX = Regex("""\[\[(.*?)\|(.*?)]]""")
+private val CHAPTER_LINE_REGEX = Regex("""\[\[\[chapter\|(\d+)\|(.*)]]]""")
+private val TABLE_LINE_REGEX = Regex("""\[\[\[table\|(\d+)]]]""")
+/** Separator-like text: "---", "***", "___", also spaced out ("* * *"). */
+private val SEPARATOR_TEXT_REGEX = Regex("""^([-*_])(\s*\1){2,}$""")
+private val NEWLINES_REGEX = Regex("\\n+")
+private val WHITESPACE_REGEX = Regex("\\s+")
+
 /** Hex-encodes an FB2 element id for safe transport through the pipeline. */
 fun String.encodeReferenceId(): String =
     toByteArray(Charsets.UTF_8).joinToString("") { byte -> "%02x".format(byte) }
@@ -99,6 +113,7 @@ fun String.decodeReferenceId(): String =
 class DocumentParser @Inject constructor(
     private val markdownParser: MarkdownParser
 ) {
+
     /**
      * Parses document to get it's text.
      * Fixes issues such as manual line breaking in <p>.
@@ -130,22 +145,30 @@ class DocumentParser @Inject constructor(
         document.selectFirst("body")
             .run { this ?: document.body() }
             .apply {
-                // Remove manual line breaks from all <p>, <a>
+                // Remove manual line breaks from all <p>, <a>. Setting .html()
+                // re-parses the fragment, so skip it when there is no newline —
+                // most paragraphs in a non-pretty-printed file have none.
                 select("p").forEach { element ->
                     yield()
-                    element.html(element.html().replace(Regex("\\n+"), " "))
+                    val html = element.html()
+                    if (html.indexOf('\n') >= 0) {
+                        element.html(html.replace(NEWLINES_REGEX, " "))
+                    }
                     element.append("\n")
                 }
                 select("a").forEach { element ->
                     yield()
-                    element.html(element.html().replace(Regex("\\n+"), ""))
+                    val html = element.html()
+                    if (html.indexOf('\n') >= 0) {
+                        element.html(html.replace(NEWLINES_REGEX, ""))
+                    }
                 }
 
                 // Section/body titles are already turned into chapter markers
                 // upstream; the titles left here belong to FB2 <poem>/<epigraph>/
                 // <cite>. Flatten them into a bold line instead of dropping them.
                 select("title").forEach { title ->
-                    val text = title.wholeText().replace(Regex("\\s+"), " ").trim()
+                    val text = title.wholeText().replace(WHITESPACE_REGEX, " ").trim()
                     if (text.isBlank()) title.remove()
                     else title.replaceWith(TextNode("\n$TITLE_ROLE_MARKER**$text**\n"))
                 }
@@ -172,7 +195,7 @@ class DocumentParser @Inject constructor(
                 // the markdown and drop the line entirely. Others get bold+italic.
                 select("subtitle").forEach { subtitle ->
                     val text = subtitle.wholeText().trim()
-                    if (text.matches(Regex("""^([-*_])(\s*\1){2,}$"""))) {
+                    if (text.matches(SEPARATOR_TEXT_REGEX)) {
                         subtitle.replaceWith(TextNode("\n$text\n"))
                     } else {
                         subtitle.prepend("\n_**").append("**_\n") // bold + italic
@@ -312,7 +335,7 @@ class DocumentParser @Inject constructor(
                             if (cells.isEmpty()) return@mapNotNull null
                             cells.map { cell ->
                                 markdownParser.parse(
-                                    cell.wholeText().replace(Regex("\\s+"), " ").trim()
+                                    cell.wholeText().replace(WHITESPACE_REGEX, " ").trim()
                                 )
                             }
                         }
@@ -334,11 +357,11 @@ class DocumentParser @Inject constructor(
                     // Tabs are not rendered and would glue the surrounding words together
                     "\t", " "
                 ).replace(
-                    Regex("""\*\*\*\s*(.*?)\s*\*\*\*"""), "_**$1**_"
+                    BOLD_ITALIC_NORMALIZE_REGEX, "_**$1**_"
                 ).replace(
-                    Regex("""\*\*\s*(.*?)\s*\*\*"""), "**$1**"
+                    BOLD_NORMALIZE_REGEX, "**$1**"
                 ).replace(
-                    Regex("""_\s*(.*?)\s*_"""), "_$1_"
+                    ITALIC_NORMALIZE_REGEX, "_$1_"
                 ).trim()
 
                 // Role marker prefix (from FB2 <title>/<epigraph>/<text-author>)
@@ -358,18 +381,18 @@ class DocumentParser @Inject constructor(
                     else -> ReaderTextRole.Paragraph to formattedLine
                 }
 
-                val imageRegex = Regex("""\[\[(.*?)\|(.*?)]]""")
-                val chapterRegex = Regex("""\[\[\[chapter\|(\d+)\|(.*)]]]""")
-                val tableRegex = Regex("""\[\[\[table\|(\d+)]]]""")
-                // Separator-like text: "---", "***", "___", also spaced out ("* * *")
-                val separatorRegex = Regex("""^([-*_])(\s*\1){2,}$""")
+                val imageRegex = IMAGE_LINE_REGEX
+                val chapterRegex = CHAPTER_LINE_REGEX
+                val tableRegex = TABLE_LINE_REGEX
+                val separatorRegex = SEPARATOR_TEXT_REGEX
 
                 if (line.containsVisibleText()) {
+                    val trimmed = line.trim()
                     when {
                         // Poem boundaries: everything in between is collected
                         // into a single poem block
-                        line.trim() == POEM_BEGIN_MARKER -> poemLines = mutableListOf()
-                        line.trim() == POEM_END_MARKER -> {
+                        trimmed == POEM_BEGIN_MARKER -> poemLines = mutableListOf()
+                        trimmed == POEM_END_MARKER -> {
                             poemLines?.takeIf { it.isNotEmpty() }?.let { lines ->
                                 readerText.add(ReaderText.Poem(lines.toList()))
                             }
@@ -379,7 +402,7 @@ class DocumentParser @Inject constructor(
                         // Empty line marker (from FB2 <empty-line/>). A blank line
                         // cannot survive the containsVisibleText() gate on its own,
                         // so it is carried as a marker and rendered as a blank line.
-                        line.trim() == EMPTY_LINE_MARKER -> {
+                        trimmed == EMPTY_LINE_MARKER -> {
                             val blank = ReaderText.Text(AnnotatedString(" "))
                             poemLines?.add(blank) ?: readerText.add(blank)
                         }
@@ -410,7 +433,7 @@ class DocumentParser @Inject constructor(
                         }
 
                         // Section separator (from <hr>)
-                        line.trim() == SEPARATOR_MARKER -> {
+                        trimmed == SEPARATOR_MARKER -> {
                             readerText.add(ReaderText.Separator)
                         }
 
@@ -501,7 +524,7 @@ class DocumentParser @Inject constructor(
         clone.select("sub").prepend(SUBSCRIPT_MARK).append(SUBSCRIPT_MARK)
         clone.select("sup").prepend(SUPERSCRIPT_MARK).append(SUPERSCRIPT_MARK)
         clone.select("p").forEach { paragraph ->
-            paragraph.html(paragraph.html().replace(Regex("\\n+"), " "))
+            paragraph.html(paragraph.html().replace(NEWLINES_REGEX, " "))
             paragraph.append("\n")
         }
 
@@ -597,6 +620,7 @@ class DocumentParser @Inject constructor(
             val checksum = CRC32().apply { update(bytes) }.value
             ReaderImage(
                 id = "$src-${bytes.size}-$checksum",
+                src = src,
                 bytes = bytes,
                 width = bounds.outWidth,
                 height = bounds.outHeight

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/image/BookImageLoader.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/image/BookImageLoader.kt
@@ -1,0 +1,89 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.parser.image
+
+import android.util.Base64
+import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
+import ua.acclorite.book_story.core.log.logE
+import ua.acclorite.book_story.data.model.file.CachedFile
+import java.io.File
+import java.util.zip.ZipFile
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "BookImageLoader"
+
+/**
+ * Re-loads the encoded bytes of book images by their `src` lookup key, straight
+ * from the source file — without re-parsing the text. Used to refill images on a
+ * parse-cache hit (the cache stores image metadata only). The `src` matching
+ * mirrors [ua.acclorite.book_story.data.parser.document.DocumentParser]:
+ * FB2 keys are the lowercased `<binary>` id, EPUB keys the lowercased basename.
+ *
+ * Only FB2 and EPUB carry image bytes; every other format returns nothing.
+ */
+@Singleton
+class BookImageLoader @Inject constructor() {
+
+    /** Returns encoded bytes for the [srcs] that could be resolved, keyed by src. */
+    fun loadImageBytes(cachedFile: CachedFile, srcs: Set<String>): Map<String, ByteArray> {
+        if (srcs.isEmpty()) return emptyMap()
+        val format = ".${cachedFile.name.substringAfterLast(".")}".lowercase().trim()
+        return when (format) {
+            ".fb2" -> loadFromFb2(cachedFile, srcs)
+            ".epub" -> loadFromEpub(cachedFile, srcs)
+            else -> emptyMap()
+        }
+    }
+
+    private fun loadFromFb2(cachedFile: CachedFile, srcs: Set<String>): Map<String, ByteArray> {
+        val result = HashMap<String, ByteArray>(srcs.size)
+        try {
+            cachedFile.openInputStream()?.use { stream ->
+                val document = Jsoup.parse(stream, null, "", Parser.xmlParser())
+                document.select("binary").forEach { binary ->
+                    val id = binary.attr("id").trim().lowercase()
+                    if (id in srcs && id !in result) {
+                        try {
+                            result[id] = Base64.decode(binary.wholeText(), Base64.DEFAULT)
+                        } catch (e: Exception) {
+                            logE(TAG, "Could not decode <binary> [$id]: ${e.message}")
+                        }
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            logE(TAG, "Could not load FB2 images: ${e.message}")
+        }
+        return result
+    }
+
+    private fun loadFromEpub(cachedFile: CachedFile, srcs: Set<String>): Map<String, ByteArray> {
+        val rawFile = cachedFile.rawFile
+        if (rawFile == null || !rawFile.exists() || !rawFile.canRead()) return emptyMap()
+        val result = HashMap<String, ByteArray>(srcs.size)
+        try {
+            ZipFile(rawFile).use { zip ->
+                val entries = zip.entries().toList()
+                srcs.forEach { src ->
+                    val entry = entries.find { entry ->
+                        src == entry.name.substringAfterLast(File.separator).lowercase()
+                    } ?: return@forEach
+                    try {
+                        result[src] = zip.getInputStream(entry).use { it.readBytes() }
+                    } catch (e: Exception) {
+                        logE(TAG, "Could not read EPUB image [$src]: ${e.message}")
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            logE(TAG, "Could not load EPUB images: ${e.message}")
+        }
+        return result
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
@@ -22,6 +22,9 @@ import javax.inject.Inject
 
 private const val TAG = "XmlTextParser"
 
+/** Compiled once — used per <title> when converting FB2 headings to chapters. */
+private val WHITESPACE_REGEX = Regex("\\s+")
+
 class XmlTextParser @Inject constructor(
     private val documentParser: DocumentParser
 ) : TextParser {
@@ -48,7 +51,7 @@ class XmlTextParser @Inject constructor(
                     if (parentTag != "body" && parentTag != "section") return@forEach
 
                     val text = title.wholeText()
-                        .replace(Regex("\\s+"), " ")
+                        .replace(WHITESPACE_REGEX, " ")
                         .trim()
                     if (text.isBlank()) return@forEach
 
@@ -98,6 +101,7 @@ class XmlTextParser @Inject constructor(
             }
 
             logI(TAG, "Successfully finished XML parsing.")
+
             ParsedText(readerText, notes)
         } catch (e: Exception) {
             logE(TAG, "Could not parse text with message: ${e.message}.")

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
@@ -9,14 +9,19 @@ package ua.acclorite.book_story.data.repository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import ua.acclorite.book_story.core.CoverImage
+import ua.acclorite.book_story.data.cache.ParseCache
 import ua.acclorite.book_story.data.local.room.BookDatabase
+import ua.acclorite.book_story.data.model.file.CachedFile
+import ua.acclorite.book_story.data.settings.SettingsManager
 import ua.acclorite.book_story.data.mapper.book.BookMapper
 import ua.acclorite.book_story.data.mapper.file.FileMapper
 import ua.acclorite.book_story.data.parser.cover.CoverParser
+import ua.acclorite.book_story.data.parser.image.BookImageLoader
 import ua.acclorite.book_story.data.parser.text.TextParser
 import ua.acclorite.book_story.domain.model.file.File
 import ua.acclorite.book_story.domain.model.library.Book
 import ua.acclorite.book_story.domain.model.reader.ParsedText
+import ua.acclorite.book_story.domain.model.reader.ReaderImage
 import ua.acclorite.book_story.domain.model.reader.ReaderText
 import ua.acclorite.book_story.domain.repository.BookRepository
 import ua.acclorite.book_story.domain.service.FileProvider
@@ -30,7 +35,10 @@ class BookRepositoryImpl @Inject constructor(
     private val fileMapper: FileMapper,
     private val coverParser: CoverParser,
     private val textParser: TextParser,
-    private val fileProvider: FileProvider
+    private val fileProvider: FileProvider,
+    private val parseCache: ParseCache,
+    private val bookImageLoader: BookImageLoader,
+    private val settings: SettingsManager
 ) : BookRepository {
 
     override suspend fun searchBooks(query: String): Result<List<Book>> = runCatching {
@@ -52,9 +60,107 @@ class BookRepositoryImpl @Inject constructor(
         return withContext(Dispatchers.IO) {
             getBook(bookId)
                 .mapCatching { fileProvider.getFileFromBook(it).getOrThrow() }
-                .mapCatching { textParser.parse(it) }
+                .mapCatching { cachedFile ->
+                    // A size-cap of 0 means the parse cache is disabled entirely.
+                    val capMb = settings.parseCacheSizeMb.lastValue
+                    val cachingEnabled = capMb > 0
+                    val maxBytes = capMb.toLong() * 1024 * 1024
+                    val cacheImages = settings.cacheImagesInBooks.lastValue
+
+                    val cached = if (cachingEnabled) parseCache.read(
+                        cachedFile.path, cachedFile.size, cachedFile.lastModified
+                    ) else null
+
+                    if (cached != null) {
+                        // Hit: the stored text carries image metadata only —
+                        // refill any image bytes from cached blobs or the source.
+                        fillImages(cached, cachedFile, maxBytes, cacheImages)
+                    } else {
+                        textParser.parse(cachedFile).also { fresh ->
+                            // Best-effort caching; skip empty/failed parses.
+                            if (cachingEnabled && fresh.text.isNotEmpty()) {
+                                parseCache.write(
+                                    cachedFile.path,
+                                    cachedFile.size,
+                                    cachedFile.lastModified,
+                                    fresh,
+                                    maxBytes = maxBytes,
+                                    images = if (cacheImages) fresh.collectImageBytes() else null
+                                )
+                            }
+                        }
+                    }
+                }
         }
     }
+
+    /**
+     * Refills empty image bytes on a cache hit: cached blobs first, then the
+     * source book (one pass). When [cacheImages] is on, bytes read from the
+     * source are persisted as blobs for the next hit. Returns [parsed] unchanged
+     * when there are no images to fill or none could be resolved.
+     */
+    private fun fillImages(
+        parsed: ParsedText,
+        cachedFile: CachedFile,
+        maxBytes: Long,
+        cacheImages: Boolean
+    ): ParsedText {
+        val missingSrcs = parsed.text.asSequence()
+            .filterIsInstance<ReaderText.Image>()
+            .map { it.image }
+            .filter { it.bytes.isEmpty() }
+            .map { it.src }
+            .toSet()
+        if (missingSrcs.isEmpty()) return parsed
+
+        val fromBlobs = parseCache.readImageBlobs(
+            cachedFile.path, cachedFile.size, cachedFile.lastModified, missingSrcs
+        )
+        val stillMissing = missingSrcs - fromBlobs.keys
+        val fromSource = if (stillMissing.isNotEmpty()) {
+            bookImageLoader.loadImageBytes(cachedFile, stillMissing)
+        } else {
+            emptyMap()
+        }
+
+        if (cacheImages && fromSource.isNotEmpty()) {
+            parseCache.writeImageBlobs(
+                cachedFile.path, cachedFile.size, cachedFile.lastModified,
+                fromSource, maxBytes
+            )
+        }
+
+        val bytesBySrc = fromBlobs + fromSource
+        if (bytesBySrc.isEmpty()) return parsed
+
+        return parsed.copy(
+            text = parsed.text.map { element ->
+                if (element is ReaderText.Image && element.image.bytes.isEmpty()) {
+                    val bytes = bytesBySrc[element.image.src] ?: return@map element
+                    element.copy(
+                        image = ReaderImage(
+                            id = element.image.id,
+                            src = element.image.src,
+                            bytes = bytes,
+                            width = element.image.width,
+                            height = element.image.height
+                        )
+                    )
+                } else {
+                    element
+                }
+            }
+        )
+    }
+
+    /** Encoded bytes of every image that has them, keyed by src. */
+    private fun ParsedText.collectImageBytes(): Map<String, ByteArray> =
+        text.asSequence()
+            .filterIsInstance<ReaderText.Image>()
+            .map { it.image }
+            .filter { it.bytes.isNotEmpty() }
+            .associate { it.src to it.bytes }
 
     override suspend fun getFileFromBook(bookId: Int): Result<File> {
         return withContext(Dispatchers.IO) {

--- a/app/src/main/java/ua/acclorite/book_story/data/settings/SettingsManager.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/settings/SettingsManager.kt
@@ -113,6 +113,12 @@ class SettingsManager @Inject constructor(
     val showNavigationLabels = setting<Boolean, Boolean>(
         key = booleanPreferencesKey("show_navigation_labels"), default = true
     )
+    val parseCacheSizeMb = setting<Int, Int>(
+        key = intPreferencesKey("parse_cache_size_mb"), default = 150
+    )
+    val cacheImagesInBooks = setting<Boolean, Boolean>(
+        key = booleanPreferencesKey("cache_images_in_books"), default = false
+    )
 
     /* ------ Reader ----------------------------- */
     val fontFamily = setting<FontWithName, String>(

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/reader/ReaderImage.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/reader/ReaderImage.kt
@@ -15,11 +15,15 @@ import androidx.compose.runtime.Immutable
  * layout space before that happens.
  *
  * @param id Stable cache key, unique per image content.
- * @param bytes Encoded image (JPEG/PNG/GIF) bytes.
+ * @param src Source reference (FB2 <binary> id / EPUB entry name), the lookup
+ *   key used to (re)load [bytes] from the book file — e.g. lazily on a cache hit.
+ * @param bytes Encoded image (JPEG/PNG/GIF) bytes. May be empty when the image
+ *   was restored from the parse cache and its bytes are not loaded yet.
  */
 @Immutable
 class ReaderImage(
     val id: String,
+    val src: String,
     val bytes: ByteArray,
     val width: Int,
     val height: Int

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/cache/ClearParseCacheUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/cache/ClearParseCacheUseCase.kt
@@ -1,0 +1,17 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.cache
+
+import ua.acclorite.book_story.data.cache.ParseCache
+import javax.inject.Inject
+
+class ClearParseCacheUseCase @Inject constructor(
+    private val parseCache: ParseCache
+) {
+
+    operator fun invoke() = parseCache.clear()
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/cache/GetParseCacheSizeUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/cache/GetParseCacheSizeUseCase.kt
@@ -1,0 +1,17 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.cache
+
+import ua.acclorite.book_story.data.cache.ParseCache
+import javax.inject.Inject
+
+class GetParseCacheSizeUseCase @Inject constructor(
+    private val parseCache: ParseCache
+) {
+
+    operator fun invoke(): Long = parseCache.totalSizeBytes()
+}

--- a/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsEvent.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsEvent.kt
@@ -79,4 +79,8 @@ sealed class SettingsEvent {
     ) : SettingsEvent()
 
     data object OnConfirmReorderColorPresets : SettingsEvent()
+
+    data object OnClearParseCache : SettingsEvent()
+
+    data object OnRefreshParseCacheSize : SettingsEvent()
 }

--- a/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsModel.kt
@@ -26,6 +26,8 @@ import ua.acclorite.book_story.domain.use_case.category.DeleteCategoryUseCase
 import ua.acclorite.book_story.domain.use_case.category.GetCategoriesUseCase
 import ua.acclorite.book_story.domain.use_case.category.UpdateCategoriesOrderUseCase
 import ua.acclorite.book_story.domain.use_case.category.UpdateCategoryUseCase
+import ua.acclorite.book_story.domain.use_case.cache.ClearParseCacheUseCase
+import ua.acclorite.book_story.domain.use_case.cache.GetParseCacheSizeUseCase
 import ua.acclorite.book_story.domain.use_case.color_preset.DeleteColorPresetUseCase
 import ua.acclorite.book_story.domain.use_case.color_preset.GetColorPresetsUseCase
 import ua.acclorite.book_story.domain.use_case.color_preset.ReorderColorPresetsUseCase
@@ -52,7 +54,9 @@ class SettingsModel @Inject constructor(
     private val getCategoriesUseCase: GetCategoriesUseCase,
     private val updateCategoryUseCase: UpdateCategoryUseCase,
     private val updateCategoriesOrderUseCase: UpdateCategoriesOrderUseCase,
-    private val deleteCategoryUseCase: DeleteCategoryUseCase
+    private val deleteCategoryUseCase: DeleteCategoryUseCase,
+    private val getParseCacheSizeUseCase: GetParseCacheSizeUseCase,
+    private val clearParseCacheUseCase: ClearParseCacheUseCase
 ) : ViewModel() {
 
     private val mutex = Mutex()
@@ -86,11 +90,14 @@ class SettingsModel @Inject constructor(
                 )
             }
 
+            val parseCacheSize = withContext(Dispatchers.IO) { getParseCacheSizeUseCase() }
+
             _state.update {
                 it.copy(
                     selectedColorPreset = colorPresets.getSelectedColorPreset(),
                     colorPresets = colorPresets,
-                    categories = getCategoriesUseCase()
+                    categories = getCategoriesUseCase(),
+                    parseCacheSizeBytes = parseCacheSize
                 )
             }
 
@@ -403,6 +410,23 @@ class SettingsModel @Inject constructor(
                         withContext(Dispatchers.Default) {
                             reorderColorPresetsUseCase(_state.value.colorPresets)
                         }
+                    }
+                }
+
+                is SettingsEvent.OnClearParseCache -> {
+                    val size = withContext(Dispatchers.IO) {
+                        clearParseCacheUseCase()
+                        getParseCacheSizeUseCase()
+                    }
+                    _state.update {
+                        it.copy(parseCacheSizeBytes = size)
+                    }
+                }
+
+                is SettingsEvent.OnRefreshParseCacheSize -> {
+                    val size = withContext(Dispatchers.IO) { getParseCacheSizeUseCase() }
+                    _state.update {
+                        it.copy(parseCacheSizeBytes = size)
                     }
                 }
             }

--- a/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsState.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsState.kt
@@ -18,5 +18,7 @@ data class SettingsState(
     val animateColorPreset: Boolean = false,
     val colorPresetListState: LazyListState = LazyListState(),
 
-    val categories: List<Category> = emptyList()
+    val categories: List<Category> = emptyList(),
+
+    val parseCacheSizeBytes: Long = 0L
 )

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/general/GeneralSettingsCategory.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/general/GeneralSettingsCategory.kt
@@ -11,14 +11,24 @@ package ua.acclorite.book_story.ui.settings.general
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.ui.settings.components.SettingsSubcategory
 import ua.acclorite.book_story.ui.settings.general.components.AppLanguageOption
+import ua.acclorite.book_story.ui.settings.general.components.CacheImagesOption
+import ua.acclorite.book_story.ui.settings.general.components.ClearParseCacheOption
 import ua.acclorite.book_story.ui.settings.general.components.DoublePressExitOption
+import ua.acclorite.book_story.ui.settings.general.components.ParseCacheSizeOption
 
 fun LazyListScope.GeneralSettingsCategory(
+    titleColor: @Composable () -> Color = { MaterialTheme.colorScheme.primary },
     topPadding: Dp = 16.dp,
     bottomPadding: Dp = 16.dp
 ) {
@@ -32,6 +42,25 @@ fun LazyListScope.GeneralSettingsCategory(
 
     item {
         DoublePressExitOption()
+    }
+
+    SettingsSubcategory(
+        titleColor = titleColor,
+        title = { stringResource(id = R.string.parse_cache_option) },
+        showTitle = true,
+        showDivider = false
+    ) {
+        item {
+            ParseCacheSizeOption()
+        }
+
+        item {
+            CacheImagesOption()
+        }
+
+        item {
+            ClearParseCacheOption()
+        }
     }
 
     item {

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/general/components/CacheImagesOption.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/general/components/CacheImagesOption.kt
@@ -1,0 +1,26 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.settings.general.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.ui.common.components.settings.SwitchWithTitle
+import ua.acclorite.book_story.ui.common.helpers.LocalSettings
+
+@Composable
+fun CacheImagesOption() {
+    val settings = LocalSettings.current
+
+    SwitchWithTitle(
+        selected = settings.cacheImagesInBooks.value,
+        title = stringResource(id = R.string.cache_images_option),
+        description = stringResource(id = R.string.cache_images_option_desc)
+    ) {
+        settings.cacheImagesInBooks.update(!settings.cacheImagesInBooks.lastValue)
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/general/components/ClearParseCacheOption.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/general/components/ClearParseCacheOption.kt
@@ -1,0 +1,86 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.settings.general.components
+
+import android.text.format.Formatter
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.presentation.settings.SettingsEvent
+import ua.acclorite.book_story.presentation.settings.SettingsModel
+import ua.acclorite.book_story.ui.common.components.common.StyledText
+import ua.acclorite.book_story.ui.common.components.dialog.Dialog
+
+@Composable
+fun ClearParseCacheOption() {
+    val settingsModel = hiltViewModel<SettingsModel>()
+    val state = settingsModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    var showDialog by remember { mutableStateOf(false) }
+
+    // The size is loaded once at ViewModel init; refresh it when this screen
+    // appears so it reflects books cached since (e.g. after reading).
+    LaunchedEffect(Unit) {
+        settingsModel.onEvent(SettingsEvent.OnRefreshParseCacheSize)
+    }
+
+    val sizeText = remember(state.value.parseCacheSizeBytes) {
+        Formatter.formatShortFileSize(context, state.value.parseCacheSizeBytes)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { showDialog = true }
+            .padding(horizontal = 18.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.Center
+    ) {
+        StyledText(
+            text = stringResource(id = R.string.clear_parse_cache_option),
+            style = MaterialTheme.typography.titleMedium.copy(
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        )
+        StyledText(
+            text = stringResource(id = R.string.clear_parse_cache_option_desc, sizeText),
+            style = MaterialTheme.typography.bodySmall.copy(
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        )
+    }
+
+    if (showDialog) {
+        Dialog(
+            title = stringResource(id = R.string.clear_parse_cache_dialog),
+            description = stringResource(id = R.string.clear_parse_cache_dialog_desc),
+            actionEnabled = true,
+            withContent = false,
+            onDismiss = { showDialog = false },
+            onAction = {
+                settingsModel.onEvent(SettingsEvent.OnClearParseCache)
+                showDialog = false
+            }
+        )
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/general/components/ParseCacheSizeOption.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/general/components/ParseCacheSizeOption.kt
@@ -1,0 +1,38 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.settings.general.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.ui.common.components.settings.ChipsWithTitle
+import ua.acclorite.book_story.ui.common.helpers.LocalSettings
+import ua.acclorite.book_story.ui.common.model.ListItem
+
+/** Cache size cap presets in MB; 0 disables the parse cache entirely. */
+private val PARSE_CACHE_PRESETS_MB = listOf(0, 150, 300, 500, 1000)
+
+@Composable
+fun ParseCacheSizeOption() {
+    val settings = LocalSettings.current
+    val selected = settings.parseCacheSizeMb.value
+
+    ChipsWithTitle(
+        title = stringResource(id = R.string.parse_cache_size_option),
+        chips = PARSE_CACHE_PRESETS_MB.map { mb ->
+            ListItem(
+                item = mb,
+                title = if (mb == 0) stringResource(id = R.string.parse_cache_off)
+                else stringResource(id = R.string.parse_cache_size_value, mb),
+                selected = mb == selected
+            )
+        },
+        onClick = { mb ->
+            settings.parseCacheSizeMb.update(mb)
+        }
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,16 @@
     <string name="double_press_exit_option_desc">Press back twice to exit the app</string>
     <string name="show_navigation_labels_option">Show navigation labels</string>
     <string name="show_navigation_labels_option_desc">Show navigation bar labels under icons</string>
+    <string name="parse_cache_option">Parse cache</string>
+    <string name="parse_cache_size_option">Cache size limit</string>
+    <string name="parse_cache_off">Off</string>
+    <string name="parse_cache_size_value">%1$d MB</string>
+    <string name="cache_images_option">Cache images in books</string>
+    <string name="cache_images_option_desc">Also store image data in the cache so books with images open instantly too. Uses more space.</string>
+    <string name="clear_parse_cache_option">Clear cache</string>
+    <string name="clear_parse_cache_option_desc">Currently using %1$s</string>
+    <string name="clear_parse_cache_dialog">Clear parse cache?</string>
+    <string name="clear_parse_cache_dialog_desc">This removes all cached parsed books. They will be re-parsed the next time you open them.</string>
 
     <!-- Reader -->
     <string name="font_family_option">Font family</string>


### PR DESCRIPTION
Caches the parsed book on disk so **repeat opens are near-instant** instead of re-parsing from scratch every time.

## What's included (4 commits)
1. **perf** — speed up the FB2/document parse hot path (hoisted per-line regexes, skip redundant `<p>`/`<a>` re-parse + per-line trims).
2. **feat** — hand-rolled binary codecs for the parsed text (`AnnotatedStringCodec` packs SpanStyles into an Int bitmask; `ParsedTextCodec` versions the whole `ParsedText`; images stored as metadata only). No serialization plugin in the project.
3. **feat** — on-disk `ParseCache` (directory-per-book in `cacheDir`, keyed by source identity + format VERSION): atomic writes, corrupt entries dropped, **LRU size cap** (evicts a whole book — text + image blobs — least-recently-*opened* first). Wired into `getText`. Image-bearing books are cached too — on a hit, image bytes are refilled from cached blobs or re-read from the source (`BookImageLoader`, FB2 base64 / EPUB zip) with no text re-parse.
4. **feat** — General → "Parse cache" settings: size limit chips (Off / 150 / 300 / 500 / 1000 MB; Off disables the cache), "Cache images in books" toggle (persist image blobs), and "Clear cache" with a live usage readout.

## Measurements (device)
- Text-heavy trilogy (2.9M chars): ~23 s parse → **~0.1 s** cache hit.
- Image-heavy FB2 (33.8 MB, 75 images): ~9–13 s parse → **~0.12 s** hit (blobs) / **~1.7 s** hit (source reload).
- Cache is text-sized (~2 B/char), always ≤ the source file unless image blobs are enabled.

## Testing
- 30 instrumented tests green on device (`connectedDebugAndroidTest`) — codec round-trips (every span/link shape), cache hit/miss/identity/remove/clear/corrupt, LRU eviction, image blob read/write, cap-counts-blobs.
- On-device: image round-trip renders correctly on both hit paths; settings UI (chips, toggle, clear + usage) verified.

The cache is best-effort: `cacheDir` is OS-purgeable and a miss simply re-parses.

Relates to #1 (kept open for a few days of real-world testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
