### PR TITLE
fix: let cancellation propagate instead of being caught as failure

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/core/helpers/CancellationHelpers.kt
+++ b/app/src/main/java/ua/acclorite/book_story/core/helpers/CancellationHelpers.kt
@@ -1,0 +1,46 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.core.helpers
+
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Rethrows a coroutine cancellation; does nothing for any other failure.
+ *
+ * [CancellationException] is an ordinary [Exception], so `catch (e: Exception)`
+ * and [runCatching] both capture it — and a captured cancellation stops being
+ * cancellation. The coroutine runs on to the end of the function, reports
+ * whatever the failure branch reports, and the caller cannot tell "the user left"
+ * from "this file is broken".
+ *
+ * Call this first in any catch that a cancellable operation can reach.
+ */
+fun Throwable.rethrowIfCancellation() {
+    if (this is CancellationException) throw this
+}
+
+/**
+ * [runCatching], except that a cancellation propagates instead of being captured.
+ *
+ * Prefer this over [runCatching] anywhere the block can suspend: a [Result] that
+ * holds a [CancellationException] is a bug waiting for a caller to log it as an
+ * error, retry it, or show it to the user.
+ */
+inline fun <T> runCatchingCancellable(block: () -> T): Result<T> =
+    try {
+        Result.success(block())
+    } catch (e: Throwable) {
+        e.rethrowIfCancellation()
+        Result.failure(e)
+    }
+
+/** [Result.mapCatching], with the same guarantee as [runCatchingCancellable]. */
+inline fun <T, R> Result<T>.mapCatchingCancellable(transform: (T) -> R): Result<R> =
+    fold(
+        onSuccess = { value -> runCatchingCancellable { transform(value) } },
+        onFailure = { failure -> Result.failure(failure) }
+    )

--- a/app/src/main/java/ua/acclorite/book_story/data/mapper/color_preset/ColorPresetMapperImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/mapper/color_preset/ColorPresetMapperImpl.kt
@@ -7,6 +7,7 @@
 package ua.acclorite.book_story.data.mapper.color_preset
 
 import androidx.compose.ui.graphics.Color
+import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.data.local.dto.ColorPresetEntity
 import ua.acclorite.book_story.domain.model.reader.ColorPreset
 import ua.acclorite.book_story.domain.model.reader.ColorPresetType
@@ -36,7 +37,7 @@ class ColorPresetMapperImpl @Inject constructor() : ColorPresetMapper {
             backgroundColor = Color(colorPresetEntity.backgroundColor.toULong()),
             fontColor = Color(colorPresetEntity.fontColor.toULong()),
             isSelected = colorPresetEntity.isSelected,
-            type = runCatching {
+            type = runCatchingCancellable {
                 ColorPresetType.valueOf(colorPresetEntity.type)
             }.getOrDefault(ColorPresetType.CUSTOM)
         )

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/cover/EpubCoverParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/cover/EpubCoverParser.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.withContext
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser
 import ua.acclorite.book_story.core.CoverImage
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.data.model.file.CachedFile
 import java.net.URLDecoder
@@ -78,6 +79,7 @@ class EpubCoverParser @Inject constructor() : CoverParser {
             }
             coverImage
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             logE(TAG, "Could not parse cover image with message: ${e.message}.")
             null
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/cover/Fb2CoverParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/cover/Fb2CoverParser.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.withContext
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser
 import ua.acclorite.book_story.core.CoverImage
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.data.model.file.CachedFile
 import javax.inject.Inject
@@ -46,6 +47,7 @@ class Fb2CoverParser @Inject constructor() : CoverParser {
                 }
             }
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             logE(TAG, "Could not parse cover with message: ${e.message}.")
             null
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -23,6 +23,7 @@ import org.jsoup.nodes.Element
 import org.jsoup.nodes.Node
 import org.jsoup.nodes.TextNode
 import ua.acclorite.book_story.core.helpers.containsVisibleText
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.timed
 import ua.acclorite.book_story.domain.model.reader.NOTE_LINK_TAG_PREFIX
 import ua.acclorite.book_story.domain.model.reader.ReaderImage
