### PR TITLE
Italicise <i>, strike out <s>/<del>/<strike>

### DIFF
--- a/app/src/androidTest/java/ua/acclorite/book_story/data/parser/HtmlInlineTagsTest.kt
+++ b/app/src/androidTest/java/ua/acclorite/book_story/data/parser/HtmlInlineTagsTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.parser
+
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.commonmark.parser.Parser as CommonmarkParser
+import org.jsoup.Jsoup
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import ua.acclorite.book_story.data.parser.document.DocumentParser
+import ua.acclorite.book_story.data.parser.document.MarkdownParser
+import ua.acclorite.book_story.domain.model.reader.ReaderText
+
+/**
+ * Inline styling tags of the HTML/EPUB path. `<i>` used to be ignored — the
+ * parser only knew `<em>` and FB2's `<emphasis>` — so an EPUB converted from
+ * print lost nearly all of its italics.
+ */
+@RunWith(AndroidJUnit4::class)
+class HtmlInlineTagsTest {
+
+    private val documentParser = DocumentParser(
+        MarkdownParser(CommonmarkParser.builder().build())
+    )
+
+    @Test
+    fun iIsItalicised() {
+        // The shape a print-converted EPUB uses: <i> around a single stressed
+        // word, with the trailing space kept inside the tag
+        val paragraph = paragraphs(
+            """<p>Він мовив: "це <i>твоя </i>справа", з наголосом на другому слові.</p>"""
+        ).single()
+
+        assertEquals(
+            """Він мовив: "це твоя справа", з наголосом на другому слові.""",
+            paragraph.line.text
+        )
+        assertItalic(paragraph, "твоя ")
+    }
+
+    @Test
+    fun emIsStillItalicised() {
+        val paragraph = paragraphs("<p>Це <em>значно</em>-краще рішення.</p>").single()
+
+        assertEquals("Це значно-краще рішення.", paragraph.line.text)
+        assertItalic(paragraph, "значно")
+    }
+
+    @Test
+    fun italicWorksInsideAWord() {
+        // No CommonMark flanking rules stand in the way of a sentinel
+        val paragraph = paragraphs("<p>б<i>о</i>льшинство</p>").single()
+
+        assertEquals("большинство", paragraph.line.text)
+        assertItalic(paragraph, "о")
+    }
+
+    @Test
+    fun htmlStrikethroughTagsAreStruckOut() {
+        listOf("s", "del", "strike").forEach { tag ->
+            val paragraph = paragraphs("<p>Було <$tag>сто</$tag> двісті.</p>").single()
+
+            assertEquals("<$tag> text", "Було сто двісті.", paragraph.line.text)
+            assertTrue(
+                "<$tag> is struck through",
+                paragraph.line.spanStyles.any { span ->
+                    span.item.textDecoration == TextDecoration.LineThrough &&
+                            paragraph.line.text.substring(span.start, span.end) == "сто"
+                }
+            )
+        }
+    }
+
+    @Test
+    fun italicAndBoldCompose() {
+        val paragraph = paragraphs("<p>Це <b><i>обидва</i></b> разом.</p>").single()
+
+        assertEquals("Це обидва разом.", paragraph.line.text)
+        assertItalic(paragraph, "обидва")
+        assertTrue(
+            "bold span",
+            paragraph.line.spanStyles.any { span ->
+                span.item.fontWeight == FontWeight.Medium &&
+                        paragraph.line.text.substring(span.start, span.end) == "обидва"
+            }
+        )
+    }
+
+    // --- helpers ---
+
+    private fun assertItalic(paragraph: ReaderText.Text, run: String) {
+        assertTrue(
+            "italic span over \"$run\"",
+            paragraph.line.spanStyles.any { span ->
+                span.item.fontStyle == FontStyle.Italic &&
+                        paragraph.line.text.substring(span.start, span.end) == run
+            }
+        )
+    }
+
+    /** The first line becomes the chapter title, so the body starts at the second. */
+    private fun paragraphs(body: String): List<ReaderText.Text> = runBlocking {
+        documentParser
+            .parseDocument(Jsoup.parse("<html><body><p>Розділ</p>$body</body></html>"))
+            .filterIsInstance<ReaderText.Text>()
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/cache/ParseCache.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/cache/ParseCache.kt
@@ -255,6 +255,7 @@ class ParseCache @Inject constructor(application: Application) {
          */
         // 4: tables carry per-column alignment (ParsedTextCodec format 3).
         // 5: literal "*"/"_" of the book's text are no longer stripped.
-        const val VERSION = 5
+        // 6: <i> is italicised, <s>/<del>/<strike> struck through.
+        const val VERSION = 6
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -371,7 +371,11 @@ class DocumentParser @Inject constructor(
                 select("h2").append(BOLD_MARK).prepend(BOLD_MARK)
                 select("h3").append(BOLD_MARK).prepend(BOLD_MARK)
                 select("strong").append(BOLD_MARK).prepend(BOLD_MARK)
-                select("em").prepend(ITALIC_MARK).append(ITALIC_MARK)
+                // <i> as well as <em>: EPUBs converted from print use it for
+                // most of their italics, and the distinction between semantic
+                // emphasis and typographic italic is one this renderer cannot
+                // act on anyway.
+                select("em, i").prepend(ITALIC_MARK).append(ITALIC_MARK)
 
                 // FB2 inline: <emphasis> is the italic tag (FB2 has no <em>).
                 // Wrapped in a sentinel rather than "_": a mark styles intra-word
@@ -423,8 +427,10 @@ class DocumentParser @Inject constructor(
 
                 // FB2 inline: <code> as a monospace backtick code span
                 select("code").prepend("`").append("`")
-                // <strikethrough> wrapped in a sentinel, styled by MarkdownParser
-                select("strikethrough").prepend(STRIKETHROUGH_MARK).append(STRIKETHROUGH_MARK)
+                // <strikethrough> wrapped in a sentinel, styled by MarkdownParser.
+                // FB2 spells it out; HTML/EPUB use <s>, <del> or the old <strike>.
+                select("strikethrough, s, del, strike")
+                    .prepend(STRIKETHROUGH_MARK).append(STRIKETHROUGH_MARK)
                 // <sub>/<sup> wrapped in sentinels, styled by MarkdownParser
                 select("sub").prepend(SUBSCRIPT_MARK).append(SUBSCRIPT_MARK)
                 select("sup").prepend(SUPERSCRIPT_MARK).append(SUPERSCRIPT_MARK)
@@ -734,8 +740,9 @@ class DocumentParser @Inject constructor(
         clone.stripInlineMarks()
 
         clone.select("strong, b").prepend(BOLD_MARK).append(BOLD_MARK)
-        clone.select("emphasis, em").prepend(ITALIC_MARK).append(ITALIC_MARK)
-        clone.select("strikethrough").prepend(STRIKETHROUGH_MARK).append(STRIKETHROUGH_MARK)
+        clone.select("emphasis, em, i").prepend(ITALIC_MARK).append(ITALIC_MARK)
+        clone.select("strikethrough, s, del, strike")
+            .prepend(STRIKETHROUGH_MARK).append(STRIKETHROUGH_MARK)
         clone.select("sub").prepend(SUBSCRIPT_MARK).append(SUBSCRIPT_MARK)
         clone.select("sup").prepend(SUPERSCRIPT_MARK).append(SUPERSCRIPT_MARK)
         clone.select("p").forEach { paragraph ->


### PR DESCRIPTION
Closes #31.

`parseDocument` knew `<em>` and FB2's `<emphasis>` but not `<i>`, so an EPUB converted from print lost nearly all of its italics. Same gap on the other side: `<strikethrough>` is FB2's spelling, while HTML and EPUB use `<s>`, `<del>` or the old `<strike>`.

Both reuse marks that already exist, so this only widens two selectors — in `parseDocument` and in `parseNote`. `ParseCache.VERSION` 5 -> 6.

## Testing

`connectedDebugAndroidTest` on the Lenovo TB128FU: **133 tests, 0 failures**, 5 new in `HtmlInlineTagsTest` (`<i>`, `<em>`, intra-word italic, the three strikethrough spellings, italic+bold composing).

Device QA on a test EPUB carrying 339 `<i>` tags. Before: a full page of prose with no italics at all. After: every `<i>` run on screen renders italic, each one checked against the source markup — section numbers, a repeated word set in italic for emphasis, and a stressed verb mid-sentence. Cache MISS on first open re-parsed in 2050 ms, as expected from the version bump.

## Not included

`<u>`: it needs a new sentinel *and* `TextDecoration.Underline`, which is how the reader draws links — an underlined word would read as tappable. Wants a decision on its own.
