### PR TITLE
perf: resolve a book's file once per open, not once per pass

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
@@ -18,6 +18,7 @@ import ua.acclorite.book_story.data.cache.ImageMemoryBudget
 import ua.acclorite.book_story.data.cache.ParseCache
 import ua.acclorite.book_story.data.cache.ReaderImageFiles
 import ua.acclorite.book_story.data.local.room.BookDatabase
+import ua.acclorite.book_story.data.model.file.CachedFile
 import ua.acclorite.book_story.data.settings.SettingsManager
 import ua.acclorite.book_story.data.mapper.book.BookMapper
 import ua.acclorite.book_story.data.mapper.file.FileMapper
@@ -49,6 +50,25 @@ class BookRepositoryImpl @Inject constructor(
     private val settings: SettingsManager
 ) : BookRepository {
 
+    /** The book, and the file [getText] resolved for it. */
+    private data class OpenedBookFile(val bookId: Int, val file: CachedFile)
+
+    /**
+     * What the last [getText] resolved. [loadBookImages] runs a moment later for
+     * the same book, and resolving it again is not free: [FileProvider] finds a
+     * book by walking every persisted SAF tree, a ContentResolver query per
+     * directory and the largest named step of an open, and for EPUB a second
+     * [CachedFile] means a second copy of the whole book, since
+     * [CachedFile.rawFile] is a per-instance `lazy`.
+     *
+     * Deliberately one entry rather than a cache keyed by path. It is read only by
+     * the image pass that follows the open that wrote it, so it cannot serve a
+     * stale grant or a path the user has since edited — the next open overwrites
+     * it, and every other caller still asks [FileProvider].
+     */
+    @Volatile
+    private var lastOpenedFile: OpenedBookFile? = null
+
     override suspend fun searchBooks(query: String): Result<List<Book>> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             database.bookDao.searchBooks(query).map { bookMapper.toBook(it) }
@@ -72,7 +92,7 @@ class BookRepositoryImpl @Inject constructor(
                     // a ContentResolver query per directory — hence timed on its own.
                     timed("  open: find file") {
                         fileProvider.getFileFromBook(book).getOrThrow()
-                    }
+                    }.also { lastOpenedFile = OpenedBookFile(bookId, it) }
                 }
                 .mapCatchingCancellable { cachedFile ->
                     // A size-cap of 0 means the parse cache is disabled entirely.
@@ -175,8 +195,7 @@ class BookRepositoryImpl @Inject constructor(
             // has to check for itself, or it would keep writing files into a
             // directory the closing reader has just deleted.
             val pass = coroutineContext.job
-            getBook(bookId)
-                .mapCatchingCancellable { fileProvider.getFileFromBook(it).getOrThrow() }
+            resolveOpenedFile(bookId)
                 .mapCatchingCancellable { cachedFile ->
                     val capMb = settings.parseCacheSizeMb.lastValue
                     val maxBytes = capMb.toLong() * 1024 * 1024
@@ -230,6 +249,21 @@ class BookRepositoryImpl @Inject constructor(
                         cachedFile.path, cachedFile.size, cachedFile.lastModified, maxBytes
                     )
                 }
+        }
+    }
+
+    /**
+     * The book's file for the image pass: the one the open resolved a moment ago
+     * when it is the same book, and the ordinary walk otherwise — the reader can be
+     * entered by a restored back stack, which this process never opened.
+     */
+    private suspend fun resolveOpenedFile(bookId: Int): Result<CachedFile> {
+        lastOpenedFile?.takeIf { it.bookId == bookId }?.let { opened ->
+            bookTimingNote { "images: reused the file the open resolved" }
+            return Result.success(opened.file)
+        }
+        return getBook(bookId).mapCatchingCancellable {
+            timed("  images: find file") { fileProvider.getFileFromBook(it).getOrThrow() }
         }
     }
 


### PR DESCRIPTION
Part of #36 — the first of its two parts. Stops the second SAF tree walk per open; the walk itself is left alone for the follow-up.

## What it does

`BookRepositoryImpl.loadBookImages` began with `getBook(bookId)` → `getFileFromBook(it)`, building a second `CachedFile` for the book `getText` had resolved a moment earlier. `FileProvider` resolves a book by walking every persisted SAF tree — one ContentResolver query per directory — so every open of a book with images did that twice.

The repository now remembers what the last `getText` resolved and hands it to the image pass. One entry, not a cache keyed by path: it is only ever read by the pass that follows the open that wrote it, so it cannot serve a revoked grant or a path the user has since edited in the book-info dialog. Every other caller resolves exactly as before, and a reader entered by a restored back stack — no open behind it — falls through to the ordinary walk, now timed on its own as `images: find file`.

## Device QA — Lenovo TB128FU, release-debug + AOT

Installed in place over the reading build (`firstInstallTime` unchanged), AOT forced.

| Run | walk | second walk | copies |
|---|---|---|---|
| 33 MB FB2, 75 images — cache hit | `open: find file: 210 ms` | none, `images: reused the file the open resolved` | — |
| 9 KB EPUB, 3 images — cache miss | `open: find file: 152 ms` | none, reused | one (`copy book: 22 ms`, the parse) |
| same EPUB — cache hit | `open: find file: 199 ms` | none, reused | one (`copy book: 50 ms`, the image pass) |

Images render in both books; the FB2 artwork and the EPUB image-only chapter (08) both draw. First frame 574 / 459 / 368 ms.

## Two corrections this produced

- **The walk is dearer than recorded.** 152–210 ms today against the 110–150 ms in #36. Same device, same books — the library has grown. Cost scales with the directory count, which is the argument for the second part of #36.
- **The EPUB double copy the code review predicted is not reachable in practice.** With reader images on, a fresh parse already carries every image's bytes, so the pass has nothing to scan and never touches `rawFile`; on a cache hit there is no earlier copy to reuse. Both runs above show exactly one copy, never two. What the runs *do* show is the copy on the **cache-hit** path — `copy book: 50 ms` after the first frame, with `cacheImagesInBooks` at its default `false`. That is the real finding, and it is written up in #36.

## Not covered by tests

`BookRepositoryImpl` has no unit test — it needs Room and Hilt, and the four instrumented test files that touch storage would wipe the SAF grant. The behaviour under change is a timing property visible only in `BookTiming`, so the evidence is the QA table above. `lintDebug` green, `testDebugUnitTest` 100 tests / 0 failures.