@@ -956,6 +957,7 @@ class DocumentParser @Inject constructor(
                 height = bounds.outHeight
             )
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             e.printStackTrace()
             null
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/MarkdownParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/MarkdownParser.kt
@@ -27,6 +27,7 @@ import org.commonmark.node.Node
 import org.commonmark.node.StrongEmphasis
 import org.commonmark.node.Text
 import org.commonmark.parser.Parser
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.TimingSum
 import ua.acclorite.book_story.domain.model.reader.ANCHOR_LINK_TAG_PREFIX
 import ua.acclorite.book_story.domain.model.reader.NOTE_LINK_TAG_PREFIX
@@ -94,6 +95,7 @@ class MarkdownParser @Inject constructor(
 
             annotatedString
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             e.printStackTrace()
             buildAnnotatedString { append(markdown) }
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/file/EpubFileParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/file/EpubFileParser.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.withContext
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser
 import ua.acclorite.book_story.R
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.ui.UIText
 import ua.acclorite.book_story.data.model.file.CachedFile
@@ -79,6 +80,7 @@ class EpubFileParser @Inject constructor() : FileParser {
             }
             book
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             logE(TAG, "Could not parse file with message: ${e.message}.")
             null
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/file/Fb2FileParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/file/Fb2FileParser.kt
@@ -9,6 +9,7 @@ package ua.acclorite.book_story.data.parser.file
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser
 import ua.acclorite.book_story.R
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.ui.UIText
 import ua.acclorite.book_story.data.model.file.CachedFile
@@ -59,6 +60,7 @@ class Fb2FileParser @Inject constructor() : FileParser {
                 coverImage = null
             )
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             logE(TAG, "Could not parse file with message: ${e.message}.")
             null
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/file/HtmlFileParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/file/HtmlFileParser.kt
@@ -9,6 +9,7 @@ package ua.acclorite.book_story.data.parser.file
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser
 import ua.acclorite.book_story.R
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.ui.UIText
 import ua.acclorite.book_story.data.model.file.CachedFile
@@ -45,6 +46,7 @@ class HtmlFileParser @Inject constructor() : FileParser {
                 coverImage = null
             )
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             logE(TAG, "Could not parse file with message: ${e.message}.")
             null
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/file/PdfFileParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/file/PdfFileParser.kt
@@ -10,6 +10,7 @@ import android.app.Application
 import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
 import com.tom_roush.pdfbox.pdmodel.PDDocument
 import ua.acclorite.book_story.R
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.ui.UIText
 import ua.acclorite.book_story.data.model.file.CachedFile
@@ -50,6 +51,7 @@ class PdfFileParser @Inject constructor(
                 coverImage = null
             )
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             logE(TAG, "Could not parse file with message: ${e.message}.")
             null
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/file/TxtFileParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/file/TxtFileParser.kt
@@ -7,6 +7,7 @@
 package ua.acclorite.book_story.data.parser.file
 
 import ua.acclorite.book_story.R
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.ui.UIText
 import ua.acclorite.book_story.data.model.file.CachedFile
@@ -34,6 +35,7 @@ class TxtFileParser @Inject constructor() : FileParser {
                 coverImage = null
             )
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             logE(TAG, "Could not parse file with message: ${e.message}.")
             null
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/EpubTextParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/EpubTextParser.kt
@@ -20,6 +20,7 @@ import org.jsoup.parser.Parser
 import ua.acclorite.book_story.core.data.ExtensionsData
 import ua.acclorite.book_story.core.helpers.addAll
 import ua.acclorite.book_story.core.helpers.containsVisibleText
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.core.log.logW
@@ -98,6 +99,7 @@ class EpubTextParser @Inject constructor(
             logI(TAG, "Successfully finished EPUB parsing.")
             ParsedText(readerText)
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             logE(TAG, "Could not parse text with message: ${e.message}.")
             ParsedText.EMPTY
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/HtmlTextParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/HtmlTextParser.kt
@@ -9,6 +9,7 @@ package ua.acclorite.book_story.data.parser.text
 import kotlinx.coroutines.yield
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.data.model.file.CachedFile
@@ -47,6 +48,7 @@ class HtmlTextParser @Inject constructor(
             logI(TAG, "Successfully finished HTML parsing.")
             ParsedText(readerText)
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             logE(TAG, "Could not parse text with message: ${e.message}.")
             ParsedText.EMPTY
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/PdfTextParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/PdfTextParser.kt
@@ -12,6 +12,7 @@ import com.tom_roush.pdfbox.pdmodel.PDDocument
 import com.tom_roush.pdfbox.text.PDFTextStripper
 import kotlinx.coroutines.yield
 import ua.acclorite.book_story.core.helpers.clearAllMarkdown
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.data.model.file.CachedFile
@@ -109,6 +110,8 @@ class PdfTextParser @Inject constructor(
                     }
 
                 } catch (e: Exception) {
+
+                    e.rethrowIfCancellation()
                     e.printStackTrace()
                     return@forEachIndexed
                 }
@@ -158,6 +161,7 @@ class PdfTextParser @Inject constructor(
             logI(TAG, "Successfully finished PDF parsing.")
             ParsedText(readerText)
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             logE(TAG, "Could not parse text with message: ${e.message}.")
             ParsedText.EMPTY
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/TxtTextParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/TxtTextParser.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import ua.acclorite.book_story.core.helpers.clearAllMarkdown
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.data.model.file.CachedFile
@@ -75,6 +76,7 @@ class TxtTextParser @Inject constructor(
             logI(TAG, "Successfully finished TXT parsing.")
             ParsedText(readerText)
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             logE(TAG, "Could not parse text with message: ${e.message}.")
             ParsedText.EMPTY
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
@@ -11,6 +11,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.TextNode
 import org.jsoup.parser.Parser
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.core.log.timed
@@ -119,6 +120,7 @@ class XmlTextParser @Inject constructor(
 
             ParsedText(readerText, notes)
         } catch (e: Exception) {
+            e.rethrowIfCancellation()
             logE(TAG, "Could not parse text with message: ${e.message}.")
             ParsedText.EMPTY
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
 import ua.acclorite.book_story.core.CoverImage
+import ua.acclorite.book_story.core.helpers.mapCatchingCancellable
+import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.core.log.bookTimingNote
 import ua.acclorite.book_story.core.log.timed
 import ua.acclorite.book_story.data.cache.ImageMemoryBudget
@@ -47,13 +49,13 @@ class BookRepositoryImpl @Inject constructor(
     private val settings: SettingsManager
 ) : BookRepository {
 
-    override suspend fun searchBooks(query: String): Result<List<Book>> = runCatching {
+    override suspend fun searchBooks(query: String): Result<List<Book>> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.bookDao.searchBooks(query).map { bookMapper.toBook(it) }
         }
     }
 
-    override suspend fun getBook(bookId: Int): Result<Book> = runCatching {
+    override suspend fun getBook(bookId: Int): Result<Book> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.bookDao.findBookById(bookId).let {
                 if (it == null) throw NoSuchElementException("Couldn't get book [$bookId].")
@@ -65,14 +67,14 @@ class BookRepositoryImpl @Inject constructor(
     override suspend fun getText(bookId: Int): Result<ParsedText> {
         return withContext(Dispatchers.IO) {
             timed("  open: book row") { getBook(bookId) }
-                .mapCatching { book ->
+                .mapCatchingCancellable { book ->
                     // Walks every persisted SAF tree looking for the book's path,
                     // a ContentResolver query per directory — hence timed on its own.
                     timed("  open: find file") {
                         fileProvider.getFileFromBook(book).getOrThrow()
                     }
                 }
-                .mapCatching { cachedFile ->
+                .mapCatchingCancellable { cachedFile ->
                     // A size-cap of 0 means the parse cache is disabled entirely.
                     val capMb = settings.parseCacheSizeMb.lastValue
                     val cachingEnabled = capMb > 0
@@ -174,8 +176,8 @@ class BookRepositoryImpl @Inject constructor(
             // directory the closing reader has just deleted.
             val pass = coroutineContext.job
             getBook(bookId)
-                .mapCatching { fileProvider.getFileFromBook(it).getOrThrow() }
-                .mapCatching { cachedFile ->
+                .mapCatchingCancellable { fileProvider.getFileFromBook(it).getOrThrow() }
+                .mapCatchingCancellable { cachedFile ->
                     val capMb = settings.parseCacheSizeMb.lastValue
                     val maxBytes = capMb.toLong() * 1024 * 1024
                     val cacheImages = capMb > 0 && settings.cacheImagesInBooks.lastValue
@@ -231,7 +233,7 @@ class BookRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun keepOnlyBookImages(bookId: Int): Result<Unit> = runCatching {
+    override suspend fun keepOnlyBookImages(bookId: Int): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             readerImageFiles.keepOnly(bookId)
         }
@@ -256,18 +258,18 @@ class BookRepositoryImpl @Inject constructor(
     override suspend fun getFileFromBook(bookId: Int): Result<File> {
         return withContext(Dispatchers.IO) {
             getBook(bookId)
-                .mapCatching { fileProvider.getFileFromBook(it).getOrThrow() }
-                .mapCatching { fileMapper.toFile(it) }
+                .mapCatchingCancellable { fileProvider.getFileFromBook(it).getOrThrow() }
+                .mapCatchingCancellable { fileMapper.toFile(it) }
         }
     }
 
-    override suspend fun addBook(book: Book): Result<Unit> = runCatching {
+    override suspend fun addBook(book: Book): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.bookDao.insertBook(bookMapper.toBookEntity(book))
         }
     }
 
-    override suspend fun updateBook(book: Book): Result<Unit> = runCatching {
+    override suspend fun updateBook(book: Book): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.bookDao.updateBook(bookMapper.toBookEntity(book)).also {
                 if (it == 0) throw Exception("Could not update book in database.")
@@ -275,7 +277,7 @@ class BookRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun deleteBook(book: Book): Result<Unit> = runCatching {
+    override suspend fun deleteBook(book: Book): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.bookDao.deleteBook(bookMapper.toBookEntity(book)).also {
                 if (it == 0) throw Exception("Could not delete book in database.")
@@ -283,9 +285,9 @@ class BookRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getDefaultCover(book: Book): Result<CoverImage?> = runCatching {
+    override suspend fun getDefaultCover(book: Book): Result<CoverImage?> = runCatchingCancellable {
         return withContext(Dispatchers.IO) {
-            fileProvider.getFileFromBook(book).mapCatching {
+            fileProvider.getFileFromBook(book).mapCatchingCancellable {
                 coverParser.parse(it)
             }
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/CategoryRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/CategoryRepositoryImpl.kt
@@ -8,6 +8,7 @@ package ua.acclorite.book_story.data.repository
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.data.local.room.BookDatabase
 import ua.acclorite.book_story.data.mapper.category.CategoryMapper
 import ua.acclorite.book_story.domain.model.library.Category
@@ -21,7 +22,7 @@ class CategoryRepositoryImpl @Inject constructor(
     private val categoryMapper: CategoryMapper
 ) : CategoryRepository {
 
-    override suspend fun addCategory(category: Category): Result<Unit> = runCatching {
+    override suspend fun addCategory(category: Category): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.categoryDao.insertCategory(
                 categoryMapper.toCategoryEntity(
@@ -33,13 +34,13 @@ class CategoryRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getCategories(): Result<List<Category>> = runCatching {
+    override suspend fun getCategories(): Result<List<Category>> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.categoryDao.getCategories().map { categoryMapper.toCategory(it) }
         }
     }
 
-    override suspend fun updateCategory(category: Category): Result<Unit> = runCatching {
+    override suspend fun updateCategory(category: Category): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.categoryDao.updateCategory(
                 category = categoryMapper.toCategoryEntity(
@@ -53,7 +54,7 @@ class CategoryRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun updateOrder(categories: List<Category>): Result<Unit> = runCatching {
+    override suspend fun updateOrder(categories: List<Category>): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             categories.forEachIndexed { index, category ->
                 if (category.id == -1) return@forEachIndexed
@@ -66,7 +67,7 @@ class CategoryRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun deleteCategory(category: Category): Result<Unit> = runCatching {
+    override suspend fun deleteCategory(category: Category): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             if (category.id == -1) throw IllegalArgumentException("Id should not be -1.")
             database.categoryDao.deleteCategory(categoryMapper.toCategoryEntity(category))

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/ColorPresetRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/ColorPresetRepositoryImpl.kt
@@ -8,6 +8,7 @@ package ua.acclorite.book_story.data.repository
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.data.local.room.BookDatabase
 import ua.acclorite.book_story.data.mapper.color_preset.ColorPresetMapper
 import ua.acclorite.book_story.domain.model.reader.ColorPreset
@@ -21,7 +22,7 @@ class ColorPresetRepositoryImpl @Inject constructor(
     private val colorPresetMapper: ColorPresetMapper
 ) : ColorPresetRepository {
 
-    override suspend fun getColorPresets(): Result<List<ColorPreset>> = runCatching {
+    override suspend fun getColorPresets(): Result<List<ColorPreset>> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.colorPresetDao.getColorPresets().map {
                 colorPresetMapper.toColorPreset(it)
@@ -31,7 +32,7 @@ class ColorPresetRepositoryImpl @Inject constructor(
 
     override suspend fun updateColorPreset(
         colorPreset: ColorPreset
-    ): Result<Unit> = runCatching {
+    ): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.colorPresetDao.updateColorPreset(
                 colorPresetMapper.toColorPresetEntity(
@@ -46,7 +47,7 @@ class ColorPresetRepositoryImpl @Inject constructor(
 
     override suspend fun selectColorPreset(
         colorPreset: ColorPreset
-    ): Result<Unit> = runCatching {
+    ): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.colorPresetDao.getColorPresets().map {
                 it.copy(isSelected = it.id == colorPreset.id)
@@ -58,7 +59,7 @@ class ColorPresetRepositoryImpl @Inject constructor(
 
     override suspend fun reorderColorPresets(
         colorPresets: List<ColorPreset>
-    ): Result<Unit> = runCatching {
+    ): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.colorPresetDao.deleteColorPresets()
             colorPresets.forEachIndexed { index, colorPreset ->
@@ -71,7 +72,7 @@ class ColorPresetRepositoryImpl @Inject constructor(
 
     override suspend fun deleteColorPreset(
         colorPreset: ColorPreset
-    ): Result<Unit> = runCatching {
+    ): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.colorPresetDao.deleteColorPreset(
                 colorPresetMapper.toColorPresetEntity(

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/FileSystemRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/FileSystemRepositoryImpl.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import ua.acclorite.book_story.core.CoverImage
 import ua.acclorite.book_story.core.data.ExtensionsData
+import ua.acclorite.book_story.core.helpers.mapCatchingCancellable
+import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.data.local.room.BookDatabase
 import ua.acclorite.book_story.data.mapper.file.FileMapper
 import ua.acclorite.book_story.data.model.file.CachedFile
@@ -33,7 +35,7 @@ class FileSystemRepositoryImpl @Inject constructor(
 
     override suspend fun searchFiles(query: String): Result<List<File>> {
         return withContext(Dispatchers.IO) {
-            fileProvider.getStorageFiles().mapCatching { storages ->
+            fileProvider.getStorageFiles().mapCatchingCancellable { storages ->
                 val existingFiles = database.bookDao.searchBooks("").map { it.filePath }
 
                 storages.map { storage ->
@@ -77,7 +79,7 @@ class FileSystemRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getBookFromFile(file: File): Result<Pair<Book, CoverImage?>> =
-        runCatching {
+        runCatchingCancellable {
             withContext(Dispatchers.IO) {
                 val cachedFile = fileMapper.toCachedFile(file)
 

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/HistoryRepositoryImpl.kt
@@ -8,6 +8,7 @@ package ua.acclorite.book_story.data.repository
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.data.local.room.BookDatabase
 import ua.acclorite.book_story.data.mapper.history.HistoryMapper
 import ua.acclorite.book_story.domain.model.history.History
@@ -21,7 +22,7 @@ class HistoryRepositoryImpl @Inject constructor(
     private val historyMapper: HistoryMapper
 ) : HistoryRepository {
 
-    override suspend fun getHistoryForBook(bookId: Int): Result<History> = runCatching {
+    override suspend fun getHistoryForBook(bookId: Int): Result<History> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.historyDao.getHistoryForBook(bookId).let {
                 if (it == null) throw NoSuchElementException("Could not get history from [$bookId].")
@@ -30,19 +31,19 @@ class HistoryRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun addHistory(history: History): Result<Unit> = runCatching {
+    override suspend fun addHistory(history: History): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.historyDao.insertHistory(historyMapper.toHistoryEntity(history))
         }
     }
 
-    override suspend fun getHistory(): Result<List<History>> = runCatching {
+    override suspend fun getHistory(): Result<List<History>> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.historyDao.getHistoryWithBook().map { historyMapper.toHistory(it) }
         }
     }
 
-    override suspend fun deleteWholeHistory(): Result<Unit> = runCatching {
+    override suspend fun deleteWholeHistory(): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.historyDao.deleteWholeHistory().also {
                 if (it == 0) throw Exception("Could not delete whole history in database.")
@@ -50,7 +51,7 @@ class HistoryRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun deleteHistoryForBook(bookId: Int): Result<Unit> = runCatching {
+    override suspend fun deleteHistoryForBook(bookId: Int): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.historyDao.deleteHistoryForBook(bookId = bookId).also {
                 if (it == 0) throw Exception("Could not delete history for book [$bookId] in database.")
@@ -58,7 +59,7 @@ class HistoryRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun deleteHistory(history: History): Result<Unit> = runCatching {
+    override suspend fun deleteHistory(history: History): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.historyDao.deleteHistory(historyMapper.toHistoryEntity(history)).also {
                 if (it == 0) throw Exception("Could not delete history in database.")

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/PermissionRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/PermissionRepositoryImpl.kt
@@ -9,6 +9,7 @@ package ua.acclorite.book_story.data.repository
 import android.app.Application
 import android.content.Intent
 import androidx.core.net.toUri
+import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.domain.repository.PermissionRepository
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -18,14 +19,14 @@ class PermissionRepositoryImpl @Inject constructor(
     private val application: Application
 ) : PermissionRepository {
 
-    override suspend fun grantPersistableUriPermission(uri: String): Result<Unit> = runCatching {
+    override suspend fun grantPersistableUriPermission(uri: String): Result<Unit> = runCatchingCancellable {
         application.contentResolver.takePersistableUriPermission(
             uri.toUri(),
             Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
         )
     }
 
-    override suspend fun releasePersistableUriPermission(uri: String): Result<Unit> = runCatching {
+    override suspend fun releasePersistableUriPermission(uri: String): Result<Unit> = runCatchingCancellable {
         application.contentResolver.releasePersistableUriPermission(
             uri.toUri(),
             Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION

--- a/app/src/main/java/ua/acclorite/book_story/data/service/CoverImageHandlerImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/service/CoverImageHandlerImpl.kt
@@ -14,6 +14,7 @@ import androidx.core.net.toFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import ua.acclorite.book_story.core.CoverImage
+import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.domain.service.CoverImageHandler
 import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream
@@ -29,7 +30,7 @@ class CoverImageHandlerImpl @Inject constructor(
     private val filesDir: File = application.filesDir
     private val coversDir = File(filesDir, "covers")
 
-    override suspend fun saveCover(coverImage: CoverImage): Result<File> = runCatching {
+    override suspend fun saveCover(coverImage: CoverImage): Result<File> = runCatchingCancellable {
         if (!coversDir.exists()) {
             coversDir.mkdirs()
         }
@@ -52,13 +53,13 @@ class CoverImageHandlerImpl @Inject constructor(
         cover
     }
 
-    override suspend fun deleteCover(coverImage: Uri): Result<Unit> = runCatching {
+    override suspend fun deleteCover(coverImage: Uri): Result<Unit> = runCatchingCancellable {
         coverImage.toFile().apply {
             if (exists() && !delete()) throw Exception("Couldn't delete cover image.")
         }
     }
 
-    override suspend fun compressCover(coverImage: CoverImage): Result<CoverImage> = runCatching {
+    override suspend fun compressCover(coverImage: CoverImage): Result<CoverImage> = runCatchingCancellable {
         val stream = ByteArrayOutputStream()
         coverImage.copy(Bitmap.Config.RGB_565, false)
             .compress(Bitmap.CompressFormat.WEBP, 20, stream)

--- a/app/src/main/java/ua/acclorite/book_story/data/service/FileProviderImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/service/FileProviderImpl.kt
@@ -7,6 +7,7 @@
 package ua.acclorite.book_story.data.service
 
 import android.app.Application
+import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.data.model.file.CachedFile
 import ua.acclorite.book_story.data.model.file.CachedFileCompat
 import ua.acclorite.book_story.domain.model.library.Book
@@ -17,7 +18,7 @@ class FileProviderImpl @Inject constructor(
     private val application: Application
 ) : FileProvider {
 
-    override fun getFileFromBook(book: Book): Result<CachedFile> = runCatching {
+    override fun getFileFromBook(book: Book): Result<CachedFile> = runCatchingCancellable {
         application.contentResolver.persistedUriPermissions.forEach { storage ->
             val storageFile = CachedFileCompat.fromUri(
                 application,
@@ -29,7 +30,7 @@ class FileProviderImpl @Inject constructor(
 
             storageFile.walk().forEach { file ->
                 if (book.filePath.equals(file.path, ignoreCase = true)) {
-                    return@runCatching file
+                    return@runCatchingCancellable file
                 }
             }
         }
@@ -37,7 +38,7 @@ class FileProviderImpl @Inject constructor(
         throw NoSuchElementException("Could not find file from book.")
     }
 
-    override fun getStorageFiles(): Result<List<CachedFile>> = runCatching {
+    override fun getStorageFiles(): Result<List<CachedFile>> = runCatchingCancellable {
         application.contentResolver.persistedUriPermissions.mapNotNull { permission ->
             val storage = CachedFileCompat.fromUri(
                 application,

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/CanResetCoverImageUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/CanResetCoverImageUseCase.kt
@@ -8,6 +8,7 @@ package ua.acclorite.book_story.domain.use_case.book
 
 import android.app.Application
 import android.graphics.BitmapFactory
+import ua.acclorite.book_story.core.helpers.mapCatchingCancellable
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.domain.repository.BookRepository
@@ -25,14 +26,14 @@ class CanResetCoverImageUseCase @Inject constructor(
     suspend operator fun invoke(bookId: Int): Boolean {
         logI(TAG, "Checking if can reset cover image of [$bookId].")
 
-        bookRepository.getBook(bookId).mapCatching { book ->
+        bookRepository.getBook(bookId).mapCatchingCancellable { book ->
             // Getting default cover image
             val defaultCoverImage = bookRepository.getDefaultCover(book).getOrThrow()
-                ?: return@mapCatching false
+                ?: return@mapCatchingCancellable false
 
             // Return true if current cover is null (and default is not)
             if (book.coverImage == null) {
-                return@mapCatching true
+                return@mapCatchingCancellable true
             }
 
             // Getting compressed cover images

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/GetTextUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/GetTextUseCase.kt
@@ -6,6 +6,7 @@
 
 package ua.acclorite.book_story.domain.use_case.book
 
+import ua.acclorite.book_story.core.helpers.mapCatchingCancellable
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.domain.model.reader.ParsedText
@@ -23,7 +24,7 @@ class GetTextUseCase @Inject constructor(
         logI(TAG, "Getting text from: [$bookId].")
         if (bookId == -1) return ParsedText.EMPTY
 
-        bookRepository.getText(bookId).mapCatching { parsedText ->
+        bookRepository.getText(bookId).mapCatchingCancellable { parsedText ->
             if (
                 parsedText.text.filterIsInstance<ReaderText.Text>().isEmpty() ||
                 parsedText.text.filterIsInstance<ReaderText.Chapter>().isEmpty()

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/ResetCoverImageUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/ResetCoverImageUseCase.kt
@@ -7,6 +7,7 @@
 package ua.acclorite.book_story.domain.use_case.book
 
 import androidx.core.net.toUri
+import ua.acclorite.book_story.core.helpers.mapCatchingCancellable
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.core.log.logW
@@ -24,7 +25,7 @@ class ResetCoverImageUseCase @Inject constructor(
     suspend operator fun invoke(bookId: Int): Boolean {
         logI(TAG, "Resetting cover image of [$bookId].")
 
-        bookRepository.getBook(bookId).mapCatching { book ->
+        bookRepository.getBook(bookId).mapCatchingCancellable { book ->
             // Getting default cover image
             val defaultCoverImage = bookRepository.getDefaultCover(book).getOrThrow()
                 ?: throw NoSuchElementException("Could not find default cover image")
@@ -40,7 +41,7 @@ class ResetCoverImageUseCase @Inject constructor(
             }
 
             book.copy(coverImage = newCoverImage.toUri())
-        }.mapCatching { newBook ->
+        }.mapCatchingCancellable { newBook ->
             bookRepository.updateBook(newBook).getOrThrow()
         }.fold(
             onSuccess = {

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/UpdateCoverImageUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/UpdateCoverImageUseCase.kt
@@ -8,6 +8,7 @@ package ua.acclorite.book_story.domain.use_case.book
 
 import androidx.core.net.toUri
 import ua.acclorite.book_story.core.CoverImage
+import ua.acclorite.book_story.core.helpers.mapCatchingCancellable
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.core.log.logW
@@ -25,7 +26,7 @@ class UpdateCoverImageUseCase @Inject constructor(
     suspend operator fun invoke(bookId: Int, coverImage: CoverImage?) {
         logI(TAG, "Updating cover image of [$bookId].")
 
-        bookRepository.getBook(bookId).mapCatching { book ->
+        bookRepository.getBook(bookId).mapCatchingCancellable { book ->
             if (book.coverImage == coverImage) return
 
             // Deleting old cover
@@ -39,7 +40,7 @@ class UpdateCoverImageUseCase @Inject constructor(
             }
 
             book.copy(coverImage = newCoverImage?.toUri())
-        }.mapCatching { newBook ->
+        }.mapCatchingCancellable { newBook ->
             bookRepository.updateBook(newBook).getOrThrow()
         }.fold(
             onSuccess = {

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/file_system/GetFilesUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/file_system/GetFilesUseCase.kt
@@ -7,6 +7,7 @@
 package ua.acclorite.book_story.domain.use_case.file_system
 
 import ua.acclorite.book_story.core.helpers.compareByWithOrder
+import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.data.settings.SettingsManager
@@ -55,7 +56,7 @@ class GetFilesUseCase @Inject constructor(
             )
         }
 
-        return runCatching {
+        return runCatchingCancellable {
             fileSystemRepository.searchFiles(query)
                 .getOrThrow()
                 .filterFiles()

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/history/GetHistoryUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/history/GetHistoryUseCase.kt
@@ -6,6 +6,7 @@
 
 package ua.acclorite.book_story.domain.use_case.history
 
+import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.domain.model.history.History
@@ -48,7 +49,7 @@ class GetHistoryUseCase @Inject constructor(
         }
 
         val query = query.lowercase().trim()
-        return runCatching {
+        return runCatchingCancellable {
             historyRepository.getHistory().getOrThrow()
                 .filter { history -> history.book.title.lowercase().trim().contains(query) }
                 .sortedByDescending { history -> history.time }


### PR DESCRIPTION
CancellationException is an ordinary Exception, so `catch (e: Exception)` and runCatching both capture it. The data layer did that in 33 catches and 51 runCatching sites, and mentioned CancellationException nowhere.

The visible shape of it: every text parser ends in

    } catch (e: Exception) {
        logE(TAG, "Could not parse text with message: ${e.message}.")
        ParsedText.EMPTY
    }

so a parse the reader walked away from was not cancelled, it was *an empty book*. Nothing above the parser could tell the two apart, and the coroutine ran on to the end of the function either way. #39 made the parse loop check ensureActive() on every item precisely so a cancelled parse stops at once; that only works if what it throws survives the trip back to the caller.

New core/helpers/CancellationHelpers.kt: `rethrowIfCancellation()` for the catch sites, `runCatchingCancellable`/`mapCatchingCancellable` for the Result-returning ones. A Result must never be able to hold a cancellation — a caller would log it as an error, retry it, or show it.

Applied where the code can actually be cancelled: the text, file and cover parsers, DocumentParser.loadImage, MarkdownParser.parse, and every runCatching in data/ and domain/. Deliberately not applied to ParseCache, ReaderImageFiles, CachedFile, BookImageLoader or the reference-id decode in MarkScanner: none of them suspend, so nothing there can throw a cancellation, and pretending otherwise would be noise. BookImageLoader is the interesting one — its blocking scan has nowhere to observe cancellation at all, which is why loadBookImages checks the job before publishing rather than relying on an exception.

Verified on the device (release-debug + AOT, cache cleared): opening the 5.6 MB book and pressing Back a second in now ends the log at the last phase mark, with no `getText:` line at all. Before, the chain ran to completion and logged chars=0. A full open, a cache write and a cache hit still behave exactly as before.

Closes #41