### PR TITLE
Keep the author's literal "*" and "_" in the text

### DIFF
--- a/app/src/androidTest/java/ua/acclorite/book_story/data/parser/LiteralMarkdownCharsTest.kt
+++ b/app/src/androidTest/java/ua/acclorite/book_story/data/parser/LiteralMarkdownCharsTest.kt
@@ -1,0 +1,205 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.parser
+
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.commonmark.parser.Parser as CommonmarkParser
+import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import ua.acclorite.book_story.data.parser.document.DocumentParser
+import ua.acclorite.book_story.data.parser.document.MarkdownParser
+import ua.acclorite.book_story.data.parser.text.markChapterTitles
+import ua.acclorite.book_story.domain.model.reader.ReaderText
+
+/**
+ * Punctuation the author typed reaches the reader untouched. The parser used
+ * to encode styling as literal "**"/"_" and then strip every "*"/"_" left in
+ * the text, which deleted the book's own asterisks and underscores along with
+ * its own leftovers — "(*)" came out as "()".
+ */
+@RunWith(AndroidJUnit4::class)
+class LiteralMarkdownCharsTest {
+
+    // The default builder enables every block type, while the app narrows them
+    // (see AppModule): a stricter parser than production, on purpose.
+    private val documentParser = DocumentParser(
+        MarkdownParser(CommonmarkParser.builder().build())
+    )
+
+    @Test
+    fun loneAsteriskSurvives() {
+        // The footnote convention of the Touhou book that surfaced this
+        assertEquals(
+            "(*): Этим летом алый туман покрыл всё Генсокё.",
+            text("<p>(*): Этим летом алый туман покрыл всё Генсокё.</p>").single()
+        )
+    }
+
+    @Test
+    fun numberedAsteriskReferenceSurvives() {
+        assertEquals(
+            "С момента инцидента (*1), произошедшего в прошлом месяце.",
+            text("<p>С момента инцидента (*1), произошедшего в прошлом месяце.</p>").single()
+        )
+    }
+
+    @Test
+    fun underscoresInAUrlSurvive() {
+        val url = "https://ru.touhouwiki.net/wiki/Bohemian_Archive_in_Japanese_Red"
+        assertEquals("Перевод взят с $url", text("<p>Перевод взят с $url</p>").single())
+    }
+
+    @Test
+    fun underscoresInACyrillicUrlSurvive() {
+        val url = "https://ru.touhouwiki.net/wiki/Bohemian_Archive_in_Japanese_Red/" +
+                "Музыкальная_рубрика#Вступление"
+        assertEquals("Читайте на $url.", text("<p>Читайте на $url.</p>").single())
+    }
+
+    @Test
+    fun twoAsterisksOnOneLineSurvive() {
+        assertEquals(
+            "Сноски (*1) и (*2) в одном абзаце.",
+            text("<p>Сноски (*1) и (*2) в одном абзаце.</p>").single()
+        )
+    }
+
+    @Test
+    fun twoNumberedReferencesDoNotPairIntoEmphasis() {
+        // The shape the book actually uses twice in one paragraph: a closing
+        // "*" followed by a digit is not right-flanking, so CommonMark leaves
+        // both alone
+        val paragraph = paragraphs(
+            "<p>Названа (*1) служба. (*1): Муси но Сё.</p>"
+        ).single()
+
+        assertEquals("Названа (*1) служба. (*1): Муси но Сё.", paragraph.line.text)
+        assertTrue("nothing was emphasised", paragraph.line.spanStyles.isEmpty())
+    }
+
+    @Test
+    fun asterisksSurviveNextToAnEmphasisRun() {
+        val paragraph = paragraphs(
+            "<p>Смотри (*) і <emphasis>ось це</emphasis> теж.</p>"
+        ).single()
+
+        assertEquals("Смотри (*) і ось це теж.", paragraph.line.text)
+        assertTrue(
+            "the emphasis still styles only its own run",
+            paragraph.line.spanStyles.any { span ->
+                span.item.fontStyle == FontStyle.Italic &&
+                        paragraph.line.text.substring(span.start, span.end) == "ось це"
+            }
+        )
+    }
+
+    @Test
+    fun boldIsStyledWithoutLeakingAsterisks() {
+        val paragraph = paragraphs("<p>Це <strong>жирний</strong> текст.</p>").single()
+
+        assertEquals("Це жирний текст.", paragraph.line.text)
+        assertTrue(
+            "bold span",
+            paragraph.line.spanStyles.any { span ->
+                span.item.fontWeight == FontWeight.Medium &&
+                        paragraph.line.text.substring(span.start, span.end) == "жирний"
+            }
+        )
+    }
+
+    @Test
+    fun boldSurvivesAnAdjacentLiteralAsterisk() {
+        // The old "**" injection sat right against the author's asterisk, and
+        // the cleanup then swallowed the author's one along with its own
+        val paragraph = paragraphs("<p>(*)<strong>жирний</strong> текст.</p>").single()
+
+        assertEquals("(*)жирний текст.", paragraph.line.text)
+        assertTrue(
+            "bold span",
+            paragraph.line.spanStyles.any { span ->
+                span.item.fontWeight == FontWeight.Medium &&
+                        paragraph.line.text.substring(span.start, span.end) == "жирний"
+            }
+        )
+    }
+
+    @Test
+    fun paddedEmphasisTagKeepsItsSpaces() {
+        // "** жирний **" was never valid markdown, hence the normalize regexes;
+        // a sentinel is a toggle, so the padding is simply part of the run
+        val paragraph = paragraphs("<p>Це <strong> жирний </strong>текст.</p>").single()
+
+        assertEquals("Це  жирний текст.", paragraph.line.text)
+    }
+
+    @Test
+    fun sentinelsCarriedByTheBookAreDropped() {
+        // A book of its own may use the private-use area (Apple's logo, legacy
+        // CJK fonts): those characters must not toggle our styles
+        val paragraph = paragraphs(
+            "<p>Текст\uE018з\uE019приватної\uE011зони.</p>"
+        ).single()
+
+        assertEquals("Текстзприватноїзони.", paragraph.line.text)
+        assertTrue("no styling leaked", paragraph.line.spanStyles.isEmpty())
+    }
+
+    @Test
+    fun knownLimit_authorsValidMarkdownIsStillConsumed() {
+        // Two bare "(*)" in one paragraph are a valid emphasis pair by
+        // CommonMark's flanking rules, so the asterisks are eaten and the
+        // text between them turns italic. Inherent to running the markdown
+        // parser over prose at all — see #29, which removes that step.
+        val paragraph = paragraphs("<p>Смотри (*) і теж (*).</p>").single()
+
+        assertEquals("Смотри () і теж ().", paragraph.line.text)
+    }
+
+    @Test
+    fun sceneBreakIsStillKeptVisible() {
+        // The separator branch predates this fix; make sure it still holds
+        assertEquals("* * *", text("<p>* * *</p>").single())
+    }
+
+    @Test
+    fun asterisksInAChapterTitleSurvive() {
+        val chapter = parse("<section><title><p>Глава (*) перша</p></title><p>Текст.</p></section>")
+            .filterIsInstance<ReaderText.Chapter>()
+            .single()
+
+        assertEquals("Глава (*) перша", chapter.title)
+    }
+
+    // --- helpers ---
+
+    private fun text(body: String): List<String> =
+        paragraphs(body).map { paragraph -> paragraph.line.text }
+
+    private fun paragraphs(body: String): List<ReaderText.Text> =
+        // A <title> keeps the body text from being taken as the chapter title
+        parse("<section><title><p>Розділ</p></title>$body</section>")
+            .filterIsInstance<ReaderText.Text>()
+
+    /** Runs the FB2 body through the same two steps as [XmlTextParser]. */
+    private fun parse(body: String): List<ReaderText> = runBlocking {
+        val document = Jsoup.parse(
+            """<FictionBook><body>$body</body></FictionBook>""",
+            "",
+            Parser.xmlParser()
+        )
+        document.markChapterTitles()
+        documentParser.parseDocument(document)
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/cache/ParseCache.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/cache/ParseCache.kt
@@ -254,6 +254,7 @@ class ParseCache @Inject constructor(application: Application) {
          * stale entries are ignored instead of rendering outdated text.
          */
         // 4: tables carry per-column alignment (ParsedTextCodec format 3).
-        const val VERSION = 4
+        // 5: literal "*"/"_" of the book's text are no longer stripped.
+        const val VERSION = 5
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -20,8 +20,6 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.Node
 import org.jsoup.nodes.TextNode
-import ua.acclorite.book_story.core.helpers.clearAllMarkdown
-import ua.acclorite.book_story.core.helpers.clearMarkdown
 import ua.acclorite.book_story.core.helpers.containsVisibleText
 import ua.acclorite.book_story.domain.model.reader.NOTE_LINK_TAG_PREFIX
 import ua.acclorite.book_story.domain.model.reader.ReaderImage
@@ -51,6 +49,22 @@ const val TITLE_ROLE_MARKER = "[[[role-title]]]"
 const val EPIGRAPH_ROLE_MARKER = "[[[role-epigraph]]]"
 const val AUTHOR_ROLE_MARKER = "[[[role-author]]]"
 
+/*
+ * Inline styling travels from the DOM to [MarkdownParser] as private-use
+ * sentinels rather than as markdown "**"/"_".
+ *
+ * The DOM is flattened into one flat string here, so a style has to be encoded
+ * into the characters of that string — and markdown's delimiters are ordinary
+ * punctuation an author may well have typed. Once ours and theirs are mixed no
+ * later pass can tell them apart, which is how "(*)" used to render as "()".
+ * The private-use area is reserved by Unicode for exactly this kind of private
+ * agreement, so a sentinel cannot collide with the book's own text.
+ *
+ * Sentinels are also stronger than delimiters: [MarkdownParser] treats each as
+ * a toggle, so they compose freely, ignore CommonMark's flanking rules — which
+ * is what makes intra-word emphasis work — and need no balancing.
+ */
+
 /**
  * Private-use sentinel wrapping FB2 <strikethrough> content. [MarkdownParser]
  * turns the enclosed text into a real strike-through span, which — unlike a
@@ -71,15 +85,13 @@ const val SUPERSCRIPT_MARK = "\uE013"
  * turns the enclosed text into an italic span. Unlike a markdown `_`, the mark
  * also styles intra-word emphasis: CommonMark disables `_` emphasis inside a
  * word, so a single stressed letter \u2014 \u00AB\u0431_\u043E_\u043B\u044C\u0448\u0438\u043D\u0441\u0442\u0432\u043E\u00BB \u2014 would otherwise be
- * dropped (clearMarkdown() strips the underscores, leaving plain text).
+ * dropped, leaving plain text.
  */
 const val ITALIC_MARK = "\uE018"
 
 /**
- * Private-use sentinel wrapping a flattened <title> (of an FB2 <poem>/
- * <epigraph>/<cite>). A mark rather than "**", because the title keeps its own
- * inline markup, which may itself carry "**" from a <strong>: nested asterisks
- * would fuse into one malformed emphasis run.
+ * Private-use sentinel for bold: <b>/<strong>/<h1..h3> and a flattened <title>
+ * (of an FB2 <poem>/<epigraph>/<cite>).
  */
 const val BOLD_MARK = "\uE019"
 
@@ -96,6 +108,28 @@ const val ANCHOR_REF_MARK = "\uE017"
 const val REF_SEPARATOR = "\uE015"
 const val REF_END_MARK = "\uE016"
 
+/** Every inline styling sentinel, as a character class. */
+private val INLINE_MARKS_REGEX = Regex(
+    "[$STRIKETHROUGH_MARK$SUBSCRIPT_MARK$SUPERSCRIPT_MARK$ITALIC_MARK$BOLD_MARK]"
+)
+
+/** A whole reference run: "<mark><hex id><separator><display text><end>". */
+private val REFERENCE_RUN_REGEX = Regex(
+    "[$NOTE_REF_MARK$ANCHOR_REF_MARK][^$REF_SEPARATOR$REF_END_MARK]*" +
+            "$REF_SEPARATOR([^$REF_END_MARK]*)$REF_END_MARK"
+)
+
+/**
+ * Drops the inline sentinels, keeping the text they wrap \u2014 for the places that
+ * need plain text instead of a styled [AnnotatedString]. Unlike
+ * [ua.acclorite.book_story.core.helpers.clearMarkdown] it touches only the
+ * marks this parser injected, so the author's own asterisks and underscores
+ * survive.
+ */
+internal fun String.clearInlineMarks(): String =
+    replace(REFERENCE_RUN_REGEX) { match -> match.groupValues[1] }
+        .replace(INLINE_MARKS_REGEX, "")
+
 /** A GFM table delimiter row, e.g. "| --- | :--: |". */
 private val TABLE_DELIMITER_REGEX =
     Regex("""^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)*\|?\s*$""")
@@ -103,9 +137,6 @@ private val TABLE_DELIMITER_REGEX =
 // Compiled once — all of these run in the per-line hot loop over the whole book
 // (parseDocument), so per-line Regex() compilation added up to a large share of
 // parse time. Kept at file scope like TABLE_DELIMITER_REGEX above.
-private val BOLD_ITALIC_NORMALIZE_REGEX = Regex("""\*\*\*\s*(.*?)\s*\*\*\*""")
-private val BOLD_NORMALIZE_REGEX = Regex("""\*\*\s*(.*?)\s*\*\*""")
-private val ITALIC_NORMALIZE_REGEX = Regex("""_\s*(.*?)\s*_""")
 private val IMAGE_LINE_REGEX = Regex("""\[\[(.*?)\|(.*?)]]""")
 private val CHAPTER_LINE_REGEX = Regex("""\[\[\[chapter\|(\d+)\|(.*)]]]""")
 private val TABLE_LINE_REGEX = Regex("""\[\[\[table\|(\d+)]]]""")
@@ -297,11 +328,14 @@ class DocumentParser @Inject constructor(
 
                 // Markdown
                 select("hr").append("\n$SEPARATOR_MARKER\n")
-                select("b").append("**").prepend("**")
-                select("h1").append("**").prepend("**")
-                select("h2").append("**").prepend("**")
-                select("h3").append("**").prepend("**")
-                select("strong").append("**").prepend("**")
+                // Bold/italic go in as sentinels, never as "**"/"_": a literal
+                // asterisk or underscore of the author's would be
+                // indistinguishable from one of ours (see BOLD_MARK).
+                select("b").append(BOLD_MARK).prepend(BOLD_MARK)
+                select("h1").append(BOLD_MARK).prepend(BOLD_MARK)
+                select("h2").append(BOLD_MARK).prepend(BOLD_MARK)
+                select("h3").append(BOLD_MARK).prepend(BOLD_MARK)
+                select("strong").append(BOLD_MARK).prepend(BOLD_MARK)
                 select("em").prepend(ITALIC_MARK).append(ITALIC_MARK)
 
                 // FB2 inline: <emphasis> is the italic tag (FB2 has no <em>).
@@ -320,7 +354,8 @@ class DocumentParser @Inject constructor(
                     if (text.matches(SEPARATOR_TEXT_REGEX)) {
                         subtitle.replaceWith(TextNode("\n$text\n"))
                     } else {
-                        subtitle.prepend("\n_**").append("**_\n") // bold + italic
+                        subtitle.prepend("\n$ITALIC_MARK$BOLD_MARK") // bold + italic
+                            .append("$BOLD_MARK$ITALIC_MARK\n")
                     }
                 }
                 select("poem").prepend("\n$POEM_BEGIN_MARKER\n").append("\n$POEM_END_MARKER\n")
@@ -334,15 +369,16 @@ class DocumentParser @Inject constructor(
                     }
                 }
                 select("v").append("\n") // verse line
-                select("text-author").prepend("\n${AUTHOR_ROLE_MARKER}_").append("_\n")
+                select("text-author")
+                    .prepend("\n$AUTHOR_ROLE_MARKER$ITALIC_MARK").append("$ITALIC_MARK\n")
 
                 // FB2 <epigraph>/<cite> are conventionally set in italic. The "\n"
                 // that the loop above appended to each <p> is its last child, so the
-                // closing underscore is inserted just before it, not after.
+                // closing mark is inserted just before it, not after.
                 select("epigraph > p, cite > p").forEach { paragraph ->
-                    paragraph.prepend("_")
+                    paragraph.prepend(ITALIC_MARK)
                     paragraph.childNode(paragraph.childNodeSize() - 1)
-                        .before(TextNode("_"))
+                        .before(TextNode(ITALIC_MARK))
                 }
                 // Prepended after the italic wrapping, so the marker ends up
                 // first on the line
@@ -406,7 +442,7 @@ class DocumentParser @Inject constructor(
                         } ?: return@forEach
 
                     val alt = element.attr("alt").trim().takeIf {
-                        it.clearMarkdown().containsVisibleText()
+                        it.containsVisibleText()
                     } ?: ""
 
                     imageJobs.getOrPut(src) {
@@ -486,16 +522,11 @@ class DocumentParser @Inject constructor(
             .forEach { line ->
                 yield()
 
-                val formattedLine = line.replace(
-                    // Tabs are not rendered and would glue the surrounding words together
-                    "\t", " "
-                ).replace(
-                    BOLD_ITALIC_NORMALIZE_REGEX, "_**$1**_"
-                ).replace(
-                    BOLD_NORMALIZE_REGEX, "**$1**"
-                ).replace(
-                    ITALIC_NORMALIZE_REGEX, "_$1_"
-                ).trim()
+                // Tabs are not rendered and would glue the surrounding words
+                // together. Nothing else is rewritten: all emphasis this parser
+                // adds is carried by sentinels, so any "*"/"_" left on the line
+                // is the author's own text and must reach the reader intact.
+                val formattedLine = line.replace("\t", " ").trim()
 
                 // Role marker prefix (from FB2 <title>/<epigraph>/<text-author>)
                 val (role, styledLine) = when {
@@ -588,9 +619,13 @@ class DocumentParser @Inject constructor(
                                 ReaderText.Image(
                                     image = image,
                                     caption = alt.takeIf { caption ->
-                                        caption.clearMarkdown().containsVisibleText()
+                                        caption.containsVisibleText()
                                     }?.let { caption -> // Alternative text (caption) for image
-                                        ReaderText.Text(markdownParser.parse("_${caption}_"))
+                                        ReaderText.Text(
+                                            markdownParser.parse(
+                                                "$ITALIC_MARK$caption$ITALIC_MARK"
+                                            )
+                                        )
                                     }
                                 )
                             )
@@ -599,8 +634,7 @@ class DocumentParser @Inject constructor(
                         // A line of separator characters ("* * *", "---") is the
                         // author's literal scene-break text, kept visible as-is.
                         // Without this branch markdownParser.parse() would swallow
-                        // it as a thematic break, and the clearMarkdown() gate
-                        // below would drop the line entirely.
+                        // it as a thematic break and drop the line entirely.
                         separatorRegex.matches(formattedLine) -> {
                             readerText.add(
                                 ReaderText.Text(
@@ -610,20 +644,24 @@ class DocumentParser @Inject constructor(
                         }
 
                         else -> {
+                            // Plain text of the line: only the sentinels go,
+                            // so punctuation the author wrote survives both the
+                            // visibility gate and the chapter list.
+                            val plainLine = styledLine.clearInlineMarks()
                             if (
                                 !chapterAdded &&
                                 poemLines == null &&
-                                styledLine.clearAllMarkdown().containsVisibleText() &&
+                                plainLine.containsVisibleText() &&
                                 includeChapter
                             ) {
                                 readerText.add(
                                     0, ReaderText.Chapter(
-                                        title = styledLine.clearAllMarkdown()
+                                        title = plainLine.trim()
                                     )
                                 )
                                 chapterAdded = true
                             } else if (
-                                styledLine.clearMarkdown().containsVisibleText()
+                                plainLine.containsVisibleText()
                             ) {
                                 val text = ReaderText.Text(
                                     line = markdownParser.parse(styledLine),
@@ -658,7 +696,7 @@ class DocumentParser @Inject constructor(
         val clone = section.clone()
         clone.select("title").remove()
 
-        clone.select("strong, b").prepend("**").append("**")
+        clone.select("strong, b").prepend(BOLD_MARK).append(BOLD_MARK)
         clone.select("emphasis, em").prepend(ITALIC_MARK).append(ITALIC_MARK)
         clone.select("strikethrough").prepend(STRIKETHROUGH_MARK).append(STRIKETHROUGH_MARK)
         clone.select("sub").prepend(SUBSCRIPT_MARK).append(SUBSCRIPT_MARK)

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -58,7 +58,8 @@ const val AUTHOR_ROLE_MARKER = "[[[role-author]]]"
  * punctuation an author may well have typed. Once ours and theirs are mixed no
  * later pass can tell them apart, which is how "(*)" used to render as "()".
  * The private-use area is reserved by Unicode for exactly this kind of private
- * agreement, so a sentinel cannot collide with the book's own text.
+ * agreement, so a sentinel cannot collide with the book's own text (whatever
+ * the book itself brings in is dropped by [stripInlineMarks] on the way in).
  *
  * Sentinels are also stronger than delimiters: [MarkdownParser] treats each as
  * a toggle, so they compose freely, ignore CommonMark's flanking rules — which
@@ -107,6 +108,36 @@ const val NOTE_REF_MARK = "\uE014"
 const val ANCHOR_REF_MARK = "\uE017"
 const val REF_SEPARATOR = "\uE015"
 const val REF_END_MARK = "\uE016"
+
+/**
+ * The private-use block every sentinel above lives in. A new mark only has to
+ * stay inside this range for [stripInlineMarks] to keep covering it.
+ */
+private val MARK_RANGE = '\uE011'..'\uE019'
+
+/**
+ * Drops the sentinel characters the string itself carries, so nothing in the
+ * book can be mistaken for a mark this parser injected. Unicode reserves the
+ * private-use area for private agreement — but someone else may have made one:
+ * Apple's logo sits at U+F8FF and legacy CJK fonts use the area too.
+ */
+private fun String.stripInlineMarks(): String =
+    if (none { char -> char in MARK_RANGE }) this
+    else filterNot { char -> char in MARK_RANGE }
+
+/** Applies [stripInlineMarks] to every text node of the subtree. */
+private fun Node.stripInlineMarks() {
+    childNodes().forEach { child ->
+        if (child !is TextNode) {
+            child.stripInlineMarks()
+            return@forEach
+        }
+
+        val text = child.wholeText
+        val stripped = text.stripInlineMarks()
+        if (stripped !== text) child.text(stripped)
+    }
+}
 
 /** Every inline styling sentinel, as a character class. */
 private val INLINE_MARKS_REGEX = Regex(
@@ -291,6 +322,10 @@ class DocumentParser @Inject constructor(
         document.selectFirst("body")
             .run { this ?: document.body() }
             .apply {
+                // Before anything is injected: the book's own text must not be
+                // able to pass itself off as one of our sentinels
+                stripInlineMarks()
+
                 // Remove manual line breaks from all <p>, <a>. Setting .html()
                 // re-parses the fragment, so skip it when there is no newline —
                 // most paragraphs in a non-pretty-printed file have none.
@@ -441,7 +476,8 @@ class DocumentParser @Inject constructor(
                             } == true
                         } ?: return@forEach
 
-                    val alt = element.attr("alt").trim().takeIf {
+                    // An attribute is not a text node, so it needs its own pass
+                    val alt = element.attr("alt").trim().stripInlineMarks().takeIf {
                         it.containsVisibleText()
                     } ?: ""
 
@@ -695,6 +731,7 @@ class DocumentParser @Inject constructor(
     fun parseNote(section: org.jsoup.nodes.Element): AnnotatedString {
         val clone = section.clone()
         clone.select("title").remove()
+        clone.stripInlineMarks()
 
         clone.select("strong, b").prepend(BOLD_MARK).append(BOLD_MARK)
         clone.select("emphasis, em").prepend(ITALIC_MARK).append(ITALIC_MARK)

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/MarkdownParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/MarkdownParser.kt
@@ -27,7 +27,6 @@ import org.commonmark.node.Node
 import org.commonmark.node.StrongEmphasis
 import org.commonmark.node.Text
 import org.commonmark.parser.Parser
-import ua.acclorite.book_story.core.helpers.clearMarkdown
 import ua.acclorite.book_story.domain.model.reader.ANCHOR_LINK_TAG_PREFIX
 import ua.acclorite.book_story.domain.model.reader.NOTE_LINK_TAG_PREFIX
 import javax.inject.Inject
@@ -117,7 +116,10 @@ class MarkdownParser @Inject constructor(
             }
 
             is Text -> {
-                scanner.append(node.literal.clearMarkdown())
+                // Appended verbatim: commonmark has already consumed every
+                // "*"/"_" that was real markup, so whatever is left is the
+                // author's own punctuation — "(*)" must not become "()".
+                scanner.append(node.literal)
                 parseChildren(node, scanner)
             }
 
@@ -204,10 +206,10 @@ private class MarkScanner(private val builder: AnnotatedString.Builder) {
         } catch (e: Exception) {
             refId.toString()
         }
-        // The reference text may carry inline markers (e.g. a note number
-        // wrapped in <strong> becomes "**[3]**"); strip them so no literal
-        // asterisks/underscores show in the tiny marker.
-        val text = refText.toString().clearMarkdown()
+        // The reference text may carry inline sentinels (e.g. a note number
+        // wrapped in <strong>); the run is appended as one plain span, so
+        // strip them rather than let private-use characters reach the marker.
+        val text = refText.toString().clearInlineMarks()
         if (text.isBlank()) return
 
         val (tag, style) = if (mark == NOTE_REF_CHAR) {


### PR DESCRIPTION
Closes #28.

`MarkdownParser` ran `clearMarkdown()` — a blunt `Regex("(_+)|(\\*+)") -> ""` — on every commonmark `Text` literal. By that point commonmark has already consumed everything that *was* markup, so what it deleted was the author's own punctuation: `(*)` rendered as `()`, `(*1)` as `(1)`, and a URL with underscores in its path lost them.

The cleanup existed because `parseDocument` injected styling as literal `**`/`_`, which does not always come out as valid markdown — without it the reader would show bare asterisks. So the defect was the transport: styling encoded with characters that legitimately occur in prose. Fourth bug of this class after 377e62bf, 1d3c50d4 and 36be9ea6; this one removes the mechanism instead of the symptom.

## Changes

- **`2adcf213`** — the last `**`/`_` injections (`<b>`, `<strong>`, `<h1..h3>`, `<subtitle>`, `<epigraph>`, `<cite>`, `<text-author>`, image captions, `parseNote`) move onto the private-use sentinels the parser already used for italic, strikethrough and sub/superscript; `clearMarkdown()` goes from the `is Text` branch. A sentinel is a toggle rather than a delimiter, so it needs no whitespace normalising either — the three `*_NORMALIZE_REGEX` go with it (they only ever ran in `parseDocument`, tidying our own injections; `.txt`/`.md`/`.pdf` never reach it), which also takes three regexes out of the per-line hot loop. New `clearInlineMarks()` for the call sites that want plain text; unlike `clearMarkdown()` it strips only what the parser injected, and it closes a leak where a reference's hex id could reach a chapter title. `ParseCache.VERSION` 4 -> 5.
- **`4281a359`** — strips `U+E011..U+E019` from the book's own text (and from an `<img alt>`) on the way in. The private-use area is reserved for private agreement, but someone else may have made one — Apple's logo sits at U+F8FF and legacy CJK fonts use the area too. Makes "a sentinel cannot collide with the book's text" true by construction rather than by luck.
- **`fc66d5b3`** — 14 tests in `LiteralMarkdownCharsTest`.

## Testing

`connectedDebugAndroidTest` on the Lenovo TB128FU: **128 tests, 0 failures**, 14 of them new. `lintDebug` clean.

The CommonMark half of the expectations was verified separately by running commonmark 0.26 directly over the cases, rather than reasoning about the flanking rules — which caught one wrong assertion of mine (see below).

Checked against a real 1704-paragraph FB2: 46 paragraphs carry more than one asterisk, 40 of those are `* * *` scene breaks (handled by their own branch), the rest are deliberate emphasis and `(*1)…(*1)` pairs, which do not pair up. Every paragraph with underscores was a URL with intra-word `_`, which CommonMark leaves alone.

## Known limit, pinned as a test

Two bare `(*)` in one paragraph *are* a valid emphasis pair under CommonMark's flanking rules — both delimiters sit between punctuation, so both can open and close, and the rule of three does not block them. The asterisks are consumed and the text between them turns italic. `knownLimit_authorsValidMarkdownIsStillConsumed` pins that so it stays visible.

Fixing it means not running a markdown parser over prose at all, which is #29. It does not occur in the book this came from.

