### PR TITLE
feat: time the whole open of a book, tap to first frame

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/core/log/BookOpenTrace.kt
+++ b/app/src/main/java/ua/acclorite/book_story/core/log/BookOpenTrace.kt
@@ -1,0 +1,58 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.core.log
+
+/**
+ * One timeline for opening a book, measured from the tap that started it.
+ *
+ * [timed] answers "how long did this step take"; this answers "how long until
+ * this step happened", which is the only way to see the parts of an open that
+ * are nobody's `timed` block — navigation, the DB read, composition, and the
+ * gap between the text existing and the text being on screen.
+ *
+ * A trace runs from [start] (a tap on a book) to [end] (the first frame that
+ * carries text). Outside one, [mark] does nothing: entering the reader by some
+ * other route — a restored back stack, say — has no tap to measure from, and a
+ * number without an origin is worse than no number.
+ *
+ * Costs nothing when [BOOK_TIMING] is off, and single-user by construction:
+ * there is one reader, opened by one tap at a time.
+ */
+object BookOpenTrace {
+
+    @Volatile
+    private var startNs: Long = 0
+
+    /** Starts a trace — call at the tap, before navigating. */
+    fun start(what: String) {
+        if (!BOOK_TIMING) return
+        startNs = System.nanoTime()
+        logI(TAG, "open $what — t0")
+    }
+
+    /** Notes that [label] has been reached, if a trace is running. */
+    fun mark(label: String) {
+        if (!BOOK_TIMING) return
+        val start = startNs
+        if (start == 0L) return
+        logI(TAG, format(start, label))
+    }
+
+    /** [mark]s [label] and closes the trace, so nothing later appends to it. */
+    fun end(label: String) {
+        if (!BOOK_TIMING) return
+        val start = startNs
+        if (start == 0L) return
+        startNs = 0
+        logI(TAG, format(start, label))
+    }
+
+    private fun format(start: Long, label: String): String {
+        val ms = (System.nanoTime() - start) / 1_000_000
+        return "  +${ms.toString().padStart(5)} ms  $label"
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
@@ -64,8 +64,14 @@ class BookRepositoryImpl @Inject constructor(
 
     override suspend fun getText(bookId: Int): Result<ParsedText> {
         return withContext(Dispatchers.IO) {
-            getBook(bookId)
-                .mapCatching { fileProvider.getFileFromBook(it).getOrThrow() }
+            timed("  open: book row") { getBook(bookId) }
+                .mapCatching { book ->
+                    // Walks every persisted SAF tree looking for the book's path,
+                    // a ContentResolver query per directory — hence timed on its own.
+                    timed("  open: find file") {
+                        fileProvider.getFileFromBook(book).getOrThrow()
+                    }
+                }
                 .mapCatching { cachedFile ->
                     // A size-cap of 0 means the parse cache is disabled entirely.
                     val capMb = settings.parseCacheSizeMb.lastValue
@@ -73,9 +79,20 @@ class BookRepositoryImpl @Inject constructor(
                     val maxBytes = capMb.toLong() * 1024 * 1024
                     val cacheImages = settings.cacheImagesInBooks.lastValue
 
+                    // The parse-cache key, resolved before the cache is consulted
+                    // so its cost is not counted as cache time. Each of the three
+                    // is a lazy property that may be a ContentResolver round-trip
+                    // against the document URI; `size` and `lastModified` share
+                    // one query, so whichever is asked for first pays for both.
+                    val path = timed("  open: key path") { cachedFile.path }
+                    val size = timed("  open: key size") { cachedFile.size }
+                    val lastModified = timed("  open: key modified") {
+                        cachedFile.lastModified
+                    }
+
                     timed("getText", describe = { it.describeForTiming() }) {
                         val cached = if (cachingEnabled) parseCache.read(
-                            cachedFile.path, cachedFile.size, cachedFile.lastModified
+                            path, size, lastModified
                         ) else null
 
                         bookTimingNote {
@@ -84,7 +101,7 @@ class BookRepositoryImpl @Inject constructor(
                                 cached != null -> "cache HIT"
                                 else -> "cache MISS"
                             }
-                            "$state — ${cachedFile.name}, ${cachedFile.size / 1024} KB"
+                            "$state — ${cachedFile.name}, ${size / 1024} KB"
                         }
 
                         if (cached != null) {
@@ -109,9 +126,9 @@ class BookRepositoryImpl @Inject constructor(
                                 if (cachingEnabled && fresh.text.isNotEmpty()) {
                                     timed("  cache write") {
                                         parseCache.write(
-                                            cachedFile.path,
-                                            cachedFile.size,
-                                            cachedFile.lastModified,
+                                            path,
+                                            size,
+                                            lastModified,
                                             fresh,
                                             maxBytes = maxBytes,
                                             images = if (cacheImages) {

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import ua.acclorite.book_story.R
 import ua.acclorite.book_story.core.helpers.coerceAndPreventNaN
+import ua.acclorite.book_story.core.log.BookOpenTrace
+import ua.acclorite.book_story.core.log.timed
 import ua.acclorite.book_story.core.ui.UIText
 import ua.acclorite.book_story.domain.model.reader.BookImageStore
 import ua.acclorite.book_story.domain.model.reader.ReaderText
@@ -93,6 +95,7 @@ class ReaderModel @Inject constructor(
                     withContext(Dispatchers.Default) {
                         val parsedText = getTextUseCase(_state.value.book.id)
                         val text = parsedText.text
+                        BookOpenTrace.mark("text parsed")
                         ensureActive()
 
                         if (text.isEmpty()) {
@@ -145,6 +148,7 @@ class ReaderModel @Inject constructor(
                                 notes = parsedText.notes
                             )
                         }
+                        BookOpenTrace.mark("text in state")
                         ensureActive()
 
                         updateBookUseCase(_state.value.book)
@@ -477,18 +481,18 @@ class ReaderModel @Inject constructor(
 
     fun init(bookId: Int) {
         viewModelScope.launch(Dispatchers.Default) {
-            val book = getBookUseCase(bookId)
+            val book = timed("  init: book row") { getBookUseCase(bookId) }
 
             if (book == null) {
                 _effects.emit(ReaderEffect.OnNavigateBack)
                 return@launch
             }
 
-            clear()
+            timed("  init: clear previous") { clear() }
             // Here rather than when the previous reader closed: a book keeps its
             // image files so that reopening it needs no work, and this is the
             // point where they stop being the ones worth keeping.
-            keepOnlyBookImagesUseCase(bookId)
+            timed("  init: drop other images") { keepOnlyBookImagesUseCase(bookId) }
 
             _state.update {
                 ReaderState(

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderScreen.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderScreen.kt
@@ -45,6 +45,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.parcelize.Parcelize
 import ua.acclorite.book_story.core.helpers.calculateProgress
+import ua.acclorite.book_story.core.log.BookOpenTrace
 import ua.acclorite.book_story.presentation.navigator.Screen
 import ua.acclorite.book_story.presentation.reader.model.ReaderColorEffects
 import ua.acclorite.book_story.presentation.reader.model.ReaderProgressCount
@@ -342,6 +343,7 @@ data class ReaderScreen(val bookId: Int) : Screen, Parcelable {
         }
 
         LaunchedEffect(Unit) {
+            BookOpenTrace.mark("reader screen composed")
             screenModel.init(bookId = bookId)
         }
         LaunchedEffect(settings.fullscreen.value) {

--- a/app/src/main/java/ua/acclorite/book_story/ui/book_info/BookInfoEffects.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/book_info/BookInfoEffects.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.flow.SharedFlow
 import ua.acclorite.book_story.R
+import ua.acclorite.book_story.core.log.BookOpenTrace
 import ua.acclorite.book_story.domain.model.library.Book
 import ua.acclorite.book_story.presentation.book_info.BookInfoEffect
 import ua.acclorite.book_story.presentation.history.HistoryScreen
@@ -87,6 +88,7 @@ fun BookInfoEffects(effects: SharedFlow<BookInfoEffect>, book: Book) {
 
                 is BookInfoEffect.OnNavigateToReader -> {
                     if (book.id != -1) {
+                        BookOpenTrace.start("book ${book.id} from book info")
                         HistoryScreen.insertHistoryChannel.trySend(book.id)
                         navigator.push(ReaderScreen(book.id))
                     }

--- a/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryEffects.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryEffects.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.flow.SharedFlow
 import ua.acclorite.book_story.R
+import ua.acclorite.book_story.core.log.BookOpenTrace
 import ua.acclorite.book_story.presentation.book_info.BookInfoScreen
 import ua.acclorite.book_story.presentation.history.HistoryEffect
 import ua.acclorite.book_story.presentation.history.HistoryEvent
@@ -69,6 +70,7 @@ fun HistoryEffects(
                 }
 
                 is HistoryEffect.OnNavigateToReader -> {
+                    BookOpenTrace.start("book ${effect.bookId} from history")
                     insertHistoryChannel.trySend(effect.bookId)
                     navigator.push(ReaderScreen(bookId = effect.bookId))
                 }

--- a/app/src/main/java/ua/acclorite/book_story/ui/library/LibraryEffects.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/library/LibraryEffects.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.flow.SharedFlow
 import ua.acclorite.book_story.R
+import ua.acclorite.book_story.core.log.BookOpenTrace
 import ua.acclorite.book_story.presentation.book_info.BookInfoScreen
 import ua.acclorite.book_story.presentation.browse.BrowseScreen
 import ua.acclorite.book_story.presentation.history.HistoryScreen
@@ -56,6 +57,7 @@ fun LibraryEffects(effects: SharedFlow<LibraryEffect>, focusRequester: FocusRequ
                 }
 
                 is LibraryEffect.OnNavigateToReader -> {
+                    BookOpenTrace.start("book ${effect.id} from library")
                     HistoryScreen.insertHistoryChannel.trySend(effect.id)
                     navigator.push(ReaderScreen(effect.id))
                 }

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderFirstFrameTrace.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderFirstFrameTrace.kt
@@ -1,0 +1,47 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.reader
+
+import android.os.Build
+import android.view.Choreographer
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalView
+import ua.acclorite.book_story.core.log.BOOK_TIMING
+import ua.acclorite.book_story.core.log.BookOpenTrace
+
+/**
+ * Closes the [BookOpenTrace] at the first frame that actually carries text —
+ * the moment the reader stops being a blank screen, which is the number a
+ * reader feels and the one nothing else measures.
+ *
+ * Composition is not that moment: it only decides what the frame will contain.
+ * So the mark waits for the frame to be handed to the display, one vsync later
+ * on API 29+, or for the start of the following frame below it.
+ *
+ * Compiles to nothing when [BOOK_TIMING] is off.
+ */
+@Composable
+fun ReaderFirstFrameTrace(hasText: Boolean) {
+    if (!BOOK_TIMING) return
+    val view = LocalView.current
+
+    DisposableEffect(hasText) {
+        if (!hasText) return@DisposableEffect onDispose { }
+
+        val mark = Runnable { BookOpenTrace.end("first frame with text") }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // Fires once, when the frame is committed, and removes itself.
+            view.viewTreeObserver.registerFrameCommitCallback(mark)
+            onDispose { view.viewTreeObserver.unregisterFrameCommitCallback(mark) }
+        } else {
+            val callback = Choreographer.FrameCallback { mark.run() }
+            Choreographer.getInstance().postFrameCallback(callback)
+            onDispose { Choreographer.getInstance().removeFrameCallback(callback) }
+        }
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderLayout.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderLayout.kt
@@ -99,6 +99,7 @@ fun ReaderLayout(
     openDictionary: (ReaderEvent.OnOpenDictionary) -> Unit
 ) {
     val activity = LocalActivity.current
+    ReaderFirstFrameTrace(hasText = text.isNotEmpty())
     SelectionContainer(
         onCopyRequested = {
             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {


### PR DESCRIPTION
BookTiming answers "how long did this step take". It has nothing to say about the steps that are nobody's timed block, and those turned out to be most of the wall clock on a cache hit: getText itself is 6-18 ms on a warm book, while the tap that started it was hundreds of milliseconds ago. Time-to-visible was not measured at all — the last mark was composition, which only decides what the next frame will contain.

BookOpenTrace is the other half: one timeline per open, every mark relative to the tap that started it. Outside a trace mark() does nothing, so entering the reader by a restored back stack logs nothing rather than logging a number with no origin.

Marks, in order: the tap (library, history, book info), the reader screen composed, the parse, the text reaching state, and the first frame that actually carries text. That last one waits for the frame to be committed to the display on API 29+, so it is a paint and not a composition; the Choreographer fallback below is a vsync late.

Durations fill in what the timeline only bounds: the Room read and the image sweep in ReaderModel.init, and in getText the second Room read, the walk that finds the file, and each of the three lazy properties making up the parse-cache key. The key is resolved before the cache is consulted, so its cost stops being counted as cache time.

All of it is gated on BOOK_TIMING exactly as the existing marks are, so release builds carry none of it.

Refs #27