### PR TITLE
Keep a chapter that holds only an image

### DIFF
--- a/app/src/androidTest/java/ua/acclorite/book_story/data/parser/EmptyDocumentGuardTest.kt
+++ b/app/src/androidTest/java/ua/acclorite/book_story/data/parser/EmptyDocumentGuardTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.parser
+
+import android.app.Application
+import android.util.Base64
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.commonmark.parser.Parser as CommonmarkParser
+import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import ua.acclorite.book_story.data.parser.document.DocumentParser
+import ua.acclorite.book_story.data.parser.document.MarkdownParser
+import ua.acclorite.book_story.domain.model.reader.ReaderText
+import java.io.File
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+
+/**
+ * The guard that decides whether a parsed document is empty. It used to ask
+ * whether the document had any *text*, which is not the same question: a page
+ * holding only an image — the shape of every Calibre-made cover — was thrown
+ * away with its image.
+ */
+@RunWith(AndroidJUnit4::class)
+class EmptyDocumentGuardTest {
+
+    private val documentParser = DocumentParser(
+        MarkdownParser(CommonmarkParser.builder().build())
+    )
+
+    /** A 3x2 PNG. */
+    private val png = "iVBORw0KGgoAAAANSUhEUgAAAAMAAAACCAIAAAASFvFNAAAAEElEQVR4nGP4" +
+            "z8AAQQxwFgBB0gX7h/C5SAAAAABJRU5ErkJggg=="
+
+    // <img> is the HTML/EPUB spelling and resolves against the book's zip, not
+    // against FB2's base64 binaries — so the fixture has to be a real archive.
+    private lateinit var archive: File
+    private lateinit var zip: ZipFile
+
+    @Before
+    fun packTheImage() {
+        val app = ApplicationProvider.getApplicationContext<Application>()
+        archive = File(app.cacheDir, "empty-guard-test.zip")
+        ZipOutputStream(FileOutputStream(archive)).use { out ->
+            out.putNextEntry(ZipEntry("images/pic.png"))
+            out.write(Base64.decode(png, Base64.DEFAULT))
+            out.closeEntry()
+        }
+        zip = ZipFile(archive)
+    }
+
+    @After
+    fun cleanUp() {
+        zip.close()
+        archive.delete()
+    }
+
+    @Test
+    fun aPageHoldingOnlyAnImageSurvives() {
+        val parsed = parse("<p><img src=\"pic.png\"/></p>")
+
+        assertEquals("one entry, the image", 1, parsed.size)
+        assertTrue("it is the image", parsed.single() is ReaderText.Image)
+    }
+
+    @Test
+    fun theCoverShapeSurvives() {
+        // What a Calibre-converted EPUB puts in its title page: an <image>
+        // inside an <svg>, and no text anywhere in the document
+        val parsed = parse(
+            """
+            <div>
+              <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+                   width="100%" height="100%" viewBox="0 0 3 2">
+                <image width="3" height="2" xlink:href="pic.png"/>
+              </svg>
+            </div>
+            """.trimIndent()
+        )
+
+        assertEquals("the cover is kept", 1, parsed.filterIsInstance<ReaderText.Image>().size)
+    }
+
+    @Test
+    fun anImageWithTextAroundItStillWorks() {
+        val parsed = parse("<p>Перед</p><p><img src=\"pic.png\"/></p><p>Після</p>")
+
+        assertEquals(2, parsed.filterIsInstance<ReaderText.Text>().size)
+        assertEquals(1, parsed.filterIsInstance<ReaderText.Image>().size)
+    }
+
+    @Test
+    fun aDocumentWithNothingInItIsStillDropped() {
+        assertTrue("nothing to show", parse("<div></div>").isEmpty())
+    }
+
+    @Test
+    fun aDocumentOfWhitespaceIsStillDropped() {
+        assertTrue("whitespace is not content", parse("<p>   </p><p>\n\t</p>").isEmpty())
+    }
+
+    @Test
+    fun anImageWhoseSourceIsMissingIsNotContent() {
+        // Nothing was decoded, so there is genuinely nothing to show
+        assertTrue(parse("<p><img src=\"absent.png\"/></p>").isEmpty())
+    }
+
+    /** The EPUB path: the chapter comes from the TOC, so none is required here. */
+    private fun parse(body: String): List<ReaderText> = runBlocking {
+        documentParser.parseDocument(
+            document = Jsoup.parse("<html><body>$body</body></html>", "", Parser.htmlParser()),
+            zipFile = zip,
+            imageEntries = zip.entries().toList(),
+            includeChapter = false
+        )
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/cache/ParseCache.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/cache/ParseCache.kt
@@ -256,6 +256,7 @@ class ParseCache @Inject constructor(application: Application) {
         // 4: tables carry per-column alignment (ParsedTextCodec format 3).
         // 5: literal "*"/"_" of the book's text are no longer stripped.
         // 6: <i> is italicised, <s>/<del>/<strike> struck through.
-        const val VERSION = 6
+        // 7: a chapter holding only an image is no longer dropped.
+        const val VERSION = 7
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -718,8 +718,11 @@ class DocumentParser @Inject constructor(
 
         yield()
 
+        // "Did this document yield anything", not "does it have text": a page
+        // holding only an image — every Calibre-made cover is exactly that — is
+        // not an empty document, and dropping it takes the image with it.
         if (
-            readerText.filterIsInstance<ReaderText.Text>().isEmpty() ||
+            readerText.isEmpty() ||
             (includeChapter && readerText.filterIsInstance<ReaderText.Chapter>().isEmpty())
         ) {
             return@coroutineScope emptyList()

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/EpubTextParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/EpubTextParser.kt
@@ -88,7 +88,7 @@ class EpubTextParser @Inject constructor(
             yield()
 
             if (
-                readerText.filterIsInstance<ReaderText.Text>().isEmpty() ||
+                readerText.isEmpty() ||
                 readerText.filterIsInstance<ReaderText.Chapter>().isEmpty()
             ) {
                 logE(TAG, "Could not extract text from EPUB.")
@@ -208,8 +208,10 @@ class EpubTextParser @Inject constructor(
             )
         }
 
+        // A chapter that yielded nothing beyond its own title is empty; one
+        // holding only an image (a cover page) is not.
         if (
-            readerText.filterIsInstance<ReaderText.Text>().isEmpty() ||
+            readerText.none { line -> line !is ReaderText.Chapter } ||
             readerText.filterIsInstance<ReaderText.Chapter>().isEmpty()
         ) {
             logW(TAG, "Could not extract text from [${entry.name}].")

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/HtmlTextParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/HtmlTextParser.kt
@@ -38,7 +38,6 @@ class HtmlTextParser @Inject constructor(
 
             if (
                 readerText.isNullOrEmpty() ||
-                readerText.filterIsInstance<ReaderText.Text>().isEmpty() ||
                 readerText.filterIsInstance<ReaderText.Chapter>().isEmpty()
             ) {
                 logE(TAG, "Could not extract text from HTML.")

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
@@ -109,7 +109,6 @@ class XmlTextParser @Inject constructor(
 
             if (
                 readerText.isNullOrEmpty() ||
-                readerText.filterIsInstance<ReaderText.Text>().isEmpty() ||
                 readerText.filterIsInstance<ReaderText.Chapter>().isEmpty()
             ) {
                 logE(TAG, "Could not extract text from XML.")


### PR DESCRIPTION
Closes #33.

The guard at the end of `parseDocument` asked whether the document had any **text**, meaning to ask whether it had produced anything at all. Those differ for a page holding only an image — the shape of every cover Calibre emits:

```html
<div><svg …><image xlink:href="cover.jpeg"/></svg></div>
```

so the cover was discarded together with its chapter, and with it the only TOC entry some converted books have.

Upstream never saw this: its image branch appended a caption `ReaderText.Text` from `alt` unconditionally, blank `alt` included, and that empty text satisfied the guard by accident. `dcc4f8a0` made the caption a field of `ReaderText.Image`, conditional on the alt having visible text — right in itself, but it removed the prop and exposed the guard.

## Changes

Ask the question the guard means to ask, in every parser that can carry non-text content:

| | Now asks |
|---|---|
| `DocumentParser.parseDocument` | `readerText.isEmpty()` |
| `XmlTextParser`, `HtmlTextParser` | already had `isNullOrEmpty()`; the text clause is gone |
| `EpubTextParser.parse` | `readerText.isEmpty()` |
| `EpubTextParser.parseZipEntry` | `none { it !is Chapter }` — a document that yielded nothing beyond its own title is still skipped |

`TxtTextParser` and `PdfTextParser` are left alone: those formats produce only text, so there the two questions are the same one.

`ParseCache.VERSION` 6 -> 7, since chapters that used to vanish now appear.

## Testing

`connectedDebugAndroidTest`: **139 tests, 0 failures**, 6 new in `EmptyDocumentGuardTest`. The new tests deliberately cover the other direction too, so the fix does not turn into "keep everything": a document with nothing in it, a document of whitespace, and an `<img>` whose source is missing are all still dropped.

Worth recording: the first run failed, and the fault was in my fixture, not the code — `<img>` resolves against the book's zip and never against FB2's base64 binaries, so feeding it `base64Images` yielded nothing. The fixture now builds a real archive.

## Known edge, deliberately left

A cover page that has **no `navPoint` of its own** is still dropped: `EpubTextParser` takes the chapter title from the "first visible line" fallback, and an image-only page has no line to take. Inventing a title would be worse than not having one. Both real cases at hand — the reported book and chapter 08 of `epub-tags-test.epub` — do have a TOC entry.

## On device

Not yet confirmed on the tablet (it locked mid-check). Two places to look: the reported EPUB should open on a chapter named `Start` showing the cover, and chapter **08. Розділ лише з картинкою** of `epub-tags-test.epub` should stop being missing.
