### PR TITLE
Stop rewriting reader images on every open

### DIFF
--- a/app/src/androidTest/java/ua/acclorite/book_story/data/cache/ImageMemoryBudgetTest.kt
+++ b/app/src/androidTest/java/ua/acclorite/book_story/data/cache/ImageMemoryBudgetTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.cache
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Checks the tally that decides which images the reader keeps in memory. */
+@RunWith(AndroidJUnit4::class)
+class ImageMemoryBudgetTest {
+
+    @Test
+    fun imagesFitUntilTheBudgetIsSpent() {
+        val budget = ImageMemoryBudget(maxBytes = 100)
+
+        assertTrue(budget.claim(60))
+        assertTrue(budget.claim(40))
+        assertFalse(budget.claim(1))
+    }
+
+    @Test
+    fun anImageThatWouldOverrunIsRefusedWhole() {
+        val budget = ImageMemoryBudget(maxBytes = 100)
+
+        assertTrue(budget.claim(90))
+        // Refused rather than partly claimed: the caller writes it to a file, so
+        // claiming any of it would keep room from an image that does fit.
+        assertFalse(budget.claim(20))
+        assertTrue(budget.claim(10))
+    }
+
+    @Test
+    fun oneTooBigDoesNotCloseTheBudget() {
+        val budget = ImageMemoryBudget(maxBytes = 100)
+
+        assertFalse(budget.claim(500))
+        assertTrue(budget.claim(100))
+    }
+
+    @Test
+    fun anEmptyBudgetKeepsNothing() {
+        val budget = ImageMemoryBudget(maxBytes = 0)
+
+        assertFalse(budget.claim(1))
+    }
+
+    @Test
+    fun theDefaultIsRoomForAnOrdinaryIllustratedBookAndNoMore() {
+        val budget = ImageMemoryBudget()
+
+        // A handful of photographs fits; a manga volume cannot. Sized so the
+        // heap-relative term cannot make this depend on the test device.
+        assertTrue(budget.claim(1024 * 1024))
+        assertFalse(budget.claim(64 * 1024 * 1024))
+    }
+}

--- a/app/src/androidTest/java/ua/acclorite/book_story/data/cache/ReaderImageFilesTest.kt
+++ b/app/src/androidTest/java/ua/acclorite/book_story/data/cache/ReaderImageFilesTest.kt
@@ -81,14 +81,65 @@ class ReaderImageFilesTest {
     }
 
     @Test
