### PR TITLE
fix: give the cache format its own codes instead of enum ordinals

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/data/cache/ParsedTextCodec.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/cache/ParsedTextCodec.kt
@@ -45,6 +45,21 @@ object ParsedTextCodec {
     private const val TYPE_SEPARATOR = 4
     private const val TYPE_IMAGE = 5
 
+    // Roles and alignments go on the wire as these codes, NOT as `ordinal`:
+    // the enums live in the domain layer, which has no reason to know that
+    // reordering its members would reinterpret every cached book. Codes are
+    // frozen — a new member takes the next free number, and the `when`s below
+    // stop compiling until it gets one.
+    private const val ROLE_PARAGRAPH = 0
+    private const val ROLE_TITLE = 1
+    private const val ROLE_EPIGRAPH = 2
+    private const val ROLE_TEXT_AUTHOR = 3
+
+    private const val ALIGN_UNSPECIFIED = 0
+    private const val ALIGN_START = 1
+    private const val ALIGN_CENTER = 2
+    private const val ALIGN_END = 3
+
     fun encode(parsed: ParsedText, out: DataOutput) {
         out.writeInt(VERSION)
 
@@ -118,7 +133,9 @@ object ParsedTextCodec {
                     row.forEach { cell -> AnnotatedStringCodec.encode(cell, out) }
                 }
                 out.writeInt(element.alignments.size)
-                element.alignments.forEach { alignment -> out.writeByte(alignment.ordinal) }
+                element.alignments.forEach { alignment ->
+                    out.writeByte(alignmentCode(alignment))
+                }
             }
 
             is ReaderText.Separator -> out.writeByte(TYPE_SEPARATOR)
@@ -174,7 +191,7 @@ object ParsedTextCodec {
                 val alignmentCount = input.readInt()
                 val alignments = ArrayList<TableAlignment>(alignmentCount)
                 repeat(alignmentCount) {
-                    alignments.add(TableAlignment.entries[input.readByte().toInt()])
+                    alignments.add(alignmentOf(input.readByte().toInt()))
                 }
                 ReaderText.Table(rows = rows, hasHeader = hasHeader, alignments = alignments)
             }
@@ -205,12 +222,42 @@ object ParsedTextCodec {
     }
 
     private fun encodeText(text: ReaderText.Text, out: DataOutput) {
-        out.writeByte(text.role.ordinal)
+        out.writeByte(roleCode(text.role))
         AnnotatedStringCodec.encode(text.line, out)
     }
 
     private fun decodeText(input: DataInput): ReaderText.Text {
-        val role = ReaderTextRole.entries[input.readByte().toInt()]
+        val role = roleOf(input.readByte().toInt())
         return ReaderText.Text(line = AnnotatedStringCodec.decode(input), role = role)
+    }
+
+    private fun roleCode(role: ReaderTextRole): Int = when (role) {
+        ReaderTextRole.Paragraph -> ROLE_PARAGRAPH
+        ReaderTextRole.Title -> ROLE_TITLE
+        ReaderTextRole.Epigraph -> ROLE_EPIGRAPH
+        ReaderTextRole.TextAuthor -> ROLE_TEXT_AUTHOR
+    }
+
+    private fun roleOf(code: Int): ReaderTextRole = when (code) {
+        ROLE_PARAGRAPH -> ReaderTextRole.Paragraph
+        ROLE_TITLE -> ReaderTextRole.Title
+        ROLE_EPIGRAPH -> ReaderTextRole.Epigraph
+        ROLE_TEXT_AUTHOR -> ReaderTextRole.TextAuthor
+        else -> throw IllegalArgumentException("Unknown ReaderTextRole code: $code")
+    }
+
+    private fun alignmentCode(alignment: TableAlignment): Int = when (alignment) {
+        TableAlignment.Unspecified -> ALIGN_UNSPECIFIED
+        TableAlignment.Start -> ALIGN_START
+        TableAlignment.Center -> ALIGN_CENTER
+        TableAlignment.End -> ALIGN_END
+    }
+
+    private fun alignmentOf(code: Int): TableAlignment = when (code) {
+        ALIGN_UNSPECIFIED -> TableAlignment.Unspecified
+        ALIGN_START -> TableAlignment.Start
+        ALIGN_CENTER -> TableAlignment.Center
+        ALIGN_END -> TableAlignment.End
+        else -> throw IllegalArgumentException("Unknown TableAlignment code: $code")
     }
 }

--- a/app/src/test/java/ua/acclorite/book_story/data/cache/ParsedTextCodecTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/data/cache/ParsedTextCodecTest.kt
@@ -20,12 +20,14 @@ import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.em
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import ua.acclorite.book_story.domain.model.reader.ParsedText
 import ua.acclorite.book_story.domain.model.reader.ReaderImage
 import ua.acclorite.book_story.domain.model.reader.ReaderText
 import ua.acclorite.book_story.domain.model.reader.ReaderTextRole
 import ua.acclorite.book_story.domain.model.reader.TableAlignment
