### PR TITLE
Stop wiping the parse cache when the app is closed

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/Application.kt
+++ b/app/src/main/java/ua/acclorite/book_story/Application.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import ua.acclorite.book_story.core.crash.CrashHandler
 import ua.acclorite.book_story.data.cache.ReaderImageFiles
+import ua.acclorite.book_story.data.model.file.CachedFile
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -25,9 +26,13 @@ class Application : Application() {
         super.onCreate()
         Thread.setDefaultUncaughtExceptionHandler(CrashHandler(this))
 
-        // Reader image files of runs that never got to clean up after themselves
-        // — being killed, or swiped away from the recents list, is an ordinary
-        // way to leave a book, so app start is the only reliable place for this.
-        CoroutineScope(Dispatchers.IO).launch { readerImageFiles.sweep() }
+        // Reader image files and book copies of runs that never got to clean up
+        // after themselves — being killed, or swiped away from the recents list, is
+        // an ordinary way to leave a book, so app start is the only reliable place
+        // for this.
+        CoroutineScope(Dispatchers.IO).launch {
+            readerImageFiles.sweep()
+            CachedFile.clearCopies(this@Application)
+        }
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/model/file/CachedFile.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/model/file/CachedFile.kt
@@ -168,13 +168,18 @@ class CachedFile(
     }
 
     /**
-     * Copies the file to [context].cacheDir and provides [File].
+     * Copies the file into [copiesDir] and provides [File]. A copy is the only way
+     * to hand the file to something that needs a real path rather than a stream —
+     * `ZipFile`, and so every EPUB parser — since the book itself lives behind a
+     * document URI.
      *
      * @return null if the file is directory or failed
      */
     private fun storeInCache(): File? {
         if (isDirectory) return null
-        val cacheFile = File(context.cacheDir, UUID.randomUUID().toString())
+        val dir = copiesDir(context)
+        if (!dir.exists() && !dir.mkdirs()) return null
+        val cacheFile = File(dir, UUID.randomUUID().toString())
 
         try {
             context.contentResolver.openInputStream(uri)?.use { input ->
@@ -298,5 +303,30 @@ class CachedFile(
     private fun getFilePath(): String {
         val tempFile = DocumentFileCompat.fromUri(context, uri)
         return tempFile?.getAbsolutePath(context)?.trimEnd('/') ?: ""
+    }
+
+    companion object {
+
+        /**
+         * Where [rawFile] puts its copies — a directory of their own inside the
+         * cache rather than the cache itself, so that dropping them cannot take
+         * anything else with it. The cache also holds the parse cache and the
+         * reader's image files, which are meant to outlive a book being closed,
+         * and the image loader's own store.
+         */
+        private const val COPIES_DIR_NAME = "raw_copies"
+
+        private fun copiesDir(context: Context): File =
+            File(context.cacheDir, COPIES_DIR_NAME)
+
+        /**
+         * Drops every copy [rawFile] has made. Safe to call at app start — a copy
+         * only lives as long as the [CachedFile] that made it, and nothing has made
+         * one yet — which is where the copies of a killed run get collected, since
+         * nothing runs on the way out of one.
+         */
+        fun clearCopies(context: Context) {
+            copiesDir(context).deleteRecursively()
+        }
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/presentation/main/MainActivity.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/main/MainActivity.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.collections.immutable.persistentListOf
 import ua.acclorite.book_story.R
+import ua.acclorite.book_story.data.model.file.CachedFile
 import ua.acclorite.book_story.data.settings.SettingsManager
 import ua.acclorite.book_story.presentation.browse.BrowseModel
 import ua.acclorite.book_story.presentation.browse.BrowseScreen
@@ -180,7 +181,10 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        cacheDir.deleteRecursively()
+        // Only the copies made to hand books to parsers that need a real path, not
+        // the whole cache: the parse cache and the reader's image files live there
+        // too, and they are meant to survive a book being closed.
+        CachedFile.clearCopies(this)
         super.onDestroy()
     }
 }


### PR DESCRIPTION
Closes #22. Bears on #1.

`MainActivity.onDestroy` cleared the whole of `cacheDir`, which is where the parse cache lives —
so backing out of the app threw away every parsed book. Only the impolite exits kept it: swiping
the app off the recents list kills the process and `onDestroy` never runs, which is the path every
measurement of the feature took, hence nobody noticed.

What the line was there for is narrower: `CachedFile.rawFile` copies a book into the cache
whenever something needs a real path rather than a stream — every EPUB parser, since `ZipFile`
cannot read a document URI. Those copies are per instance and nothing else drops them.

So they get `cacheDir/raw_copies` and `onDestroy` drops only that. `Application.onCreate` sweeps
it too, next to the reader images: nothing runs on the way out of a killed run, so its copies
would otherwise sit there until the next polite exit.

## Device QA

Lenovo TB128FU / Android 12, 33.8 MB FB2 with 75 images.

| | Before | After |
|---|---|---|
| Back out of the app | `cacheDir` gone entirely, process still alive | `parsed_books` intact — 1 entry, 351 KB |
| Fresh parse | ~15 s to the image pass | ~15 s |
| Reopen after backing out | ~15 s — cache was wiped | **~1.9 s** |

- Planted a copy in `raw_copies`, backed out: the copy is gone, the parse cache is not.
- Planted a copy, killed the process (`am force-stop`, no `onDestroy`), restarted: the start-up
  sweep took the copy, the parse cache survived.
- Nothing else in the cache is touched, and `rawFile` is only reached by the EPUB parsers, so an
  FB2-only library makes no copies at all.

No tests: `CachedFile` needs a `Context` and a document URI, and the behaviour under test is an
activity callback. `lintDebug` clean.
