### PR TITLE
Reader settings: stop the sheet resizing between tabs and losing the menu

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderBottomSheet.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderBottomSheet.kt
@@ -16,13 +16,11 @@ import ua.acclorite.book_story.presentation.reader.ReaderScreen
 fun ReaderBottomSheet(
     bottomSheet: BottomSheet?,
     currentNote: AnnotatedString?,
-    menuVisibility: (ReaderEvent.OnMenuVisibility) -> Unit,
     dismissBottomSheet: (ReaderEvent.OnDismissBottomSheet) -> Unit
 ) {
     when (bottomSheet) {
         ReaderScreen.SETTINGS_BOTTOM_SHEET -> {
             ReaderSettingsBottomSheet(
-                menuVisibility = menuVisibility,
                 dismissBottomSheet = dismissBottomSheet
             )
         }

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderContent.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderContent.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.AnnotatedString
 import ua.acclorite.book_story.domain.model.reader.ReaderText
 import ua.acclorite.book_story.domain.model.reader.ReaderText.Chapter
 import ua.acclorite.book_story.presentation.reader.ReaderEvent
+import ua.acclorite.book_story.presentation.reader.ReaderScreen
 import ua.acclorite.book_story.presentation.reader.model.Checkpoint
 import ua.acclorite.book_story.presentation.reader.model.ReaderFontThickness
 import ua.acclorite.book_story.presentation.reader.model.ReaderHorizontalGesture
@@ -122,7 +123,6 @@ fun ReaderContent(
     ReaderBottomSheet(
         bottomSheet = bottomSheet,
         currentNote = currentNote,
-        menuVisibility = menuVisibility,
         dismissBottomSheet = dismissBottomSheet
     )
 
@@ -147,6 +147,7 @@ fun ReaderContent(
             isLoading = isLoading,
             checkpoints = checkpoints,
             showMenu = showMenu,
+            coveredByBottomSheet = bottomSheet == ReaderScreen.SETTINGS_BOTTOM_SHEET,
             lockMenu = lockMenu,
             contentPadding = contentPadding,
             verticalPadding = verticalPadding,

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderScaffold.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderScaffold.kt
@@ -61,6 +61,7 @@ fun ReaderScaffold(
     isLoading: Boolean,
     checkpoints: List<Checkpoint>,
     showMenu: Boolean,
+    coveredByBottomSheet: Boolean,
     lockMenu: Boolean,
     contentPadding: PaddingValues,
     verticalPadding: Dp,
@@ -122,8 +123,13 @@ fun ReaderScaffold(
             .nestedScroll(nestedScrollConnection),
         containerColor = MaterialTheme.colorScheme.surface,
         topBar = {
+            // Hidden while a sheet covers the screen, rather than switched off:
+            // the bars under it cannot be reached anyway, but [showMenu] is what
+            // the page tap toggles and what drives the system bars, so clearing it
+            // here would both leave the reader menu gone once the sheet closes and
+            // move the insets — resizing the sheet as it opens.
             AnimatedVisibility(
-                visible = showMenu,
+                visible = showMenu && !coveredByBottomSheet,
                 enter = slideInVertically { -it },
                 exit = slideOutVertically { -it }
             ) {
@@ -146,7 +152,7 @@ fun ReaderScaffold(
         bottomBar = {
             AnimatedVisibility(
                 modifier = Modifier.fillMaxWidth(),
-                visible = showMenu,
+                visible = showMenu && !coveredByBottomSheet,
                 enter = slideInVertically { it },
                 exit = slideOutVertically { it }
             ) {

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderSettingsBottomSheet.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderSettingsBottomSheet.kt
@@ -6,21 +6,15 @@
 
 package ua.acclorite.book_story.ui.reader
 
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -43,41 +37,37 @@ import ua.acclorite.book_story.ui.settings.reader.translator.TranslatorSubcatego
 
 private var initialPage = 0
 
+/**
+ * Share of the screen the sheet takes. The rest of it is the page being read —
+ * kept the same on every tab, because a sheet that resizes as you move between
+ * them is a jump in the one place the eye is trying to compare a before and an
+ * after.
+ */
+private const val HEIGHT_FRACTION = 0.65f
+
+/**
+ * The reader's settings, over the page they change.
+ *
+ * The scrim is transparent and the reader's own bars are hidden while this is
+ * open (see [ReaderScaffold]), so the strip above the sheet shows the book as the
+ * settings being touched will leave it — not only for colors, but for margins,
+ * font and image width just as much.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReaderSettingsBottomSheet(
-    menuVisibility: (ReaderEvent.OnMenuVisibility) -> Unit,
     dismissBottomSheet: (ReaderEvent.OnDismissBottomSheet) -> Unit
 ) {
     val scope = rememberCoroutineScope()
     val pagerState = rememberPagerState(initialPage) { 3 }
     DisposableEffect(Unit) { onDispose { initialPage = pagerState.currentPage } }
 
-    val animatedScrimColor by animateColorAsState(
-        targetValue = if (pagerState.currentPage == 2) Color.Transparent
-        else BottomSheetDefaults.ScrimColor,
-        animationSpec = tween(300)
-    )
-    val animatedHeight by animateFloatAsState(
-        targetValue = if (pagerState.currentPage == 2) 0.6f else 0.7f,
-        animationSpec = tween(300)
-    )
-
-    LaunchedEffect(pagerState.currentPage) {
-        menuVisibility(
-            ReaderEvent.OnMenuVisibility(
-                show = pagerState.currentPage != 2,
-                saveCheckpoint = false
-            )
-        )
-    }
-
     ModalBottomSheet(
         hasFixedHeight = true,
-        scrimColor = animatedScrimColor,
+        scrimColor = Color.Transparent,
         modifier = Modifier
             .fillMaxWidth()
-            .fillMaxHeight(animatedHeight),
+            .fillMaxHeight(HEIGHT_FRACTION),
         dragHandle = {},
         onDismissRequest = {
             dismissBottomSheet(ReaderEvent.OnDismissBottomSheet)


### PR DESCRIPTION
Closes #20.

## The change

The reader's bars are hidden while the settings sheet is up (`coveredByBottomSheet`) instead of
being switched off. A sheet covers the screen, so the bars under it cannot be reached anyway,
while `showMenu` stays what the page tap toggles — so the menu is simply back when the sheet
closes, with nothing to restore, and the `initialPage` quirk (the sheet reopening on Colors for
the rest of the process) stops mattering.

Clearing `showMenu` would have been worse twice over: besides losing the menu on dismissal, it
drives the system bars (`fullscreen` defaults to `true`), so hiding them changes the insets — and
`fillMaxHeight(fraction)` is a fraction of those, so the sheet would resize as it opened. The
render-only route moves nothing.

With the bars gone on every tab, the rest falls out: one height constant, `0.65`, and a
transparent scrim throughout. Every tab here changes how the page looks — margins, font and image
width no less than colors — and all of it is judged against the page, which a dimmed one hides.
`animateColorAsState`, `animateFloatAsState` and the `LaunchedEffect` that mutated menu state are
all gone with it.

The bars overlay the page rather than displacing it (`ReaderLayout` takes its own
`contentPadding`, not the scaffold's), so hiding them reflows nothing.

## Device QA

Lenovo TB128FU / Android 12, landscape.

- **Sheet top edge measured from the framebuffer: y=420 on General, Reader and Colors alike** —
  65.0 % of 1200 px, identical on all three. No resize between tabs.
- **Page pixels are untouched by the scrim:** the same page point reads (236, 225, 202) with the
  sheet open and with it closed, at three different heights. Nothing is dimmed.
- Opening the settings sheet hides the top and bottom bars; the page above the sheet shows in its
  real colours.
- Dismissing by tapping the page brings the menu back — and that tap does not also toggle the
  menu off, the scrim consumes it.
- Dismissing with Back behaves the same.

No tests: this is composition only, and the project has no Compose UI test source set. `lintDebug`
clean.