+import java.util.UUID
 
 class ParsedTextCodecTest {
 
@@ -150,6 +152,163 @@ class ParsedTextCodecTest {
 
         roundTrip(parsed)
     }
+
+    // --- the enum codes on the wire ---
+    //
+    // A round trip cannot defend these: it encodes and decodes with the same
+    // enum in the same process, so `Title` -> 1 -> `Title` holds however the
+    // members are ordered. The damage only appears across a version boundary —
+    // bytes written by yesterday's build, read by today's — which is why the
+    // format is pinned below rather than merely round-tripped.
+
+    @Test
+    fun everyRoleRoundTrips() {
+        // Iterates `entries`, so a role added later is covered without an edit.
+        ReaderTextRole.entries.forEach { role ->
+            val parsed = ParsedText(
+                text = listOf(ReaderText.Text(AnnotatedString("x"), role)),
+                notes = emptyMap()
+            )
+            val restored = ParsedTextCodec.decodeFromBytes(ParsedTextCodec.encodeToBytes(parsed))
+            assertEquals(role, (restored.text.single() as ReaderText.Text).role)
+        }
+    }
+
+    @Test
+    fun everyAlignmentRoundTrips() {
+        val parsed = ParsedText(
+            text = listOf(
+                ReaderText.Table(
+                    rows = emptyList(),
+                    hasHeader = false,
+                    alignments = TableAlignment.entries
+                )
+            ),
+            notes = emptyMap()
+        )
+        val restored = ParsedTextCodec.decodeFromBytes(ParsedTextCodec.encodeToBytes(parsed))
+        assertEquals(TableAlignment.entries, (restored.text.single() as ReaderText.Table).alignments)
+    }
+
+    /**
+     * The whole wire format, frozen. Guards the element type bytes, the field
+     * order and — the reason this test exists — the numeric code of every role
+     * and alignment, none of which any round trip can see.
+     *
+     * **If this fails and you changed the format on purpose:** bump
+     * `ParsedTextCodec.VERSION` *and* `ParseCache.VERSION` so stale entries are
+     * ignored rather than misread, then paste the new bytes in below.
+     */
+    @Test
+    fun theWireFormatIsFrozen() {
+        val expected = (
+            "000000030000000a006cca978a00004000800000000000000100016300000001" +
+                "0100000001730000000000000000010000000001700000000000000000010100" +
+                "0000017400000000000000000102000000016500000000000000000103000000" +
+                "0161000000000000000004020000000100000000017600000000000000000301" +
+                "0000000100000002000000013100000000000000000000000132000000000000" +
+                "00000000000400010203050001690005692e706e670000000300000002010000" +
+                "0000016b00000000000000000500016a00056a2e706e67000000010000000100" +
+                "0000000100016e000000046e6f74650000000000000000"
+            )
+
+        val actual = ParsedTextCodec.encodeToBytes(wireFixture())
+            .joinToString("") { byte -> "%02x".format(byte) }
+
+        assertEquals("wire format changed — see this test's doc comment", expected, actual)
+        // And the bytes still mean what they say.
+        assertParsedTextEquals(wireFixture(), ParsedTextCodec.decodeFromBytes(actual.hexToBytes()))
+    }
+
+    @Test
+    fun anUnknownRoleCodeIsRejected() {
+        // VERSION (4 bytes) + element count (4) + the TYPE_TEXT tag (1).
+        val bytes = ParsedTextCodec.encodeToBytes(
+            ParsedText(
+                text = listOf(ReaderText.Text(AnnotatedString("x"), ReaderTextRole.Title)),
+                notes = emptyMap()
+            )
+        )
+        assertEquals("role byte offset", 1, bytes[9].toInt())
+
+        bytes[9] = 99
+        // Must throw rather than return something plausible: ParseCache.read
+        // turns an exception into a clean miss, and a wrong role into a book
+        // that renders wrong.
+        assertThrows(IllegalArgumentException::class.java) {
+            ParsedTextCodec.decodeFromBytes(bytes)
+        }
+    }
+
+    @Test
+    fun anUnknownAlignmentCodeIsRejected() {
+        // ... + hasHeader (1) + row count (4) + alignment count (4).
+        val bytes = ParsedTextCodec.encodeToBytes(
+            ParsedText(
+                text = listOf(
+                    ReaderText.Table(
+                        rows = emptyList(),
+                        hasHeader = false,
+                        alignments = listOf(TableAlignment.Start)
+                    )
+                ),
+                notes = emptyMap()
+            )
+        )
+        assertEquals("alignment byte offset", 1, bytes[18].toInt())
+
+        bytes[18] = 99
+        assertThrows(IllegalArgumentException::class.java) {
+            ParsedTextCodec.decodeFromBytes(bytes)
+        }
+    }
+
+    /**
+     * Every element type, role and alignment exactly once, and nothing that
+     * could drift: plain [AnnotatedString]s, a fixed chapter id.
+     *
+     * Members are listed by hand rather than read from `entries` on purpose —
+     * **appending** an enum member is backwards compatible and must not disturb
+     * the frozen bytes. The two round-trip tests above cover a new member.
+     */
+    private fun wireFixture() = ParsedText(
+        text = listOf(
+            ReaderText.Chapter(
+                id = UUID.fromString("6cca978a-0000-4000-8000-000000000001"),
+                title = "c",
+                depth = 1,
+                styledTitle = AnnotatedString("s")
+            ),
+            ReaderText.Text(AnnotatedString("p"), ReaderTextRole.Paragraph),
+            ReaderText.Text(AnnotatedString("t"), ReaderTextRole.Title),
+            ReaderText.Text(AnnotatedString("e"), ReaderTextRole.Epigraph),
+            ReaderText.Text(AnnotatedString("a"), ReaderTextRole.TextAuthor),
+            ReaderText.Separator,
+            ReaderText.Poem(lines = listOf(ReaderText.Text(AnnotatedString("v")))),
+            ReaderText.Table(
+                rows = listOf(listOf(AnnotatedString("1"), AnnotatedString("2"))),
+                hasHeader = true,
+                alignments = listOf(
+                    TableAlignment.Unspecified,
+                    TableAlignment.Start,
+                    TableAlignment.Center,
+                    TableAlignment.End
+                )
+            ),
+            ReaderText.Image(
+                image = ReaderImage(id = "i", src = "i.png", bytes = byteArrayOf(7), width = 3, height = 2),
+                caption = ReaderText.Text(AnnotatedString("k"))
+            ),
+            ReaderText.Image(
+                image = ReaderImage(id = "j", src = "j.png", bytes = ByteArray(0), width = 1, height = 1),
+                caption = null
+            )
+        ),
+        notes = mapOf("n" to AnnotatedString("note"))
+    )
+
+    private fun String.hexToBytes() =
+        ByteArray(length / 2) { i -> substring(i * 2, i * 2 + 2).toInt(16).toByte() }
 
     // --- helpers: compare the render-relevant contract, not order-sensitive equals ---
 


### PR DESCRIPTION
Closes #45.

`ParsedTextCodec` wrote a paragraph's role and a table column's alignment as `ordinal`, and read them back as `entries[ordinal]` — so the cache's on-disk format embedded the declaration order of two enums living in `ReaderText.kt`, a domain file with no reason to know it was defining a byte layout.

## The silent case

Add a heading role next to `Title`, as the fix for #34 naturally would:

```
Paragraph, Title, Heading, Epigraph, TextAuthor
```

Every cached `Epigraph` (2) now decodes as `Heading`, every `TextAuthor` (3) as `Epigraph`. The file is well-formed, `require(version == VERSION)` passes, `ParseCache.read` throws nothing — previously-cached books just render with shuffled roles. Removing a member at least throws; appending and renaming are safe.

**No test could have caught this.** A round trip is symmetric — `Title` → 1 → `Title`, same process, same enum — so it stays green through any reordering. The corruption exists only across a version boundary: bytes written by yesterday's build, read by today's. And the two `VERSION` constants are bumped by hand, which a pure reorder gives nobody a reason to do — an alphabetise, an IDE "sort members", a merge of two branches that both touched the enum.

## The fix was already in the file

`ReaderText`'s subtypes go on the wire as explicit constants (`TYPE_CHAPTER = 0` …), not as positions. The codec was simply inconsistent with itself. Roles and alignments now get the same treatment: an explicit `when` in both directions over frozen constants. Reordering means nothing; adding or removing a member stops compiling.

The codes equal today's ordinals, so **the wire format is byte-identical and no `ParseCache.VERSION` bump is needed** — existing cache entries stay readable.

## Verified

The format claim is measured, not assumed: the fixture's encoding was captured from the **unchanged** codec, then re-captured after the change — 247 bytes, identical.

Four experiments, each reverted afterwards:

| | expected | result |
|---|---|---|
| **a.** reorder the enum, new codec | golden unchanged — order no longer matters | ✅ passed |
| **b.** reorder the enum, old `ordinal` codec | golden fails | ✅ failed, showing `Title` written as `02` instead of `01` and `Epigraph` the other way — the exact silent swap |
| **c.** change `ROLE_TITLE` from 1 to 5 | golden fails | ✅ failed |
| **d.** append a `Heading` member | compile error | ✅ `'when' expression must be exhaustive. Add the 'Heading' branch` |

(b) is the one that matters: it demonstrates the bug was real, not theoretical.

Suite: **100 JVM tests, 0 failures** (was 95); `lintDebug` green.

## The tests

- `everyRoleRoundTrips` / `everyAlignmentRoundTrips` — iterate `entries`, so a member added later is covered without editing the test.
- `theWireFormatIsFrozen` — golden bytes over a fixture containing every element type, every role and every alignment exactly once. This is the only test that can see what a round trip cannot. Its doc comment says what to do when it fails: if the format changed on purpose, bump `ParsedTextCodec.VERSION` *and* `ParseCache.VERSION`, then update the literal. The fixture lists members by hand rather than reading `entries`, so a safe append does not raise a false alarm.
- `anUnknownRoleCodeIsRejected` / `anUnknownAlignmentCodeIsRejected` — an out-of-range code must throw, so `ParseCache.read` turns it into a clean miss rather than into data.

Also closes a coverage gap: `ReaderTextRole.Epigraph` and `TableAlignment.Start` were exercised by no test at all.