-    fun clearDropsOneBookAndLeavesTheOther() {
+    fun keepOnlyDropsEveryOtherBook() {
         val kept = files.write(1, "a.jpg", byteArrayOf(1))
         val dropped = files.write(2, "a.jpg", byteArrayOf(2))
+        val alsoDropped = files.write(3, "a.jpg", byteArrayOf(3))
 
-        files.clear(bookId = 2)
+        files.keepOnly(bookId = 1)
 
         assertTrue(kept!!.exists())
         assertFalse(dropped!!.exists())
+        assertFalse(alsoDropped!!.exists())
+    }
+
+    @Test
+    fun keepOnlyAnUnknownBookLeavesNothingBehind() {
+        val written = files.write(1, "a.jpg", byteArrayOf(1))
+
+        files.keepOnly(bookId = 7)
+
+        assertFalse(written!!.exists())
+    }
+
+    @Test
+    fun existingFindsWhatWasWrittenForTheBook() {
+        files.write(1, "a.jpg", byteArrayOf(1))
+        files.write(1, "b.jpg", byteArrayOf(2))
+        files.write(2, "c.jpg", byteArrayOf(3))
+
+        val found = files.existing(bookId = 1, srcs = setOf("a.jpg", "b.jpg", "c.jpg", "d.jpg"))
+
+        assertEquals(setOf("a.jpg", "b.jpg"), found.keys)
+        assertArrayEquals(byteArrayOf(1), found.getValue("a.jpg").readBytes())
+    }
+
+    @Test
+    fun existingIsEmptyForABookThatWroteNothing() {
+        files.write(1, "a.jpg", byteArrayOf(1))
+
+        assertTrue(files.existing(bookId = 2, srcs = setOf("a.jpg")).isEmpty())
+    }
+
+    @Test
+    fun existingIgnoresAnEmptyFile() {
+        val file = files.write(1, "a.jpg", byteArrayOf(1))!!
+        file.writeBytes(ByteArray(0))
+
+        assertTrue(files.existing(bookId = 1, srcs = setOf("a.jpg")).isEmpty())
+    }
+
+    @Test
+    fun aReopenedBookFindsTheFilesItLeftBehind() {
+        // What leaving and re-entering a book looks like from here: nothing is
+        // dropped on the way out, and on the way back in its own files survive.
+        val written = files.write(1, "a.jpg", byteArrayOf(1, 2, 3))
+        files.keepOnly(bookId = 1)
+
+        val found = files.existing(1, setOf("a.jpg"))
+
+        assertEquals(written, found["a.jpg"])
+        assertArrayEquals(byteArrayOf(1, 2, 3), found.getValue("a.jpg").readBytes())
     }
 
     @Test

--- a/app/src/androidTest/java/ua/acclorite/book_story/domain/model/reader/BookImageStoreTest.kt
+++ b/app/src/androidTest/java/ua/acclorite/book_story/domain/model/reader/BookImageStoreTest.kt
@@ -8,6 +8,7 @@
 package ua.acclorite.book_story.domain.model.reader
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -42,18 +43,29 @@ class BookImageStoreTest {
     @Test
     fun putPublishesTheFileAndClearsPending() {
         store.reset(listOf("a.jpg", "b.jpg"))
-        store.put("a.jpg", File("/tmp/a"))
+        store.put("a.jpg", BookImage.Ready.InFile(File("/tmp/a")))
 
         val image = store["a.jpg"]
-        assertTrue(image is BookImage.Ready)
-        assertEquals(File("/tmp/a"), (image as BookImage.Ready).file)
+        assertTrue(image is BookImage.Ready.InFile)
+        assertEquals(File("/tmp/a"), (image as BookImage.Ready.InFile).file)
         assertEquals(setOf("b.jpg"), store.pending())
+    }
+
+    @Test
+    fun anInMemoryImageCountsAsReadyToo() {
+        store.reset(listOf("a.jpg"))
+        store.put("a.jpg", BookImage.Ready.InMemory(byteArrayOf(1, 2, 3)))
+
+        val image = store["a.jpg"]
+        assertTrue(image is BookImage.Ready.InMemory)
+        assertArrayEquals(byteArrayOf(1, 2, 3), (image as BookImage.Ready.InMemory).bytes)
+        assertTrue(store.pending().isEmpty())
     }
 
     @Test
     fun finishMarksUnresolvedAsMissing() {
         store.reset(listOf("a.jpg", "b.jpg"))
-        store.put("a.jpg", File("/tmp/a"))
+        store.put("a.jpg", BookImage.Ready.InFile(File("/tmp/a")))
 
         store.finish()
 
@@ -72,7 +84,7 @@ class BookImageStoreTest {
     @Test
     fun resetDiscardsThePreviousBook() {
         store.reset(listOf("a.jpg"))
-        store.put("a.jpg", File("/tmp/a"))
+        store.put("a.jpg", BookImage.Ready.InFile(File("/tmp/a")))
 
         store.reset(listOf("c.jpg"))
 

--- a/app/src/main/java/ua/acclorite/book_story/data/cache/ImageMemoryBudget.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/cache/ImageMemoryBudget.kt
@@ -1,0 +1,59 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.cache
+
+/**
+ * How many encoded image bytes one load pass may keep in memory before spilling
+ * the rest to files.
+ *
+ * It exists so that a book whose images are small — a cover and a few
+ * illustrations, which is most books — never writes a session file at all. The
+ * alternative would be writing tens of kilobytes to disk only to delete them
+ * again when the reader closes.
+ *
+ * The ceiling is a **constant**, deliberately not "whatever memory is free": how
+ * much is free is not a stable property (Android reclaims under pressure), so
+ * treating it as one would mean keeping the file path anyway *and* growing a
+ * spill-to-disk transition between the two. A fixed budget needs neither, because
+ * it is small enough to simply hold. The heap-relative term only keeps it modest
+ * on a device whose heap is small to begin with.
+ *
+ * One instance per pass: the tally is the open book's, and it dies with it.
+ */
+class ImageMemoryBudget(private val maxBytes: Long = defaultMaxBytes()) {
+
+    private var claimed = 0L
+
+    /**
+     * Claims room for [size] bytes, reporting whether it was there. An image too
+     * big to fit does not close the budget: a smaller one after it still can.
+     *
+     * Which images end up in memory is first-come: the book's own order when they
+     * come from a scan of it, the order a fresh parse hands them over in
+     * otherwise. That is left unspecified on purpose — it only decides *which*
+     * half of a book too big to fit is on disk, and a book that fits, fits
+     * whole.
+     */
+    fun claim(size: Int): Boolean {
+        if (claimed + size > maxBytes) return false
+        claimed += size
+        return true
+    }
+
+    private companion object {
+
+        /** Enough for an ordinary illustrated book, and never a large share of the heap. */
+        const val CEILING_BYTES = 8L * 1024 * 1024
+
+        /**
+         * Coil's own cache of decoded bitmaps already takes ~25 % of the heap, so
+         * this stays an order of magnitude below that.
+         */
+        fun defaultMaxBytes(): Long =
+            minOf(CEILING_BYTES, Runtime.getRuntime().maxMemory() / 16)
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/cache/ReaderImageFiles.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/cache/ReaderImageFiles.kt
@@ -32,9 +32,10 @@ private const val TAG = "ReaderImageFiles"
  *
  * - **per session** (one directory per process) so [sweep] can delete what other
  *   runs left behind without ever racing a live one;
- * - **per book** so closing one book cannot delete another's files — and so that
- *   two books using the same src name ("images/cover.jpg" is not exotic) never
- *   collide.
+ * - **per book** so opening one book can drop every *other* book's files in one
+ *   step ([keepOnly]) while a reopened book still finds its own ([existing]) —
+ *   and so that two books using the same src name ("images/cover.jpg" is not
+ *   exotic) never collide.
  *
  * Everything here is best-effort: a file that cannot be written just leaves the
  * image unresolved, exactly like one missing from the book.
@@ -71,9 +72,38 @@ class ReaderImageFiles @Inject constructor(application: Application) {
         }
     }
 
-    /** Drops every image file of [bookId]; call when its reader closes. */
-    fun clear(bookId: Int) {
-        File(session, bookId.toString()).deleteRecursively()
+    /**
+     * The files of [bookId] this session already holds, keyed by src — what an
+     * earlier open of the same book wrote. Reusing them is the whole point of
+     * [keepOnly] retaining them; without this the pass would extract the images
+     * again and overwrite identical files.
+     */
+    fun existing(bookId: Int, srcs: Set<String>): Map<String, File> {
+        val dir = File(session, bookId.toString())
+        if (!dir.isDirectory) return emptyMap()
+        return srcs.mapNotNull { src ->
+            val file = File(dir, sha256Hex(src))
+            // A missing file measures 0 too, so this covers existence as well;
+            // a half-written one cannot be seen (write renames into place).
+            if (file.length() > 0) src to file else null
+        }.toMap()
+    }
+
+    /**
+     * Drops the files of every book except [bookId]; call when a reader *opens*.
+     *
+     * Closing a book deliberately keeps its files. Leaving and re-entering one is
+     * an ordinary thing to do — the back gesture is easy to hit by accident — and
+     * on an image-heavy book each re-entry would otherwise extract and rewrite
+     * tens of megabytes that were on disk all along. They still never outlive the
+     * process: the next book taking over drops them, and [sweep] catches the case
+     * where the process was killed instead.
+     */
+    fun keepOnly(bookId: Int) {
+        val keep = bookId.toString()
+        session.listFiles()
+            ?.filter { it.name != keep }
+            ?.forEach { it.deleteRecursively() }
     }
 
     /**

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
 import ua.acclorite.book_story.core.CoverImage
+import ua.acclorite.book_story.data.cache.ImageMemoryBudget
 import ua.acclorite.book_story.data.cache.ParseCache
 import ua.acclorite.book_story.data.cache.ReaderImageFiles
 import ua.acclorite.book_story.data.local.room.BookDatabase
@@ -21,6 +22,7 @@ import ua.acclorite.book_story.data.parser.image.BookImageLoader
 import ua.acclorite.book_story.data.parser.text.TextParser
 import ua.acclorite.book_story.domain.model.file.File
 import ua.acclorite.book_story.domain.model.library.Book
+import ua.acclorite.book_story.domain.model.reader.BookImage
 import ua.acclorite.book_story.domain.model.reader.ParsedText
 import ua.acclorite.book_story.domain.model.reader.ReaderText
 import ua.acclorite.book_story.domain.repository.BookRepository
@@ -107,16 +109,18 @@ class BookRepositoryImpl @Inject constructor(
     }
 
     /**
-     * Resolves [srcs] to files, reporting each through [onImage] as soon as it
-     * is available, cheapest source first:
+     * Resolves [srcs], reporting each through [onImage] as soon as it is
+     * available, cheapest source first:
      *
      * 1. cached blobs — already on disk, so nothing is read or written;
-     * 2. [parsed] bytes a fresh parse just produced;
-     * 3. a scan of the source book file for whatever is left.
+     * 2. session files an earlier open of this book left behind — likewise;
+     * 3. [parsed] bytes a fresh parse just produced;
+     * 4. a scan of the source book file for whatever is left.
      *
-     * Bytes from 2 and 3 are written as parse-cache blobs when image caching is
-     * on (so the next open lands in 1), otherwise to the transient session
-     * directory. Either way the reader is handed a file and holds no bytes.
+     * Bytes from 3 and 4 have to be put somewhere: a parse-cache blob when image
+     * caching is on (so the next open lands in 1), memory while the budget lasts,
+     * a session file after that (so the next open lands in 2). Only the budgeted
+     * few are bytes; the rest of the book is files.
      *
      * Runs off the reader's critical path — the text is already on screen.
      */
@@ -124,7 +128,7 @@ class BookRepositoryImpl @Inject constructor(
         bookId: Int,
         srcs: Set<String>,
         parsed: Map<String, ByteArray>,
-        onImage: (src: String, file: java.io.File) -> Unit
+        onImage: (src: String, image: BookImage.Ready) -> Unit
     ): Result<Unit> {
         if (srcs.isEmpty()) return Result.success(Unit)
         return withContext(Dispatchers.IO) {
@@ -143,8 +147,17 @@ class BookRepositoryImpl @Inject constructor(
                     val fromBlobs = if (capMb > 0) parseCache.imageBlobFiles(
                         cachedFile.path, cachedFile.size, cachedFile.lastModified, srcs
                     ) else emptyMap()
-                    fromBlobs.forEach { (src, file) -> onImage(src, file) }
+                    fromBlobs.forEach { (src, file) -> onImage(src, BookImage.Ready.InFile(file)) }
 
+                    // Written while this book was open earlier in the session and
+                    // kept on purpose; re-extracting them would only overwrite
+                    // identical files.
+                    val fromSession = readerImageFiles.existing(bookId, srcs - fromBlobs.keys)
+                    fromSession.forEach { (src, file) ->
+                        onImage(src, BookImage.Ready.InFile(file))
+                    }
+
+                    val budget = ImageMemoryBudget()
                     var wroteBlob = false
                     fun publish(src: String, bytes: ByteArray) {
                         if (!pass.isActive) return
@@ -153,13 +166,20 @@ class BookRepositoryImpl @Inject constructor(
                             src, bytes
                         ) else null
                         wroteBlob = wroteBlob || blob != null
-                        val file = blob ?: readerImageFiles.write(bookId, src, bytes)
-                        if (file != null) onImage(src, file)
+                        when {
+                            // A blob is written for the sake of the *next* session,
+                            // so the budget has nothing to save here.
+                            blob != null -> onImage(src, BookImage.Ready.InFile(blob))
+                            budget.claim(bytes.size) ->
+                                onImage(src, BookImage.Ready.InMemory(bytes))
+                            else -> readerImageFiles.write(bookId, src, bytes)
+                                ?.let { onImage(src, BookImage.Ready.InFile(it)) }
+                        }
                     }
 
-                    var stillMissing = srcs - fromBlobs.keys
-                    // A fresh parse already read these; spilling them now is what
-                    // lets the reader drop them from memory.
+                    var stillMissing = srcs - fromBlobs.keys - fromSession.keys
+                    // A fresh parse already read these; handing them over now is
+                    // what lets the reader drop them from the text.
                     stillMissing.forEach { src -> parsed[src]?.let { publish(src, it) } }
 
                     stillMissing = stillMissing - parsed.keys
@@ -175,9 +195,9 @@ class BookRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun clearBookImages(bookId: Int): Result<Unit> = runCatching {
+    override suspend fun keepOnlyBookImages(bookId: Int): Result<Unit> = runCatching {
         withContext(Dispatchers.IO) {
-            readerImageFiles.clear(bookId)
+            readerImageFiles.keepOnly(bookId)
         }
     }
 

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/reader/BookImageStore.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/reader/BookImageStore.kt
@@ -22,14 +22,28 @@ sealed interface BookImage {
     data object Loading : BookImage
 
     /**
-     * The encoded (JPEG/PNG/GIF) image, as a local file ready to be rendered.
+     * The encoded (JPEG/PNG/GIF) image, ready to be rendered.
      *
-     * A file rather than a `ByteArray` on purpose: the image loader reads a local
-     * file directly, without copying it into a cache of its own, and holds only
-     * the *decoded* bitmap — in a memory cache that is bounded and trims itself.
-     * Encoded bytes held here would be a second, unbounded cache next to it.
+     * Most of a book's images are handed over as *files*: the image loader reads a
+     * local file directly, without copying it into a cache of its own, and holds
+     * only the *decoded* bitmap — in a memory cache that is bounded and trims
+     * itself. Every encoded image held here instead would be a second, unbounded
+     * cache next to that one.
+     *
+     * A small, fixed budget of them is nevertheless kept in memory
+     * ([ua.acclorite.book_story.data.cache.ImageMemoryBudget]), because a book
+     * whose images all fit in it never has to touch the disk at all — and writing
+     * files that are deleted minutes later is work worth skipping when the amount
+     * held is bounded either way.
      */
-    class Ready(val file: File) : BookImage
+    sealed interface Ready : BookImage {
+
+        /** Held in memory, within the budget. */
+        class InMemory(val bytes: ByteArray) : Ready
+
+        /** Written to disk — a parse-cache blob, or a transient session file. */
+        class InFile(val file: File) : Ready
+    }
 
     /**
      * The load pass finished without resolving the image: the source book file
@@ -69,9 +83,9 @@ class BookImageStore {
         srcs.forEach { src -> entries[src] = BookImage.Loading }
     }
 
-    /** Publishes the [file] holding the image [src] to the reader. */
-    fun put(src: String, file: File) {
-        entries[src] = BookImage.Ready(file)
+    /** Publishes the resolved [image] for [src] to the reader. */
+    fun put(src: String, image: BookImage.Ready) {
+        entries[src] = image
     }
 
     /** The srcs that are still not available, i.e. worth (re)loading. */

--- a/app/src/main/java/ua/acclorite/book_story/domain/repository/BookRepository.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/repository/BookRepository.kt
@@ -9,6 +9,7 @@ package ua.acclorite.book_story.domain.repository
 import ua.acclorite.book_story.core.CoverImage
 import ua.acclorite.book_story.domain.model.file.File
 import ua.acclorite.book_story.domain.model.library.Book
+import ua.acclorite.book_story.domain.model.reader.BookImage
 import ua.acclorite.book_story.domain.model.reader.ParsedText
 
 interface BookRepository {
@@ -25,24 +26,29 @@ interface BookRepository {
     ): Result<ParsedText>
 
     /**
-     * Resolves the images [srcs] of the open book to local files, calling
-     * [onImage] for each one as soon as it is available.
+     * Resolves the images [srcs] of the open book, calling [onImage] for each one
+     * as soon as it is available. Most arrive as files; the first few small ones
+     * are kept in memory instead (see
+     * [ua.acclorite.book_story.data.cache.ImageMemoryBudget]).
      *
      * [parsed] carries the bytes a fresh parse has just produced, keyed by src;
-     * they are written out and handed back as files like everything else, so the
-     * reader has a single render path and never holds encoded bytes itself. It
-     * is empty for a book restored from the parse cache, whose text carries
-     * image metadata only.
+     * they are handed over like everything else, so the reader has a single render
+     * path and the text itself never holds encoded bytes. It is empty for a book
+     * restored from the parse cache, whose text carries image metadata only.
      */
     suspend fun loadBookImages(
         bookId: Int,
         srcs: Set<String>,
         parsed: Map<String, ByteArray>,
-        onImage: (src: String, file: java.io.File) -> Unit
+        onImage: (src: String, image: BookImage.Ready) -> Unit
     ): Result<Unit>
 
-    /** Drops the transient image files of [bookId]; call when its reader closes. */
-    suspend fun clearBookImages(bookId: Int): Result<Unit>
+    /**
+     * Drops the transient image files of every book except [bookId]; call when a
+     * reader opens. The book's own files are kept so that reopening it costs
+     * nothing; the persistent parse-cache blobs are a different thing entirely.
+     */
+    suspend fun keepOnlyBookImages(bookId: Int): Result<Unit>
 
     suspend fun getFileFromBook(
         bookId: Int

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/KeepOnlyBookImagesUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/KeepOnlyBookImagesUseCase.kt
@@ -11,20 +11,22 @@ import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.domain.repository.BookRepository
 import javax.inject.Inject
 
-private const val TAG = "ClearBookImages"
+private const val TAG = "KeepOnlyBookImages"
 
 /**
- * Drops the transient image files written for a book while it was open. The
- * persistent parse-cache blobs are a different thing and are left alone.
+ * Drops the transient image files of every book except the one being opened, whose
+ * own files are kept — reopening a book should not have to extract its images all
+ * over again. The persistent parse-cache blobs are a different thing and are left
+ * alone.
  */
-class ClearBookImagesUseCase @Inject constructor(
+class KeepOnlyBookImagesUseCase @Inject constructor(
     private val bookRepository: BookRepository
 ) {
 
     suspend operator fun invoke(bookId: Int) {
         if (bookId == -1) return
-        bookRepository.clearBookImages(bookId).onFailure {
-            logE(TAG, "Could not clear images of [$bookId]: ${it.message}")
+        bookRepository.keepOnlyBookImages(bookId).onFailure {
+            logE(TAG, "Could not drop images of books other than [$bookId]: ${it.message}")
         }
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/LoadBookImagesUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/LoadBookImagesUseCase.kt
@@ -9,16 +9,16 @@ package ua.acclorite.book_story.domain.use_case.book
 
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
+import ua.acclorite.book_story.domain.model.reader.BookImage
 import ua.acclorite.book_story.domain.repository.BookRepository
-import java.io.File
 import javax.inject.Inject
 
 private const val TAG = "LoadBookImages"
 
 /**
- * Resolves the images of the open book to files, in the background, handing each
- * one over as soon as it is ready. Failures are not fatal: the text is already on
- * screen, an image that cannot be loaded simply stays unavailable.
+ * Resolves the images of the open book, in the background, handing each one over
+ * as soon as it is ready. Failures are not fatal: the text is already on screen,
+ * an image that cannot be loaded simply stays unavailable.
  */
 class LoadBookImagesUseCase @Inject constructor(
     private val bookRepository: BookRepository
@@ -28,7 +28,7 @@ class LoadBookImagesUseCase @Inject constructor(
         bookId: Int,
         srcs: Set<String>,
         parsed: Map<String, ByteArray> = emptyMap(),
-        onImage: (src: String, file: File) -> Unit
+        onImage: (src: String, image: BookImage.Ready) -> Unit
     ) {
         if (bookId == -1 || srcs.isEmpty()) return
         logI(TAG, "Loading [${srcs.size}] image(s) of [$bookId].")

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
@@ -35,10 +35,10 @@ import ua.acclorite.book_story.core.ui.UIText
 import ua.acclorite.book_story.domain.model.reader.BookImageStore
 import ua.acclorite.book_story.domain.model.reader.ReaderText
 import ua.acclorite.book_story.domain.model.reader.ReaderText.Chapter
-import ua.acclorite.book_story.domain.use_case.book.ClearBookImagesUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetBookUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetChapterProgressUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetTextUseCase
+import ua.acclorite.book_story.domain.use_case.book.KeepOnlyBookImagesUseCase
 import ua.acclorite.book_story.domain.use_case.book.LoadBookImagesUseCase
 import ua.acclorite.book_story.domain.use_case.book.UpdateBookUseCase
 import ua.acclorite.book_story.domain.use_case.history.GetHistoryForBookUseCase
@@ -57,7 +57,7 @@ class ReaderModel @Inject constructor(
     private val getHistoryForBookUseCase: GetHistoryForBookUseCase,
     private val getChapterProgressUseCase: GetChapterProgressUseCase,
     private val loadBookImagesUseCase: LoadBookImagesUseCase,
-    private val clearBookImagesUseCase: ClearBookImagesUseCase
+    private val keepOnlyBookImagesUseCase: KeepOnlyBookImagesUseCase
 ) : ViewModel() {
 
     private val mutex = Mutex()
@@ -66,7 +66,7 @@ class ReaderModel @Inject constructor(
     val state = _state.asStateFlow()
 
     /**
-     * Bytes of the open book's images. Kept out of [state] on purpose: it is
+     * Where the open book's images live. Kept out of [state] on purpose: it is
      * observable on its own, so filling an image in repaints just that image
      * instead of pushing a new text list through the whole reader.
      */
@@ -75,7 +75,7 @@ class ReaderModel @Inject constructor(
 
     /**
      * Image bytes a fresh parse produced, held only until [ReaderEvent.OnLoadImages]
-     * has written them out. Kept off [state] so they are not pinned for the whole
+     * has handed them over. Kept off [state] so they are not pinned for the whole
      * session by the text that no longer needs them.
      */
     private var parsedImageBytes: Map<String, ByteArray> = emptyMap()
@@ -113,9 +113,10 @@ class ReaderModel @Inject constructor(
                         // A freshly parsed book carries its image bytes, one
                         // restored from the cache carries metadata only. Either
                         // way the bytes are kept out of the state: [OnLoadImages]
-                        // writes them to disk in the background and the reader
-                        // renders from the file. Holding them here as well would
-                        // pin tens of megabytes for the whole session.
+                        // hands them to the store in the background, which holds
+                        // a bounded few and puts the rest on disk. Holding them
+                        // here as well would pin tens of megabytes for the whole
+                        // session.
                         val bytes = HashMap<String, ByteArray>()
                         val strippedText = text.map { entry ->
                             when {
@@ -163,8 +164,8 @@ class ReaderModel @Inject constructor(
                     val bookId = _state.value.book.id
                     val parsed = parsedImageBytes
                     imageJob = viewModelScope.launch(Dispatchers.IO) {
-                        loadBookImagesUseCase(bookId, pending, parsed) { src, file ->
-                            imageStore.put(src, file)
+                        loadBookImagesUseCase(bookId, pending, parsed) { src, image ->
+                            imageStore.put(src, image)
                         }
                         // Written out, so the last reference to them can go.
                         parsedImageBytes = emptyMap()
@@ -484,6 +485,10 @@ class ReaderModel @Inject constructor(
             }
 
             clear()
+            // Here rather than when the previous reader closed: a book keeps its
+            // image files so that reopening it needs no work, and this is the
+            // point where they stop being the ones worth keeping.
+            keepOnlyBookImagesUseCase(bookId)
 
             _state.update {
                 ReaderState(
@@ -500,7 +505,6 @@ class ReaderModel @Inject constructor(
     }
 
     suspend fun clear() {
-        val bookId = _state.value.book.id
         eventStack.forEach { job ->
             job.cancel()
             job.join()
@@ -508,16 +512,16 @@ class ReaderModel @Inject constructor(
         eventStack.clear()
 
         // Joined, not just cancelled: the image pass ends in blocking file I/O
-        // that cancellation cannot interrupt, so letting go of the files below
-        // has to wait for it to actually stop writing them.
+        // that cancellation cannot interrupt, and it must not still be publishing
+        // into the store that is emptied below.
         imageJob?.cancelAndJoin()
 
-        // Lets go of the book's images: the store, the bytes still waiting to be
-        // written, and the files written for this session. Parse-cache blobs are
-        // a different thing and outlive the reader on purpose.
+        // Releases every byte the reader held: the budgeted images in the store
+        // and whatever a fresh parse was still waiting to hand over. The files
+        // stay — dropping them is the next book's business
+        // ([KeepOnlyBookImagesUseCase]), because this book may well be reopened.
         imageStore.reset()
         parsedImageBytes = emptyMap()
-        clearBookImagesUseCase(bookId)
 
         _state.update { ReaderState() }
     }

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/BookImageData.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/BookImageData.kt
@@ -1,0 +1,22 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.reader
+
+import ua.acclorite.book_story.domain.model.reader.BookImage
+import java.nio.ByteBuffer
+
+/**
+ * The image as the loader wants it to be handed over.
+ *
+ * Neither form involves Coil's disk cache: a local file is read where it lies, and
+ * a buffer is memory-only. Both are already the book's own bytes, so a copy of
+ * them would be a third place to keep the same image.
+ */
+internal fun BookImage.Ready.imageData(): Any = when (this) {
+    is BookImage.Ready.InFile -> file
+    is BookImage.Ready.InMemory -> ByteBuffer.wrap(bytes)
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderImageViewer.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderImageViewer.kt
@@ -93,13 +93,13 @@ fun ReaderImageViewer(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
-    // The file comes from the store, exactly as for the in-page image; only a
+    // The image comes from the store, exactly as for the in-page one; only a
     // Ready image is tappable, so it is on hand by the time this opens.
-    val file = (LocalBookImages.current[entry.image.src] as? BookImage.Ready)?.file
-    val imageRequest = remember(file) {
-        file?.let {
+    val image = LocalBookImages.current[entry.image.src] as? BookImage.Ready
+    val imageRequest = remember(image) {
+        image?.let {
             ImageRequest.Builder(context)
-                .data(it)
+                .data(it.imageData())
                 .memoryCacheKey(entry.image.id)
                 .size(CoilSize.ORIGINAL)
                 .build()

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderLayoutTextImage.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderLayoutTextImage.kt
@@ -71,14 +71,14 @@ fun LazyItemScope.ReaderLayoutTextImage(
 ) {
     val context = LocalContext.current
     // The image comes from the store, not from the entry: the text arrives
-    // without it and a background pass writes it to a file. Coil reads that file
-    // directly, so the only image memory the app holds is Coil's own bounded
-    // cache of decoded bitmaps.
+    // without it and a background pass resolves it, to a file or (for a bounded
+    // few) to bytes. Either way the encoded image is held once, and the decoded
+    // bitmap only in Coil's own bounded cache.
     val image = LocalBookImages.current[entry.image.src]
     val imageRequest = remember(image) {
         (image as? BookImage.Ready)?.let { ready ->
             ImageRequest.Builder(context)
-                .data(ready.file)
+                .data(ready.imageData())
                 .memoryCacheKey(entry.image.id)
                 .crossfade(100)
                 .build()


### PR DESCRIPTION
Closes #18. Follow-up to #12.

With image caching off (the default) every open of a book extracted all its images, wrote them
to the session directory and deleted them on the way out — 24 MB written and thrown away per
open on Touhou, again for the same book reopened seconds later, and even if the reader never
scrolled to an image. #12 bounded the memory, which it did; this trims the disk churn it traded
for.

## Files survive the reader closing

`ReaderImageFiles.keepOnly(bookId)` runs when a book *opens* and drops every **other** book's
directory; `clear()` no longer deletes anything. The second half is what makes the first one
worth anything: the load pass now consults the session directory as a source
(`ReaderImageFiles.existing`) before extracting, or the retained files would just be
overwritten by identical copies. Source order is blobs → session files → fresh-parse bytes →
scan of the book.

## Small images are never written at all

`ImageMemoryBudget` — `min(8 MB, maxMemory/16)` — decides per image: what fits is handed over as
bytes, the rest spills to files exactly as before. A book whose images all fit never creates a
session directory, which is most books (a cover and a few illustrations).

Deliberately a constant, not a reading of free memory: how much is free is not a stable
property (Android reclaims under pressure), so treating it as one would mean keeping the file
path anyway *plus* a spill-to-disk transition between the two. This is not a return to the
pre-#12 state either — there the bytes sat in `state.text` unconditionally, as many megabytes
as the book had; here the ceiling is constant, the store is the single owner, and `clear()`
still releases everything.

The budget skips the blob path: with image caching on a blob is written for the *next* session
anyway, so keeping the bytes too would pay both costs.

`BookImage.Ready` became a sealed interface (`InMemory` / `InFile`); the Coil mapping lives in
one helper, `ui/reader/BookImageData.kt`.

## Device QA

Lenovo TB128FU / Android 12, image caching off, Touhou (75 images, 24 MB). Pass duration from
`LoadBookImages` logs, writes from `stat` snapshots.

| Open | Pass | Files written |
|---|---|---|
| Cold, fresh parse | — | 50 (16 MB) |
| Cold, parse-cache hit → scan | 5.7 s | 40 (16 MB) |
| **Reopen, session files present** | **2.3 s** | **0** |

Previously: 75 files / 24 MB on every open.

- Reopen writes nothing — identical mtimes and sizes.
- In-memory and file-backed images both render, in the page and in the full-screen viewer from
  #11 (a magazine scan's fine print stays legible, so it still decodes at original size).
- Leaving mid-pass: at 2 s nothing is written at all (the budget has not spilled yet) and the
  pass is cancelled with no exception; at 4.5 s the 32 files already written are kept, and the
  next open reuses all 32 untouched and writes only the 8 missing ones.

Left to unit tests, for want of a second imported book: a book small enough to need no
directory, and one book's open dropping another's files.

**A note the QA corrected:** #18 said the budget is spent in document order. True of the scan
path only — a fresh parse hands its bytes over in map order, which is why two cold opens split
25/50 and 35/40 between memory and disk. The `claim` KDoc now leaves the order unspecified: it
only decides which half of a too-big book is on disk, and a book that fits fits whole. Also
worth stating plainly: a reopen is zero-*write*, not zero-work — the budgeted images were
released with the store, so they are extracted again.

114 instrumented tests green (new `ImageMemoryBudgetTest`, 6 more in `ReaderImageFilesTest`,
`BookImageStoreTest` updated), `lintDebug` clean.
