### PR TITLE
feat: keep inline markup and footnotes in FB2 titles

### DIFF
--- a/app/src/androidTest/java/ua/acclorite/book_story/data/cache/ParsedTextCodecTest.kt
+++ b/app/src/androidTest/java/ua/acclorite/book_story/data/cache/ParsedTextCodecTest.kt
@@ -53,6 +53,27 @@ class ParsedTextCodecTest {
             text = listOf(
                 ReaderText.Chapter(title = "Розділ 1", depth = 0),
                 ReaderText.Chapter(title = "Nested", depth = 2),
+                // A title with inline markup: italic plus a footnote reference,
+                // which the plain title drops
+                ReaderText.Chapter(
+                    title = "Styled",
+                    depth = 1,
+                    styledTitle = buildAnnotatedString {
+                        withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append("Styled") }
+                        withLink(
+                            LinkAnnotation.Clickable(
+                                tag = "note:n1",
+                                styles = TextLinkStyles(
+                                    SpanStyle(
+                                        baselineShift = BaselineShift.Superscript,
+                                        fontSize = 0.75.em
+                                    )
+                                ),
+                                linkInteractionListener = null
+                            )
+                        ) { append("[1]") }
+                    }
+                ),
                 ReaderText.Text(
                     line = buildAnnotatedString {
                         append("A ")
@@ -152,6 +173,12 @@ class ParsedTextCodecTest {
                 assertEquals("$msg id", expected.id, actual.id)
                 assertEquals("$msg title", expected.title, actual.title)
                 assertEquals("$msg depth", expected.depth, actual.depth)
+                val expectedStyled = expected.styledTitle
+                if (expectedStyled == null) {
+                    assertEquals("$msg styledTitle", null, actual.styledTitle)
+                } else {
+                    assertAnnotatedEquals("$msg styledTitle", expectedStyled, actual.styledTitle!!)
+                }
             }
 
             is ReaderText.Text -> assertTextEquals(msg, expected, actual as ReaderText.Text)

--- a/app/src/androidTest/java/ua/acclorite/book_story/data/parser/Fb2TitleParsingTest.kt
+++ b/app/src/androidTest/java/ua/acclorite/book_story/data/parser/Fb2TitleParsingTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.parser
+
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.BaselineShift
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.commonmark.parser.Parser as CommonmarkParser
+import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import ua.acclorite.book_story.data.parser.document.DocumentParser
+import ua.acclorite.book_story.data.parser.document.MarkdownParser
+import ua.acclorite.book_story.data.parser.text.markChapterTitles
+import ua.acclorite.book_story.domain.model.reader.ReaderText
+import ua.acclorite.book_story.domain.model.reader.ReaderTextRole
+
+/**
+ * FB2 <title> handling: a chapter title keeps its inline markup (and its
+ * footnote references), while the chapter list keeps a plain title.
+ */
+@RunWith(AndroidJUnit4::class)
+class Fb2TitleParsingTest {
+
+    // The default builder enables every block type, while the app narrows them
+    // (see AppModule): a stricter parser than production, on purpose.
+    private val documentParser = DocumentParser(
+        MarkdownParser(CommonmarkParser.builder().build())
+    )
+
+    @Test
+    fun plainTitleCarriesNoStyling() {
+        val chapter = chapters("<title><p>Просто заголовок</p></title>").single()
+
+        assertEquals("Просто заголовок", chapter.title)
+        assertNull("a plain title needs no styled copy", chapter.styledTitle)
+    }
+
+    @Test
+    fun inlineMarkupIsKept() {
+        val chapter = chapters(
+            "<title><p>15. <emphasis>курсив</emphasis>, <strong>жирний</strong>, " +
+                    "H<sub>2</sub>O, mc<sup>2</sup></p></title>"
+        ).single()
+
+        // Plain title: no markup characters leak into the chapter list
+        assertEquals("15. курсив, жирний, H2O, mc2", chapter.title)
+
+        assertNotNull("styled title", chapter.styledTitle)
+        val styled = chapter.styledTitle!!
+        assertEquals(chapter.title, styled.text)
+        assertTrue(
+            "italic span",
+            styled.spanStyles.any { span ->
+                span.item.fontStyle == FontStyle.Italic &&
+                        styled.text.substring(span.start, span.end) == "курсив"
+            }
+        )
+        assertTrue(
+            "bold span",
+            styled.spanStyles.any { span ->
+                span.item.fontWeight == FontWeight.Medium &&
+                        styled.text.substring(span.start, span.end) == "жирний"
+            }
+        )
+        assertTrue(
+            "subscript span",
+            styled.spanStyles.any { span ->
+                span.item.baselineShift == BaselineShift.Subscript &&
+                        styled.text.substring(span.start, span.end) == "2"
+            }
+        )
+        assertTrue(
+            "superscript span",
+            styled.spanStyles.any { span ->
+                span.item.baselineShift == BaselineShift.Superscript &&
+                        styled.text.substring(span.start, span.end) == "2"
+            }
+        )
+    }
+
+    @Test
+    fun footnoteReferenceIsTappableAndOutOfThePlainTitle() {
+        val chapter = chapters(
+            """<title><p>16. Заголовок<a l:href="#note7" type="note">[7]</a></p></title>"""
+        ).single()
+
+        // The chapter list has no use for a dangling marker
+        assertEquals("16. Заголовок", chapter.title)
+
+        val styled = chapter.styledTitle!!
+        assertEquals("16. Заголовок[7]", styled.text)
+        val link = styled.getLinkAnnotations(0, styled.length).single()
+        assertEquals("[7]", styled.text.substring(link.start, link.end))
+        assertEquals("note:note7", (link.item as LinkAnnotation.Clickable).tag)
+    }
+
+    @Test
+    fun leadingListMarkerSurvives() {
+        // Commonmark would read these as list/quote/heading markers and drop them
+        listOf(
+            "1. Пролог" to "1. Пролог",
+            "17) Розділ" to "17) Розділ",
+            "- Пролог" to "- Пролог",
+            "# Пролог" to "# Пролог",
+            "11.1. Вкладений" to "11.1. Вкладений"
+        ).forEach { (raw, expected) ->
+            assertEquals(expected, chapters("<title><p>$raw</p></title>").single().title)
+        }
+    }
+
+    @Test
+    fun multiParagraphTitleBecomesOneLine() {
+        val chapter = chapters(
+            "<title>\n  <p>18. Заголовок</p>\n  <p>другий рядок</p>\n</title>"
+        ).single()
+
+        assertEquals("18. Заголовок другий рядок", chapter.title)
+    }
+
+    @Test
+    fun poemTitleKeepsItsMarkup() {
+        val text = parse(
+            """
+            <section>
+              <title><p>Розділ</p></title>
+              <p>Текст секції.</p>
+              <poem>
+                <title><p>Назва з <emphasis>курсивом</emphasis></p></title>
+                <stanza><v>Рядок</v></stanza>
+              </poem>
+            </section>
+            """.trimIndent()
+        )
+
+        val title = text.filterIsInstance<ReaderText.Poem>().single()
+            .lines.first { line -> line.role == ReaderTextRole.Title }
+
+        assertEquals("Назва з курсивом", title.line.text)
+        // The bold run is split at every inline mark, so cover, not span, is
+        // what matters: every character of the title has to be bold.
+        val bold = title.line.spanStyles.filter { span ->
+            span.item.fontWeight == FontWeight.Medium
+        }
+        assertTrue(
+            "the whole title is bold",
+            title.line.indices.all { index ->
+                bold.any { span -> index >= span.start && index < span.end }
+            }
+        )
+        assertTrue(
+            "italic is kept inside",
+            title.line.spanStyles.any { span ->
+                span.item.fontStyle == FontStyle.Italic &&
+                        title.line.text.substring(span.start, span.end) == "курсивом"
+            }
+        )
+    }
+
+    // --- helpers ---
+
+    private fun chapters(title: String): List<ReaderText.Chapter> =
+        parse("<section>$title<p>Текст секції.</p></section>")
+            .filterIsInstance<ReaderText.Chapter>()
+
+    /** Runs the FB2 body through the same two steps as [XmlTextParser]. */
+    private fun parse(body: String): List<ReaderText> = runBlocking {
+        val document = Jsoup.parse(
+            """<FictionBook><body>$body</body></FictionBook>""",
+            "",
+            Parser.xmlParser()
+        )
+        document.markChapterTitles()
+        documentParser.parseDocument(document)
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/cache/ParseCache.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/cache/ParseCache.kt
@@ -246,6 +246,6 @@ class ParseCache @Inject constructor(application: Application) {
          * Bump on any change to parser output or [ParsedTextCodec] format so
          * stale entries are ignored instead of rendering outdated text.
          */
-        const val VERSION = 2
+        const val VERSION = 3
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/cache/ParsedTextCodec.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/cache/ParsedTextCodec.kt
@@ -34,7 +34,7 @@ import java.util.UUID
  */
 object ParsedTextCodec {
 
-    const val VERSION = 1
+    const val VERSION = 2
 
     private const val TYPE_CHAPTER = 0
     private const val TYPE_TEXT = 1
@@ -91,6 +91,9 @@ object ParsedTextCodec {
                 out.writeLong(element.id.leastSignificantBits)
                 out.writeUTF(element.title)
                 out.writeInt(element.depth)
+                val styledTitle = element.styledTitle
+                out.writeBoolean(styledTitle != null)
+                if (styledTitle != null) AnnotatedStringCodec.encode(styledTitle, out)
             }
 
             is ReaderText.Text -> {
@@ -131,11 +134,19 @@ object ParsedTextCodec {
 
     private fun decodeElement(input: DataInput): ReaderText {
         return when (val type = input.readByte().toInt()) {
-            TYPE_CHAPTER -> ReaderText.Chapter(
-                id = UUID(input.readLong(), input.readLong()),
-                title = input.readUTF(),
-                depth = input.readInt()
-            )
+            TYPE_CHAPTER -> {
+                val id = UUID(input.readLong(), input.readLong())
+                val title = input.readUTF()
+                val depth = input.readInt()
+                val styledTitle =
+                    if (input.readBoolean()) AnnotatedStringCodec.decode(input) else null
+                ReaderText.Chapter(
+                    id = id,
+                    title = title,
+                    depth = depth,
+                    styledTitle = styledTitle
+                )
+            }
 
             TYPE_TEXT -> decodeText(input)
 

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -9,6 +9,7 @@ package ua.acclorite.book_story.data.parser.document
 import android.graphics.BitmapFactory
 import android.util.Base64
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -16,10 +17,13 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.yield
 import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Node
 import org.jsoup.nodes.TextNode
 import ua.acclorite.book_story.core.helpers.clearAllMarkdown
 import ua.acclorite.book_story.core.helpers.clearMarkdown
 import ua.acclorite.book_story.core.helpers.containsVisibleText
+import ua.acclorite.book_story.domain.model.reader.NOTE_LINK_TAG_PREFIX
 import ua.acclorite.book_story.domain.model.reader.ReaderImage
 import ua.acclorite.book_story.domain.model.reader.ReaderText
 import ua.acclorite.book_story.domain.model.reader.ReaderTextRole
@@ -71,6 +75,14 @@ const val SUPERSCRIPT_MARK = "\uE013"
 const val ITALIC_MARK = "\uE018"
 
 /**
+ * Private-use sentinel wrapping a flattened <title> (of an FB2 <poem>/
+ * <epigraph>/<cite>). A mark rather than "**", because the title keeps its own
+ * inline markup, which may itself carry "**" from a <strong>: nested asterisks
+ * would fuse into one malformed emphasis run.
+ */
+const val BOLD_MARK = "\uE019"
+
+/**
  * Inline reference marks (from FB2 <a l:href="#id">). The run between a
  * start mark and [REF_END_MARK] is "<hex-encoded id>[REF_SEPARATOR]<display
  * text>"; the id is hex-encoded so markdown transformations cannot corrupt
@@ -100,6 +112,107 @@ private val TABLE_LINE_REGEX = Regex("""\[\[\[table\|(\d+)]]]""")
 private val SEPARATOR_TEXT_REGEX = Regex("""^([-*_])(\s*\1){2,}$""")
 private val NEWLINES_REGEX = Regex("\\n+")
 private val WHITESPACE_REGEX = Regex("\\s+")
+
+/**
+ * Leading block marker of a line: an ordered/bullet list item, a quote or an
+ * ATX heading. See [escapeLeadingBlockMarker].
+ */
+private val LEADING_BLOCK_MARKER_REGEX = Regex("""^(\s*)(\d{1,9}[.)]|[-+*>]|#{1,6})(\s|$)""")
+
+/**
+ * Escapes a leading block marker so commonmark keeps it as text. A chapter
+ * title is a title, not markdown: "1. Prologue" must stay "1. Prologue"
+ * instead of becoming a list item that swallows its own numbering.
+ */
+private fun String.escapeLeadingBlockMarker(): String =
+    replace(LEADING_BLOCK_MARKER_REGEX) { match ->
+        val marker = match.groupValues[2]
+        val escaped = when {
+            // Only the punctuation of "12." / "12)" needs escaping
+            marker.first().isDigit() -> marker.dropLast(1) + "\\" + marker.last()
+            else -> "\\" + marker
+        }
+        "${match.groupValues[1]}$escaped${match.groupValues[3]}"
+    }
+
+/**
+ * Plain text of a parsed chapter title, for the chapter list and the toolbar:
+ * the styling is already resolved, and footnote markers are dropped, as a
+ * dangling "[1]" is noise outside the text itself.
+ */
+private fun AnnotatedString.plainTitle(): String {
+    val notes = getLinkAnnotations(0, length).filter { range ->
+        val item = range.item
+        item is LinkAnnotation.Clickable && item.tag.startsWith(NOTE_LINK_TAG_PREFIX)
+    }
+    if (notes.isEmpty()) return text.trim()
+
+    return buildString {
+        append(text)
+        notes.sortedByDescending { note -> note.start }.forEach { note ->
+            delete(note.start, note.end)
+        }
+    }.trim()
+}
+
+/** Whether the string carries any styling worth keeping over its plain text. */
+private fun AnnotatedString.hasInlineMarkup(): Boolean =
+    spanStyles.isNotEmpty() || hasLinkAnnotations(0, length)
+
+/**
+ * Flattens a <title> subtree into inline content on a single line, keeping its
+ * markup. Block children (<p>, <v>, ...) are unwrapped with a separating
+ * space, children that cannot live inside a line (<image>, <empty-line>, ...)
+ * are dropped, and all whitespace is collapsed, so neither the source
+ * indentation nor an appended "\n" can split the title in two. The inline
+ * elements (<emphasis>, <strong>, <sub>, <a>, ...) are left in place: the
+ * regular transforms then style a title exactly like body text.
+ */
+fun Element.flattenTitleToInline() {
+    select("empty-line, image, img, table, hr").remove()
+    select("p, v, subtitle, stanza, poem").forEach { block ->
+        block.after(TextNode(" "))
+        block.unwrap()
+    }
+    collapseWhitespaceDeep()
+}
+
+/**
+ * Collapses whitespace over the whole subtree, as one continuous run of text:
+ * a space split across two text nodes (the source indentation next to the
+ * separator of an unwrapped block) collapses into a single one, and the
+ * leading whitespace is dropped.
+ */
+private fun Node.collapseWhitespaceDeep() {
+    var lastWasSpace = true
+
+    fun collapse(node: Node) {
+        node.childNodes().forEach { child ->
+            if (child !is TextNode) {
+                collapse(child)
+                return@forEach
+            }
+
+            val collapsed = StringBuilder(child.wholeText.length)
+            child.wholeText.forEach { char ->
+                when {
+                    !char.isWhitespace() -> {
+                        collapsed.append(char)
+                        lastWasSpace = false
+                    }
+
+                    !lastWasSpace -> {
+                        collapsed.append(' ')
+                        lastWasSpace = true
+                    }
+                }
+            }
+            child.text(collapsed.toString())
+        }
+    }
+
+    collapse(this)
+}
 
 /** Hex-encodes an FB2 element id for safe transport through the pipeline. */
 fun String.encodeReferenceId(): String =
@@ -166,11 +279,18 @@ class DocumentParser @Inject constructor(
 
                 // Section/body titles are already turned into chapter markers
                 // upstream; the titles left here belong to FB2 <poem>/<epigraph>/
-                // <cite>. Flatten them into a bold line instead of dropping them.
+                // <cite>. Flatten them into a bold line instead of dropping them,
+                // keeping the inline markup for the transforms below.
                 select("title").forEach { title ->
-                    val text = title.wholeText().replace(WHITESPACE_REGEX, " ").trim()
-                    if (text.isBlank()) title.remove()
-                    else title.replaceWith(TextNode("\n$TITLE_ROLE_MARKER**$text**\n"))
+                    if (title.wholeText().isBlank()) {
+                        title.remove()
+                        return@forEach
+                    }
+
+                    title.flattenTitleToInline()
+                    title.before(TextNode("\n$TITLE_ROLE_MARKER$BOLD_MARK"))
+                    title.after(TextNode("$BOLD_MARK\n"))
+                    title.unwrap()
                 }
 
                 // Markdown
@@ -420,13 +540,20 @@ class DocumentParser @Inject constructor(
                             if (!includeChapter) return@forEach
 
                             val match = chapterRegex.matchEntire(line) ?: return@forEach
-                            val title = match.groupValues[2].clearAllMarkdown().trim()
+                            // The title keeps its inline markup (see
+                            // [flattenTitleToInline]), so it is parsed like any
+                            // other line; the chapter list gets the plain text.
+                            val styledTitle = markdownParser.parse(
+                                match.groupValues[2].escapeLeadingBlockMarker()
+                            )
+                            val title = styledTitle.plainTitle()
                             if (!title.containsVisibleText()) return@forEach
 
                             readerText.add(
                                 ReaderText.Chapter(
                                     title = title,
-                                    depth = match.groupValues[1].toIntOrNull() ?: 0
+                                    depth = match.groupValues[1].toIntOrNull() ?: 0,
+                                    styledTitle = styledTitle.takeIf { it.hasInlineMarkup() }
                                 )
                             )
                             chapterAdded = true

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/MarkdownParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/MarkdownParser.kt
@@ -47,6 +47,10 @@ private val MARK_STYLES = mapOf(
     ),
     ITALIC_MARK.single() to SpanStyle(
         fontStyle = FontStyle.Italic
+    ),
+    BOLD_MARK.single() to SpanStyle(
+        // Same weight as a <strong>/StrongEmphasis run
+        fontWeight = FontWeight.Medium
     )
 )
 

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
@@ -8,6 +8,7 @@ package ua.acclorite.book_story.data.parser.text
 
 import kotlinx.coroutines.yield
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
 import org.jsoup.nodes.TextNode
 import org.jsoup.parser.Parser
 import ua.acclorite.book_story.core.log.logE
@@ -16,14 +17,39 @@ import ua.acclorite.book_story.data.model.file.CachedFile
 import ua.acclorite.book_story.data.parser.document.DocumentParser
 import androidx.compose.ui.text.AnnotatedString
 import ua.acclorite.book_story.data.parser.document.EMPTY_LINE_MARKER
+import ua.acclorite.book_story.data.parser.document.flattenTitleToInline
 import ua.acclorite.book_story.domain.model.reader.ParsedText
 import ua.acclorite.book_story.domain.model.reader.ReaderText
 import javax.inject.Inject
 
 private const val TAG = "XmlTextParser"
 
-/** Compiled once — used per <title> when converting FB2 headings to chapters. */
-private val WHITESPACE_REGEX = Regex("\\s+")
+/**
+ * FB2 keeps chapter headings in the <title> of a <body>/<section>. Converts
+ * them into chapter markers before [DocumentParser] gets to the remaining
+ * (poem/epigraph/cite) titles.
+ *
+ * The title is flattened to a single line but keeps its inline markup
+ * (emphasis, sub/superscript, note references, ...): its children stay in the
+ * tree, so [DocumentParser] styles a chapter title like any other line.
+ */
+internal fun Document.markChapterTitles() {
+    selectFirst("body")?.select("title")?.forEach { title ->
+        val parentTag = title.parent()?.tagName()
+        if (parentTag != "body" && parentTag != "section") return@forEach
+        if (title.wholeText().isBlank()) return@forEach
+
+        // Depth 0 = a title of a <body> or top-level <section>
+        val depth = title.parents().count { parent ->
+            parent.tagName() == "section"
+        }.let { sections -> (sections - 1).coerceAtLeast(0) }
+
+        title.flattenTitleToInline()
+        title.before(TextNode("\n[[[chapter|$depth|"))
+        title.after(TextNode("]]]\n"))
+        title.unwrap()
+    }
+}
 
 class XmlTextParser @Inject constructor(
     private val documentParser: DocumentParser
@@ -43,26 +69,7 @@ class XmlTextParser @Inject constructor(
                 }.filterKeys { it.isNotBlank() }
                 document.select("binary").remove()
 
-                // FB2 keeps chapter headings in <title> of <body>/<section>.
-                // Convert them to chapter markers before [DocumentParser]
-                // removes all <title> elements.
-                document.selectFirst("body")?.select("title")?.forEach { title ->
-                    val parentTag = title.parent()?.tagName()
-                    if (parentTag != "body" && parentTag != "section") return@forEach
-
-                    val text = title.wholeText()
-                        .replace(WHITESPACE_REGEX, " ")
-                        .trim()
-                    if (text.isBlank()) return@forEach
-
-                    // Depth 0 = a title of a <body> or top-level <section>
-                    val depth = title.parents().count { parent ->
-                        parent.tagName() == "section"
-                    }.let { sections -> (sections - 1).coerceAtLeast(0) }
-                    title.replaceWith(
-                        TextNode("\n[[[chapter|$depth|$text]]]\n")
-                    )
-                }
+                document.markChapterTitles()
 
                 // FB2 <empty-line/> is a blank paragraph. It carries no text, so
                 // it is turned into a marker that survives text extraction and is

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/reader/ReaderText.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/reader/ReaderText.kt
@@ -37,7 +37,13 @@ sealed class ReaderText {
         val id: UUID = UUID.randomUUID(),
         val title: String,
         /** Nesting depth of the chapter: 0 for a top-level chapter. */
-        val depth: Int = 0
+        val depth: Int = 0,
+        /**
+         * The title as it is set in the text, with its inline markup (italic,
+         * sub/superscript, footnote references, ...); null when the title is
+         * plain. The chapter list and the toolbar always use [title].
+         */
+        val styledTitle: AnnotatedString? = null
     ) : ReaderText() {
         val nested: Boolean
             get() = depth > 0

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderLayoutText.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderLayoutText.kt
@@ -108,11 +108,15 @@ fun LazyItemScope.ReaderLayoutText(
         is ReaderText.Chapter -> {
             ReaderLayoutTextChapter(
                 chapter = entry,
+                showMenu = showMenu,
                 chapterTitleAlignment = chapterTitleAlignment,
                 fontColor = fontColor,
                 sidePadding = sidePadding,
                 highlightedReading = highlightedReading,
-                highlightedReadingThickness = highlightedReadingThickness
+                highlightedReadingThickness = highlightedReadingThickness,
+                toolbarHidden = toolbarHidden,
+                openNote = openNote,
+                menuVisibility = menuVisibility
             )
         }
 

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderLayoutTextChapter.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderLayoutTextChapter.kt
@@ -6,6 +6,7 @@
 
 package ua.acclorite.book_story.ui.reader
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,25 +16,51 @@ import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import ua.acclorite.book_story.domain.model.reader.ReaderText.Chapter
+import ua.acclorite.book_story.presentation.reader.ReaderEvent
 import ua.acclorite.book_story.presentation.reader.model.ReaderTextAlignment
 import ua.acclorite.book_story.ui.common.components.common.StyledText
 
 @Composable
 fun LazyItemScope.ReaderLayoutTextChapter(
     chapter: Chapter,
+    showMenu: Boolean,
     chapterTitleAlignment: ReaderTextAlignment,
     fontColor: Color,
     sidePadding: Dp,
     highlightedReading: Boolean,
-    highlightedReadingThickness: FontWeight
+    highlightedReadingThickness: FontWeight,
+    toolbarHidden: Boolean,
+    openNote: (ReaderEvent.OnOpenNote) -> Unit,
+    menuVisibility: (ReaderEvent.OnMenuVisibility) -> Unit
 ) {
+    // A title may carry inline markup, footnote references included; the note
+    // handler is attached here, at render time (see [withReferenceListeners]).
+    val styledTitle = chapter.styledTitle
+    val title = remember(styledTitle, chapter.title, openNote) {
+        styledTitle?.withReferenceListeners { tag ->
+            openNote(ReaderEvent.OnOpenNote(tag))
+        } ?: AnnotatedString(chapter.title)
+    }
+
+    // Captured from the text's layout so taps can be resolved against the
+    // actual glyph positions — see [dispatchLinkAt].
+    var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+    val uriHandler = LocalUriHandler.current
+
     Column(
         Modifier
             .animateItem(
@@ -45,10 +72,37 @@ fun LazyItemScope.ReaderLayoutTextChapter(
         Spacer(modifier = Modifier.height(22.dp))
 
         StyledText(
-            text = buildAnnotatedString { append(chapter.title) },
+            text = title,
+            onTextLayout = { layoutResult = it },
             modifier = Modifier
                 .padding(horizontal = sidePadding)
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .then(
+                    if (toolbarHidden && styledTitle != null) {
+                        // A reference in the title has to win over the reader's
+                        // menu toggle, exactly like one in a paragraph does.
+                        Modifier.pointerInput(title, showMenu) {
+                            val linkPadding = 12.dp.toPx()
+                            detectTapGestures(
+                                onTap = { position ->
+                                    val hitLink = layoutResult?.let { layout ->
+                                        title.dispatchLinkAt(
+                                            layout, position, uriHandler, linkPadding
+                                        )
+                                    } ?: false
+                                    if (!hitLink) {
+                                        menuVisibility(
+                                            ReaderEvent.OnMenuVisibility(
+                                                show = !showMenu,
+                                                saveCheckpoint = true
+                                            )
+                                        )
+                                    }
+                                }
+                            )
+                        }
+                    } else Modifier
+                ),
             style = MaterialTheme.typography.headlineMedium.let { base ->
                 // The deeper the section, the smaller its title: -15% per
                 // level, bottoming out at three levels deep


### PR DESCRIPTION
Keeps the inline markup — and the footnotes — of an FB2 `<title>`, which used to be flattened to plain text before any styling ran.

## What changed
- **`flattenTitleToInline()`** (`DocumentParser`) flattens a `<title>` subtree to a single line but **keeps its children**: `<p>`/`<v>` are unwrapped with a separating space, what cannot live inline (`<image>`, `<empty-line>`, `<table>`) is dropped, and whitespace is collapsed *across* text nodes, so the source indentation next to a separator cannot become a double space. The regular inline transforms then style a title exactly like body text.
- **`XmlTextParser.markChapterTitles()`** (extracted from `parse`, `internal` so tests can drive it) emits `[[[chapter|depth|<inline with marks>]]]`.
- **`ReaderText.Chapter.styledTitle: AnnotatedString?`** — the styled heading for the text. `title: String` stays plain for the chapters drawer and the top bar, and **drops footnote markers** ("Chapter[7]" → "Chapter"). It is null when a title is plain, so nothing changes for ordinary books.
- **`ReaderLayoutTextChapter`** renders the styled title and, like a paragraph, resolves taps positionally (`dispatchLinkAt`), so a footnote in a heading opens the note instead of toggling the reader menu.
- **`escapeLeadingBlockMarker()`** — titles reach commonmark for the first time, so a leading `1.` / `17)` / `-` / `#` / `>` is escaped and no longer swallowed as a block marker.
- **`BOLD_MARK`** replaces the `**` wrapper around poem/epigraph/cite titles: the wrapper can no longer fuse with a `<strong>` inside the title.
- Cache formats bumped: `ParsedTextCodec` 1→2 (styled title), `ParseCache` 2→3.

## Testing
- **39 instrumented tests green** on device (`connectedDebugAndroidTest`), including the new `Fb2TitleParsingTest` (plain title carries no styling; inline markup kept; footnote tappable + out of the plain title; leading list markers survive; multi-`<p>` title becomes one line; poem title keeps its markup) and a styled chapter added to `ParsedTextCodecTest`.
- **Regression check**: a JVM harness replaying the whole DOM phase (jsoup + commonmark) over the tag-coverage test book produced a line stream **identical** to the previous parser everywhere except the title lines themselves.
- **On device** (Lenovo TB128FU): italic/bold/strikethrough/sub/sup in a heading; `[7]` superscript in a heading opening note 7; `17)` preserved; a two-`<p>` title joined into one heading; poem and cite titles bold with italic inside; chapters drawer and top bar plain and marker-free.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
