### PR TITLE
test: run the suite on the JVM so CI actually gates on it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,43 @@ jobs:
       - name: Assemble optimized APK (release-debug)
         run: ./gradlew ":app:assembleRelease-debug" --stacktrace
 
+      # Robolectric downloads its ~81 MB "android-all" jar at test time, into
+      # ~/.m2 rather than the Gradle caches, so setup-gradle does not cover it.
+      # The level it fetches is pinned in app/src/test/resources.
+      - name: Cache the Robolectric android-all jar
+        uses: actions/cache@v6
+        with:
+          path: ~/.m2/repository/org/robolectric
+          key: robolectric-${{ hashFiles('app/src/test/resources/robolectric.properties', 'app/build.gradle.kts') }}
+          restore-keys: robolectric-
+
       - name: Unit tests
         run: ./gradlew :app:testDebugUnitTest --stacktrace
+
+      # The step above fails the build on a failing test, but it is just as
+      # green when it runs *no* tests — which is what it did for months, because
+      # there was no app/src/test at all (#43). Count what actually ran.
+      - name: Verify the unit tests actually ran
+        shell: python3 {0}
+        run: |
+          import glob, sys, xml.etree.ElementTree as ET
+
+          reports = glob.glob("app/build/test-results/testDebugUnitTest/TEST-*.xml")
+          total = sum(int(ET.parse(f).getroot().get("tests", "0")) for f in reports)
+          print(f"{total} unit tests in {len(reports)} classes")
+          if total == 0:
+              print("::error::the unit test step ran zero tests")
+              sys.exit(1)
+
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-test-report
+          path: |
+            app/build/reports/tests/testDebugUnitTest
+            app/build/test-results/testDebugUnitTest
+          if-no-files-found: ignore
 
       - name: Lint
         run: ./gradlew :app:lintDebug --stacktrace

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -200,7 +200,17 @@ dependencies {
     // Json
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
 
-    // Instrumented tests
+    // JVM unit tests (app/src/test) — the suite CI runs. Robolectric supplies
+    // the handful of real Android APIs the parser reaches (Log, Base64,
+    // BitmapFactory); deliberately no `unitTests.isReturnDefaultValues`, so an
+    // Android call nothing has thought about still fails loudly instead of
+    // quietly returning null. The level Robolectric runs on is pinned in
+    // app/src/test/resources/robolectric.properties.
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.robolectric:robolectric:4.16.1")
+
+    // Instrumented tests (app/src/androidTest) — only what needs a device: real
+    // app storage and a real Context. Run by hand, not in CI.
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test:core:1.6.1")

--- a/app/src/test/java/ua/acclorite/book_story/data/cache/AnnotatedStringCodecTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/data/cache/AnnotatedStringCodecTest.kt
@@ -20,17 +20,14 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.em
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
 
 /**
  * Round-trips every span/link shape the parser emits through
  * [AnnotatedStringCodec] and asserts the result equals the original. The styles
  * below mirror [ua.acclorite.book_story.data.parser.document.MarkdownParser].
  */
-@RunWith(AndroidJUnit4::class)
 class AnnotatedStringCodecTest {
 
     private fun roundTrip(value: AnnotatedString) {

--- a/app/src/test/java/ua/acclorite/book_story/data/cache/ImageMemoryBudgetTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/data/cache/ImageMemoryBudgetTest.kt
@@ -6,14 +6,11 @@
 
 package ua.acclorite.book_story.data.cache
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
 
 /** Checks the tally that decides which images the reader keeps in memory. */
-@RunWith(AndroidJUnit4::class)
 class ImageMemoryBudgetTest {
 
     @Test

--- a/app/src/test/java/ua/acclorite/book_story/data/cache/ParsedTextCodecTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/data/cache/ParsedTextCodecTest.kt
@@ -19,17 +19,14 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.em
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
 import ua.acclorite.book_story.domain.model.reader.ParsedText
 import ua.acclorite.book_story.domain.model.reader.ReaderImage
 import ua.acclorite.book_story.domain.model.reader.ReaderText
 import ua.acclorite.book_story.domain.model.reader.ReaderTextRole
 import ua.acclorite.book_story.domain.model.reader.TableAlignment
 
-@RunWith(AndroidJUnit4::class)
 class ParsedTextCodecTest {
 
     @Test

--- a/app/src/test/java/ua/acclorite/book_story/data/parser/DocumentParserImageBytesTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/data/parser/DocumentParserImageBytesTest.kt
@@ -7,7 +7,6 @@
 
 package ua.acclorite.book_story.data.parser
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import org.commonmark.parser.Parser as CommonmarkParser
 import org.jsoup.Jsoup
@@ -16,6 +15,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import ua.acclorite.book_story.data.parser.document.DocumentParser
 import ua.acclorite.book_story.data.parser.document.MarkdownParser
 import ua.acclorite.book_story.domain.model.reader.ReaderText
@@ -26,7 +26,7 @@ import ua.acclorite.book_story.domain.model.reader.ReaderText
  * is cached and reused once images are turned back on) but must not hold on to
  * the encoded bytes, which are tens of MB on an image-heavy book.
  */
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
 class DocumentParserImageBytesTest {
 
     private val documentParser = DocumentParser(

--- a/app/src/test/java/ua/acclorite/book_story/data/parser/Fb2TitleParsingTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/data/parser/Fb2TitleParsingTest.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.BaselineShift
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import org.commonmark.parser.Parser as CommonmarkParser
 import org.jsoup.Jsoup
@@ -22,6 +21,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import ua.acclorite.book_story.data.parser.document.DocumentParser
 import ua.acclorite.book_story.data.parser.document.MarkdownParser
 import ua.acclorite.book_story.data.parser.text.markChapterTitles
@@ -32,7 +32,7 @@ import ua.acclorite.book_story.domain.model.reader.ReaderTextRole
  * FB2 <title> handling: a chapter title keeps its inline markup (and its
  * footnote references), while the chapter list keeps a plain title.
  */
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
 class Fb2TitleParsingTest {
 
     // The default builder enables every block type, while the app narrows them

--- a/app/src/test/java/ua/acclorite/book_story/data/parser/HtmlInlineTagsTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/data/parser/HtmlInlineTagsTest.kt
@@ -10,7 +10,6 @@ package ua.acclorite.book_story.data.parser
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import org.commonmark.parser.Parser as CommonmarkParser
 import org.jsoup.Jsoup
@@ -18,6 +17,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import ua.acclorite.book_story.data.parser.document.DocumentParser
 import ua.acclorite.book_story.data.parser.document.MarkdownParser
 import ua.acclorite.book_story.domain.model.reader.ReaderText
@@ -27,7 +27,7 @@ import ua.acclorite.book_story.domain.model.reader.ReaderText
  * parser only knew `<em>` and FB2's `<emphasis>` — so an EPUB converted from
  * print lost nearly all of its italics.
  */
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
 class HtmlInlineTagsTest {
 
     private val documentParser = DocumentParser(

--- a/app/src/test/java/ua/acclorite/book_story/data/parser/LiteralMarkdownCharsTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/data/parser/LiteralMarkdownCharsTest.kt
@@ -9,7 +9,6 @@ package ua.acclorite.book_story.data.parser
 
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import org.commonmark.parser.Parser as CommonmarkParser
 import org.jsoup.Jsoup
@@ -18,6 +17,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import ua.acclorite.book_story.data.parser.document.DocumentParser
 import ua.acclorite.book_story.data.parser.document.MarkdownParser
 import ua.acclorite.book_story.data.parser.text.markChapterTitles
@@ -29,7 +29,7 @@ import ua.acclorite.book_story.domain.model.reader.ReaderText
  * the text, which deleted the book's own asterisks and underscores along with
  * its own leftovers — "(*)" came out as "()".
  */
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
 class LiteralMarkdownCharsTest {
 
     // The default builder enables every block type, while the app narrows them

--- a/app/src/test/java/ua/acclorite/book_story/data/parser/TableAlignmentParsingTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/data/parser/TableAlignmentParsingTest.kt
@@ -6,7 +6,6 @@
 
 package ua.acclorite.book_story.data.parser
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import org.commonmark.parser.Parser as CommonmarkParser
 import org.jsoup.Jsoup
@@ -14,6 +13,7 @@ import org.jsoup.parser.Parser
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import ua.acclorite.book_story.data.parser.document.DocumentParser
 import ua.acclorite.book_story.data.parser.document.MarkdownParser
 import ua.acclorite.book_story.domain.model.reader.ReaderText
@@ -23,7 +23,7 @@ import ua.acclorite.book_story.domain.model.reader.TableAlignment
  * Per-column table alignment reaches the model from both sources: the markdown
  * delimiter row and the `align`/`text-align` of an FB2/HTML cell.
  */
-@RunWith(AndroidJUnit4::class)
+@RunWith(RobolectricTestRunner::class)
 class TableAlignmentParsingTest {
 
     private val documentParser = DocumentParser(

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/reader/BookImageStoreTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/reader/BookImageStoreTest.kt
@@ -7,16 +7,13 @@
 
 package ua.acclorite.book_story.domain.model.reader
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import java.io.File
 
-@RunWith(AndroidJUnit4::class)
 class BookImageStoreTest {
 
     private lateinit var store: BookImageStore

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/reader/ColorPresetResolverTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/reader/ColorPresetResolverTest.kt
@@ -8,13 +8,10 @@
 package ua.acclorite.book_story.domain.model.reader
 
 import androidx.compose.ui.graphics.Color
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
 
 /** Unit-style checks for [activeColorPreset] (the theme-aware resolver). */
-@RunWith(AndroidJUnit4::class)
 class ColorPresetResolverTest {
 
     private val dark = ColorPreset(

--- a/app/src/test/java/ua/acclorite/book_story/ui/reader/ImageViewerTransformTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/ui/reader/ImageViewerTransformTest.kt
@@ -8,15 +8,12 @@ package ua.acclorite.book_story.ui.reader
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
 
 /** Unit-style checks for the full-screen image viewer's zoom/pan geometry. */
-@RunWith(AndroidJUnit4::class)
 class ImageViewerTransformTest {
 
     private val container = Size(1000f, 2000f)

--- a/app/src/test/java/ua/acclorite/book_story/ui/reader/TableColumnWidthsTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/ui/reader/TableColumnWidthsTest.kt
@@ -6,15 +6,12 @@
 
 package ua.acclorite.book_story.ui.reader
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
 
 /** Unit-style checks for [resolveColumnWidths], the table column sizer. */
-@RunWith(AndroidJUnit4::class)
 class TableColumnWidthsTest {
 
     @Test

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,0 +1,9 @@
+# Pin the Android level the JVM tests run on.
+#
+# Left to itself Robolectric takes the level from targetSdk (36), finds that
+# SDK 36 needs Java 21 while the toolchain is Java 17, prints a warning and
+# silently falls back to API 23 — below the app's own minSdk of 26. Pin it
+# instead: 34 is the newest level Robolectric runs on Java 17.
+#
+# Raise this to 36 once the build moves to Java 21 (here and in CI).
+sdk=34


### PR DESCRIPTION
Closes #43.

CI's `Unit tests` step ran against a source set that did not exist. It was green having executed **zero tests**; all 139 lived in `androidTest` and needed a device.

## What moved

**12 files → `app/src/test`, 95 tests, ~5 s.** `AnnotatedStringCodecTest`, `ParsedTextCodecTest`, `ImageMemoryBudgetTest`, `Fb2TitleParsingTest`, `LiteralMarkdownCharsTest`, `HtmlInlineTagsTest`, `TableAlignmentParsingTest`, `DocumentParserImageBytesTest`, `BookImageStoreTest`, `ColorPresetResolverTest`, `TableColumnWidthsTest`, `ImageViewerTransformTest`.

**4 files stay in `androidTest`, 44 tests** — they need real app storage and a real `Context`: `ParseCacheTest`, `ReaderImageFilesTest`, `EmptyDocumentGuardTest`, `BookImageLoaderTest`. Still run by hand; `:app:assembleDebugAndroidTest` still builds.

Done with `git mv`, so the history follows.

## Robolectric, and why not `isReturnDefaultValues`

Compose `AnnotatedString`/`SpanStyle`/`Color`/`Offset` are pure JVM and need nothing. The only real Android APIs the moved set reaches are `android.util.Log` (through `core/log/Log.kt`, in the four parser tests) and `Base64` + `BitmapFactory` (in `DocumentParserImageBytesTest`).

`testOptions { unitTests.isReturnDefaultValues = true }` would have avoided a dependency, and it was tried — but it makes *every* `android.jar` method silently return `null`/`0`. With it on, `DocumentParserImageBytesTest` did not say "Base64 not mocked"; it threw a bare `NoSuchElementException`, because the image had quietly vanished from the parse. So: Robolectric on the five files that touch Android, plain JUnit on the other seven, and no blanket default-values switch — an Android call nobody thought about still fails loudly.

### The pin matters

Left to itself Robolectric takes its level from `targetSdk` (36), finds SDK 36 needs Java 21 against a Java 17 toolchain, prints a warning, and **silently runs on API 23 — below the app's `minSdk` of 26**. `app/src/test/resources/robolectric.properties` pins `sdk=34`; verified `Build.VERSION.SDK_INT == 34`.

## CI

- **Zero-test guard.** The step fails the build on a failing test, but is equally green on no tests — the exact hole this PR closes. A step now reads the JUnit XML and fails when the total is 0. Checked both ways.
- **Test report uploaded on failure**, so a red run is readable without reproducing locally.
- **`~/.m2/repository/org/robolectric` cached** — the 81 MB `android-all` jar is fetched at test time, outside the Gradle caches.

## Verified

- `:app:testDebugUnitTest` — **95 tests, 0 failures**, 5.3 s (`--rerun-tasks`).
- `:app:assembleDebugAndroidTest` — the remaining 4 files still compile and package.
- `:app:lintDebug` — green; no new warnings beyond the usual `NewerVersionAvailable` for the two added dependencies.
- **The suite still detects breakage, not just green-on-move**: mutating `resolveColumnWidths` to hand out half the spare width failed 7 of its 9 tests; the earlier `Log`-throwing run failed 37 loudly. Both mutations reverted.
