### PR TITLE
Time opening a book, in debug builds only

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,13 +45,20 @@ android {
 
     // Build types configuration
     buildTypes {
+        // BOOK_TIMING logs how long opening a book takes, phase by phase, under
+        // the "BookTiming" tag. Off in release; on in release-debug as well as
+        // debug, because release-debug is the variant performance is measured on —
+        // a debug build runs several times slower, so its timings are only ever
+        // comparable with each other.
         getByName("debug") {
             applicationIdSuffix = ".debug"
+            buildConfigField("boolean", "BOOK_TIMING", "true")
         }
 
         getByName("release") {
             isMinifyEnabled = true
             isShrinkResources = false
+            buildConfigField("boolean", "BOOK_TIMING", "false")
 
             proguardFiles("proguard-rules.pro")
         }
@@ -60,6 +67,7 @@ android {
             initWith(getByName("release"))
             applicationIdSuffix = ".release.debug"
             signingConfig = signingConfigs.getByName("debug")
+            buildConfigField("boolean", "BOOK_TIMING", "true")
         }
     }
 

--- a/app/src/main/java/ua/acclorite/book_story/core/log/BookTiming.kt
+++ b/app/src/main/java/ua/acclorite/book_story/core/log/BookTiming.kt
@@ -1,0 +1,50 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.core.log
+
+import ua.acclorite.book_story.BuildConfig
+
+@PublishedApi
+internal const val TAG = "BookTiming"
+
+/**
+ * Whether opening a book is timed into the log — read with
+ * `adb logcat -s BookTiming`.
+ *
+ * On for `debug` and `release-debug`, off for `release`. Deliberately **not**
+ * `BuildConfig.DEBUG`: `release-debug` is a release build type, and it is the
+ * variant worth measuring, since a debug build runs several times slower and its
+ * numbers mean nothing on their own.
+ */
+const val BOOK_TIMING = BuildConfig.BOOK_TIMING
+
+/**
+ * Runs [block], logging how long it took and whatever [describe] says about the
+ * result. Costs nothing when [BOOK_TIMING] is off: no clock is read, and the line
+ * is never built.
+ *
+ * Keep [label] a constant — a interpolated one is built either way.
+ */
+inline fun <T> timed(
+    label: String,
+    crossinline describe: (T) -> String = { "" },
+    block: () -> T
+): T {
+    if (!BOOK_TIMING) return block()
+
+    val start = System.nanoTime()
+    val result = block()
+    val ms = (System.nanoTime() - start) / 1_000_000
+
+    logI(TAG, "$label: $ms ms ${describe(result)}".trimEnd())
+    return result
+}
+
+/** Notes something worth reading next to the timings, e.g. a cache hit. */
+inline fun bookTimingNote(note: () -> String) {
+    if (BOOK_TIMING) logI(TAG, note())
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/model/file/CachedFile.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/model/file/CachedFile.kt
@@ -12,6 +12,7 @@ import android.provider.DocumentsContract
 import androidx.compose.runtime.Immutable
 import com.anggrayudi.storage.file.DocumentFileCompat
 import com.anggrayudi.storage.file.getAbsolutePath
+import ua.acclorite.book_story.core.log.timed
 import java.io.BufferedOutputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -175,10 +176,13 @@ class CachedFile(
      *
      * @return null if the file is directory or failed
      */
-    private fun storeInCache(): File? {
-        if (isDirectory) return null
+    private fun storeInCache(): File? = timed(
+        "    copy book",
+        describe = { file -> "${(file?.length() ?: 0) / 1024} KB" }
+    ) {
+        if (isDirectory) return@timed null
         val dir = copiesDir(context)
-        if (!dir.exists() && !dir.mkdirs()) return null
+        if (!dir.exists() && !dir.mkdirs()) return@timed null
         val cacheFile = File(dir, UUID.randomUUID().toString())
 
         try {
@@ -189,10 +193,10 @@ class CachedFile(
             } ?: throw IllegalStateException("Failed to open InputStream.")
         } catch (e: Exception) {
             e.printStackTrace()
-            return null
+            return@timed null
         }
 
-        return cacheFile
+        cacheFile
     }
 
     private fun getFileQueryParams(): QueryParams {

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
@@ -13,6 +13,7 @@ import org.jsoup.nodes.TextNode
 import org.jsoup.parser.Parser
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
+import ua.acclorite.book_story.core.log.timed
 import ua.acclorite.book_story.data.model.file.CachedFile
 import ua.acclorite.book_story.data.parser.document.DocumentParser
 import androidx.compose.ui.text.AnnotatedString
@@ -61,7 +62,9 @@ class XmlTextParser @Inject constructor(
         return try {
             val notes = mutableMapOf<String, AnnotatedString>()
             val readerText = cachedFile.openInputStream()?.use { stream ->
-                val document = Jsoup.parse(stream, null, "", Parser.xmlParser())
+                val document = timed("    jsoup") {
+                    Jsoup.parse(stream, null, "", Parser.xmlParser())
+                }
 
                 // FB2 stores images as Base64 <binary id="...">, referenced by <image>
                 val base64Images = document.select("binary").associate { binary ->
@@ -93,11 +96,13 @@ class XmlTextParser @Inject constructor(
                     }
                 }
 
-                documentParser.parseDocument(
-                    document = document,
-                    base64Images = base64Images,
-                    keepImageBytes = keepImageBytes
-                )
+                timed("    parseDoc") {
+                    documentParser.parseDocument(
+                        document = document,
+                        base64Images = base64Images,
+                        keepImageBytes = keepImageBytes
+                    )
+                }
             }
 
             yield()

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
 import ua.acclorite.book_story.core.CoverImage
+import ua.acclorite.book_story.core.log.bookTimingNote
+import ua.acclorite.book_story.core.log.timed
 import ua.acclorite.book_story.data.cache.ImageMemoryBudget
 import ua.acclorite.book_story.data.cache.ParseCache
 import ua.acclorite.book_story.data.cache.ReaderImageFiles
@@ -71,36 +73,53 @@ class BookRepositoryImpl @Inject constructor(
                     val maxBytes = capMb.toLong() * 1024 * 1024
                     val cacheImages = settings.cacheImagesInBooks.lastValue
 
-                    val cached = if (cachingEnabled) parseCache.read(
-                        cachedFile.path, cachedFile.size, cachedFile.lastModified
-                    ) else null
+                    timed("getText", describe = { it.describeForTiming() }) {
+                        val cached = if (cachingEnabled) parseCache.read(
+                            cachedFile.path, cachedFile.size, cachedFile.lastModified
+                        ) else null
 
-                    if (cached != null) {
-                        // Hit: the stored text carries image metadata only. Its
-                        // bytes are loaded in the background (see [loadBookImages])
-                        // so the reader can show the text right away; the layout
-                        // is unaffected, image slots are sized from the cached
-                        // width/height.
-                        cached
-                    } else {
-                        // With images off the reader never renders them, so the
-                        // parse keeps their size (the cached text is the same
-                        // either way) but not their bytes — on an image-heavy
-                        // book that is tens of MB held for the whole session.
-                        textParser.parse(
-                            cachedFile,
-                            keepImageBytes = settings.images.lastValue
-                        ).also { fresh ->
-                            // Best-effort caching; skip empty/failed parses.
-                            if (cachingEnabled && fresh.text.isNotEmpty()) {
-                                parseCache.write(
-                                    cachedFile.path,
-                                    cachedFile.size,
-                                    cachedFile.lastModified,
-                                    fresh,
-                                    maxBytes = maxBytes,
-                                    images = if (cacheImages) fresh.collectImageBytes() else null
+                        bookTimingNote {
+                            val state = when {
+                                !cachingEnabled -> "cache off"
+                                cached != null -> "cache HIT"
+                                else -> "cache MISS"
+                            }
+                            "$state — ${cachedFile.name}, ${cachedFile.size / 1024} KB"
+                        }
+
+                        if (cached != null) {
+                            // Hit: the stored text carries image metadata only. Its
+                            // bytes are loaded in the background (see [loadBookImages])
+                            // so the reader can show the text right away; the layout
+                            // is unaffected, image slots are sized from the cached
+                            // width/height.
+                            cached
+                        } else {
+                            // With images off the reader never renders them, so the
+                            // parse keeps their size (the cached text is the same
+                            // either way) but not their bytes — on an image-heavy
+                            // book that is tens of MB held for the whole session.
+                            timed("  parse", describe = { it.describeForTiming() }) {
+                                textParser.parse(
+                                    cachedFile,
+                                    keepImageBytes = settings.images.lastValue
                                 )
+                            }.also { fresh ->
+                                // Best-effort caching; skip empty/failed parses.
+                                if (cachingEnabled && fresh.text.isNotEmpty()) {
+                                    timed("  cache write") {
+                                        parseCache.write(
+                                            cachedFile.path,
+                                            cachedFile.size,
+                                            cachedFile.lastModified,
+                                            fresh,
+                                            maxBytes = maxBytes,
+                                            images = if (cacheImages) {
+                                                fresh.collectImageBytes()
+                                            } else null
+                                        )
+                                    }
+                                }
                             }
                         }
                     }
@@ -199,6 +218,14 @@ class BookRepositoryImpl @Inject constructor(
         withContext(Dispatchers.IO) {
             readerImageFiles.keepOnly(bookId)
         }
+    }
+
+    /** What the timing log says about a parsed book: how much text, how many images. */
+    private fun ParsedText.describeForTiming(): String {
+        val images = text.filterIsInstance<ReaderText.Image>()
+        val chars = text.filterIsInstance<ReaderText.Text>().sumOf { it.line.length }
+        return "chars=$chars images=${images.size} " +
+                "imageBytes=${images.sumOf { it.image.bytes.size } / 1024} KB"
     }
 
     /** Encoded bytes of every image that has them, keyed by src. */


### PR DESCRIPTION
Closes #24.

`timed(label) { ... }` logs a phase under the `BookTiming` tag; `bookTimingNote { ... }` puts a
line next to it, which is where cache hit/miss goes — until now nothing in the log said whether an
open used the cache at all.

Both are inline and gated on a compile-time constant, so a release build reads no clock and builds
no string. The gate is a `BOOK_TIMING` build-config field rather than `BuildConfig.DEBUG`, because
`release-debug` is a *release* build type and it is the variant worth measuring: a debug build runs
several times slower, and its numbers are only ever comparable with each other.

Verified per variant, in the generated `BuildConfig` and in the shipped dex:

| variant | `BOOK_TIMING` | `BookTiming` tag in `classes.dex` |
|---|---|---|
| debug | true | logs (checked on device) |
| release-debug | true | present |
| **release** | **false** | **absent — R8 drops the dead branch**, while other logging stays |

## What it says

A cache miss on the 33.8 MB Touhou FB2, debug build:

```
BookTiming: cache MISS — touhou-…-v1.fb2, 33030 KB
BookTiming:     jsoup: 1924 ms
BookTiming:     parseDoc: 12176 ms
BookTiming:   parse: 14459 ms chars=174028 images=75 imageBytes=24089 KB
BookTiming:   cache write: 38 ms
BookTiming: getText: 14509 ms chars=174028 images=75 imageBytes=24089 KB
```

The same book after backing out of the app and reopening:

```
BookTiming: cache HIT — touhou-…-v1.fb2, 33030 KB
BookTiming: getText: 33 ms chars=174028 images=75 imageBytes=0 KB
```

Two things fall out of that immediately: `parseDoc` is still where the time goes (84 % of the
parse, jsoup is 13 %), and `getText` at 14.5 s against a measured 18.2 s from tap to text on
screen puts ~3.7 s outside it, in navigation, the DB read, state emission and first composition.

No tests: this is logging gated on a build-config constant. `lintDebug` clean.
