### PR TITLE
feat: split parseDocument into timed phases

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/core/log/BookTiming.kt
+++ b/app/src/main/java/ua/acclorite/book_story/core/log/BookTiming.kt
@@ -48,3 +48,43 @@ inline fun <T> timed(
 inline fun bookTimingNote(note: () -> String) {
     if (BOOK_TIMING) logI(TAG, note())
 }
+
+/**
+ * A [timed] for work that happens a great many times: it adds up instead of
+ * logging, so a step running once per line of the book yields one line of log
+ * rather than one per line of book.
+ *
+ * Not reentrant, and not safe across threads — a sum belongs to one parse, and
+ * a parse is one coroutine. Costs nothing when [BOOK_TIMING] is off beyond the
+ * call itself, which is why [add] takes a plain lambda: at 2.9M characters the
+ * allocation is noise next to what is being measured, and inlining it would put
+ * the counters in the hot path of every build.
+ */
+class TimingSum(private val label: String) {
+
+    private var ns = 0L
+    private var calls = 0
+
+    fun <T> add(block: () -> T): T {
+        if (!BOOK_TIMING) return block()
+
+        val start = System.nanoTime()
+        try {
+            return block()
+        } finally {
+            ns += System.nanoTime() - start
+            calls++
+        }
+    }
+
+    fun reset() {
+        ns = 0
+        calls = 0
+    }
+
+    /** Logs the total, or nothing at all if the step never ran. */
+    fun log(indent: String = "      ") {
+        if (!BOOK_TIMING || calls == 0) return
+        logI(TAG, "$indent$label: ${ns / 1_000_000} ms, $calls calls")
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -21,6 +21,7 @@ import org.jsoup.nodes.Element
 import org.jsoup.nodes.Node
 import org.jsoup.nodes.TextNode
 import ua.acclorite.book_story.core.helpers.containsVisibleText
+import ua.acclorite.book_story.core.log.timed
 import ua.acclorite.book_story.domain.model.reader.NOTE_LINK_TAG_PREFIX
 import ua.acclorite.book_story.domain.model.reader.ReaderImage
 import ua.acclorite.book_story.domain.model.reader.ReaderText
@@ -319,9 +320,16 @@ class DocumentParser @Inject constructor(
         // Tables extracted in the DOM phase, re-emitted by their marker line
         val tables = mutableListOf<ReaderText.Table>()
 
-        document.selectFirst("body")
-            .run { this ?: document.body() }
-            .apply {
+        // Issue #26: this function is ~98 % of a first open, and until now
+        // nothing said which of its phases that is. The chain below is written
+        // out step by step so each can be timed; the sums cover the work that
+        // happens once per line, which is where a per-call log would drown.
+        markdownParser.resetTiming()
+
+        val body = document.selectFirst("body").run { this ?: document.body() }
+
+        timed("      dom phase") {
+            body.apply {
                 // Before anything is injected: the book's own text must not be
                 // able to pass itself off as one of our sentinels
                 stripInlineMarks()
@@ -559,9 +567,17 @@ class DocumentParser @Inject constructor(
                         table.replaceWith(TextNode("\n[[[table|${tables.size}]]]\n"))
                         tables.add(ReaderText.Table(rows, hasHeader, alignments))
                     }
-            }.wholeText().lines()
-            .let { lines -> extractMarkdownTables(lines, tables) }
-            .forEach { line ->
+            }
+        }
+
+        val flat = timed("      wholeText", describe = { "${it.length} chars" }) {
+            body.wholeText()
+        }
+        val rawLines = timed("      lines", describe = { "${it.size} lines" }) { flat.lines() }
+        val lines = timed("      md tables") { extractMarkdownTables(rawLines, tables) }
+
+        timed("      line loop") {
+            lines.forEach { line ->
                 yield()
 
                 // Tabs are not rendered and would glue the surrounding words
@@ -715,6 +731,12 @@ class DocumentParser @Inject constructor(
                     }
                 }
             }
+        }
+
+        // Nested inside the loop above, so both are already counted in it; what
+        // the three do not account for is the per-line string and regex work.
+        markdownParser.commonmarkSum.log()
+        markdownParser.annotateSum.log()
 
         yield()
 

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/MarkdownParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/MarkdownParser.kt
@@ -27,6 +27,7 @@ import org.commonmark.node.Node
 import org.commonmark.node.StrongEmphasis
 import org.commonmark.node.Text
 import org.commonmark.parser.Parser
+import ua.acclorite.book_story.core.log.TimingSum
 import ua.acclorite.book_story.domain.model.reader.ANCHOR_LINK_TAG_PREFIX
 import ua.acclorite.book_story.domain.model.reader.NOTE_LINK_TAG_PREFIX
 import javax.inject.Inject
@@ -62,16 +63,34 @@ class MarkdownParser @Inject constructor(
     private val commonmarkParser: Parser
 ) {
     /**
+     * How the per-line cost of [parse] divides — commonmark building its own
+     * tree, against walking that tree into an [AnnotatedString]. The caller owns
+     * the sums, because only it knows what one document is: see
+     * [DocumentParser.parseDocument], which runs [parse] once per line of the
+     * book and is where the numbers behind issue #26 come from.
+     */
+    val commonmarkSum = TimingSum("commonmark")
+    val annotateSum = TimingSum("annotate")
+
+    fun resetTiming() {
+        commonmarkSum.reset()
+        annotateSum.reset()
+    }
+
+    /**
      * Parses markdown text to [AnnotatedString].
      *
      * @return Parsed annotated string.
      */
     fun parse(markdown: String): AnnotatedString {
         return try {
-            val annotatedString = buildAnnotatedString {
-                parseNode(commonmarkParser.parse(markdown), MarkScanner(this))
-            }.ifBlank { buildAnnotatedString { append(markdown) } }
-                .trim() as AnnotatedString
+            val document = commonmarkSum.add { commonmarkParser.parse(markdown) }
+            val annotatedString = annotateSum.add {
+                buildAnnotatedString {
+                    parseNode(document, MarkScanner(this))
+                }.ifBlank { buildAnnotatedString { append(markdown) } }
+                    .trim() as AnnotatedString
+            }
 
             annotatedString
         } catch (e: Exception) {


### PR DESCRIPTION
Issue #26 says a first open of a text-heavy book is 20 s and 98 % of it is parseDocument. It could not say which part of parseDocument, because the function is one expression: a DOM phase, a flatten, and a loop over every line of the book, chained end to end with nothing between them to measure.

Write the chain out as steps so each can be timed, and add TimingSum for the work that happens per line — a step running 29 492 times cannot log per call without drowning the log, so it adds up and reports once. MarkdownParser now keeps two of those sums, splitting its own cost into commonmark building a tree and the walk that turns that tree into an AnnotatedString; the caller owns them because only it knows where one document begins.

Behaviour is unchanged — the steps run in the same order on the same objects. Verified on the device by character count: the trilogy parses to 2 874 766 chars before and after, Touhou to 170 846.

What it reports, trilogy (5.6 MB, 2.87M chars, release-debug + AOT):

    parseDoc: 19663 ms
      dom phase: 4723 ms
      wholeText: 42 ms 2916611 chars
      lines: 29 ms 29492 lines
      md tables: 6 ms
      line loop: 14859 ms
      commonmark: 3826 ms, 14434 calls
      annotate: 1627 ms, 14434 calls

So commonmark is a fifth of it, not the bulk — the loop costs three times what it spends parsing markdown. A finer probe, run in the working tree and not kept, attributes the rest: yield() 4883 ms (29 492 calls, one per line), the four marker regexes 2180 ms, clearInlineMarks 945 ms. Recorded in #26.

Refs #26