### PR TITLE
perf: find a book by descending its path, not by walking the SAF tree

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/data/service/FileProviderImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/service/FileProviderImpl.kt
@@ -23,6 +23,14 @@ class FileProviderImpl @Inject constructor(
         val storages = application.contentResolver.persistedUriPermissions
             .map { permission -> CachedFileCompat.fromUri(application, permission.uri) }
             .filter { it.isDirectory }
+            // Deepest root first. Roots from different providers can be prefixes of
+            // one another — Google Drive reports "/storage" for a Drive folder,
+            // which prefixes every path on the device — and the shallow one then
+            // matches books it does not hold, costing a listing before the tree
+            // that does. For a cloud provider that listing is a network round trip:
+            // measured 379 ms against 101 ms for the same book with the deepest
+            // root tried first.
+            .sortedByDescending { it.path.length }
 
         storages.forEach { storage ->
             val segments = pathSegmentsUnder(storage.path, book.filePath) ?: return@forEach

--- a/app/src/main/java/ua/acclorite/book_story/data/service/FileProviderImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/service/FileProviderImpl.kt
@@ -8,6 +8,7 @@ package ua.acclorite.book_story.data.service
 
 import android.app.Application
 import ua.acclorite.book_story.core.helpers.runCatchingCancellable
+import ua.acclorite.book_story.core.log.bookTimingNote
 import ua.acclorite.book_story.data.model.file.CachedFile
 import ua.acclorite.book_story.data.model.file.CachedFileCompat
 import ua.acclorite.book_story.domain.model.library.Book
@@ -19,16 +20,34 @@ class FileProviderImpl @Inject constructor(
 ) : FileProvider {
 
     override fun getFileFromBook(book: Book): Result<CachedFile> = runCatchingCancellable {
-        application.contentResolver.persistedUriPermissions.forEach { storage ->
-            val storageFile = CachedFileCompat.fromUri(
-                application,
-                storage.uri
-            )
+        val storages = application.contentResolver.persistedUriPermissions
+            .map { permission -> CachedFileCompat.fromUri(application, permission.uri) }
+            .filter { it.isDirectory }
 
-            if (!storageFile.isDirectory) return@forEach
-            if (!book.filePath.startsWith(storageFile.path, ignoreCase = true)) return@forEach
+        storages.forEach { storage ->
+            val segments = pathSegmentsUnder(storage.path, book.filePath) ?: return@forEach
+            storage.descend(segments)?.let { return@runCatchingCancellable it }
+        }
 
-            storageFile.walk().forEach { file ->
+        // Three things the descent cannot follow, all of them properties of a
+        // particular documents provider rather than of SAF: a display name
+        // containing '/', which it would split into two segments; two children of
+        // one directory sharing a name, where it commits to the first while a walk
+        // enumerates both subtrees; and a tree whose root reports no path at all,
+        // which leaves no route to split. None is reachable on external storage,
+        // and none can be tested against a single provider, so the walk stays as
+        // the fallback at the price every open used to pay, in the case that would
+        // otherwise fail outright.
+        //
+        // The condition below is the *old* one, deliberately looser than the
+        // descent's: a root with no path composes its children as "/<name>" and the
+        // import wrote exactly that into the book row, so the walk still matches
+        // where the descent had nothing to follow. A fallback that filters more
+        // than what it falls back from is not a fallback.
+        bookTimingNote { "find file: descent found nothing, walking the tree" }
+        storages.forEach { storage ->
+            if (!book.filePath.startsWith(storage.path, ignoreCase = true)) return@forEach
+            storage.walk().forEach { file ->
                 if (book.filePath.equals(file.path, ignoreCase = true)) {
                     return@runCatchingCancellable file
                 }
@@ -36,6 +55,28 @@ class FileProviderImpl @Inject constructor(
         }
 
         throw NoSuchElementException("Could not find file from book.")
+    }
+
+    /**
+     * Walks [segments] down from this directory, one ContentResolver query per
+     * level, and returns the file they name — or null if any level is missing, is
+     * not a directory where the route needs one, or the route ends on a directory.
+     *
+     * Each child arrives from the directory cursor with its name already filled in,
+     * so matching a segment costs nothing beyond the listing itself.
+     */
+    private fun CachedFile.descend(segments: List<String>): CachedFile? {
+        var current = this
+        segments.forEachIndexed { index, segment ->
+            val child = current.listFiles().firstOrNull {
+                it.name.equals(segment, ignoreCase = true)
+            } ?: return null
+
+            if (index == segments.lastIndex) return child.takeIf { !it.isDirectory }
+            if (!child.isDirectory) return null
+            current = child
+        }
+        return null
     }
 
     override fun getStorageFiles(): Result<List<CachedFile>> = runCatchingCancellable {
@@ -58,4 +99,36 @@ class FileProviderImpl @Inject constructor(
             }
         }
     }
+}
+
+/**
+ * The route from [rootPath] down to [filePath] — one display name per element — or
+ * null when [filePath] does not name something under [rootPath].
+ *
+ * This is what lets a book be found by descending instead of by enumerating: a
+ * [CachedFile]'s path is composed as `<parent>/<display name>`, so the segments of
+ * a path and the names in a directory listing are the same strings by
+ * construction.
+ *
+ * Deliberately strict — a route it refuses is a route the walk would not have
+ * matched either, since the walk compares against those same composed paths. In
+ * particular a prefix only counts when it ends on a separator, so a tree at
+ * `/Books` does not claim `/BooksOld/novel.fb2`; the old code compared prefixes
+ * without that boundary and was saved only by the full-path comparison that
+ * followed.
+ */
+internal fun pathSegmentsUnder(rootPath: String, filePath: String): List<String>? {
+    val root = rootPath.trim().trimEnd('/')
+    val path = filePath.trim().trimEnd('/')
+
+    if (root.isEmpty() || path.length <= root.length) return null
+    if (!path.startsWith(root, ignoreCase = true)) return null
+    if (path[root.length] != '/') return null
+
+    val segments = path.substring(root.length + 1).split('/')
+    // An empty segment means a path no listing can produce ("a//b"), so there is
+    // nothing to descend to.
+    if (segments.any { it.isBlank() }) return null
+
+    return segments
 }

--- a/app/src/test/java/ua/acclorite/book_story/data/service/PathSegmentsUnderTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/data/service/PathSegmentsUnderTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The string half of finding a book by descending its path rather than walking the
+ * whole SAF tree. The traversal itself needs a documents provider; this does not,
+ * and it is where the mistakes live.
+ */
+class PathSegmentsUnderTest {
+
+    @Test
+    fun `nested path yields one segment per level`() {
+        assertEquals(
+            listOf("Books", "Lem", "solaris.fb2"),
+            pathSegmentsUnder("/storage/emulated/0", "/storage/emulated/0/Books/Lem/solaris.fb2")
+        )
+    }
+
+    @Test
+    fun `file directly in the tree root yields one segment`() {
+        assertEquals(
+            listOf("solaris.fb2"),
+            pathSegmentsUnder("/storage/emulated/0/Books", "/storage/emulated/0/Books/solaris.fb2")
+        )
+    }
+
+    @Test
+    fun `path outside the tree is refused`() {
+        assertNull(pathSegmentsUnder("/storage/emulated/0/Books", "/storage/emulated/0/Docs/a.fb2"))
+    }
+
+    /** The boundary the old prefix check was missing. */
+    @Test
+    fun `a longer sibling directory is not a child`() {
+        assertNull(
+            pathSegmentsUnder("/storage/emulated/0/Books", "/storage/emulated/0/BooksOld/a.fb2")
+        )
+    }
+
+    @Test
+    fun `case differences in the root are ignored`() {
+        assertEquals(
+            listOf("a.fb2"),
+            pathSegmentsUnder("/storage/emulated/0/books", "/storage/emulated/0/BOOKS/a.fb2")
+        )
+    }
+
+    @Test
+    fun `segment case is preserved for the listing to match ignoring it`() {
+        assertEquals(
+            listOf("Lem", "Solaris.FB2"),
+            pathSegmentsUnder("/books", "/books/Lem/Solaris.FB2")
+        )
+    }
+
+    @Test
+    fun `trailing separators on either side are ignored`() {
+        assertEquals(
+            listOf("a.fb2"),
+            pathSegmentsUnder("/books/", "/books/a.fb2/")
+        )
+    }
+
+    @Test
+    fun `the root itself names no file`() {
+        assertNull(pathSegmentsUnder("/books", "/books"))
+        assertNull(pathSegmentsUnder("/books", "/books/"))
+    }
+
+    @Test
+    fun `an empty root is refused rather than claiming everything`() {
+        assertNull(pathSegmentsUnder("", "/books/a.fb2"))
+        assertNull(pathSegmentsUnder("   ", "/books/a.fb2"))
+    }
+
+    /** No listing composes a path with an empty segment, so there is nothing to find. */
+    @Test
+    fun `doubled separators are refused`() {
+        assertNull(pathSegmentsUnder("/books", "/books//a.fb2"))
+        assertNull(pathSegmentsUnder("/books", "/books/Lem//a.fb2"))
+    }
+
+    @Test
+    fun `a path shorter than the root is refused`() {
+        assertNull(pathSegmentsUnder("/storage/emulated/0/Books", "/storage"))
+    }
+
+    /**
+     * Spaces and punctuation are ordinary in display names and must survive intact,
+     * since the segment is compared to the name the cursor reports.
+     */
+    @Test
+    fun `names keep their spaces and dots`() {
+        assertEquals(
+            listOf("Sci-Fi & Co.", "Vol. 1 (2005).fb2"),
+            pathSegmentsUnder("/books", "/books/Sci-Fi & Co./Vol. 1 (2005).fb2")
+        )
+    }
+}


### PR DESCRIPTION
Closes #36, the second and last part of it (#47 was the first).

## What it does

`getFileFromBook` searched for a book by enumerating every persisted SAF tree and comparing full paths — ignoring the very string it was given. `walk()` materialises the whole tree before comparing anything, and each `listFiles()` is two ContentResolver queries (`canAccess`, then the listing), so the cost scaled with the size of the granted folder rather than with the book.

`book.filePath` is a route. A `CachedFile`'s path is composed as `<parent>/<display name>`, so path segments and directory listings are the same strings by construction, and the resolve can query one directory per level instead of every directory in the library.

Three parts:

1. **Descend the path** instead of walking the tree.
2. **Keep the walk as a fallback**, logged when it runs — see below for why it is not dead code.
3. **Try the deepest matching root first**, because roots from different providers can be prefixes of one another.

## Device QA — Lenovo TB128FU, release-debug + AOT

`open: find file`, cache hit in every run:

| Book | depth | before | after |
|---|---|---|---|
| 33 MB FB2, 75 images | 1 | 210 ms | **93 / 66 ms** |
| 9 KB EPUB | 1 | 152–199 ms | **97 ms** |
| 5.6 MB FB2, 2.87M chars | 1 | 298 ms (2026-08-01) | **101 ms** |
| 1.2 MB FB2, nested folder | 2 | — | **113 / 122 ms** |

Every book came back a **cache hit**, which is the correctness check that matters: the parse-cache key is `path + size + lastModified`, so a resolve that returned a different file would have missed. The fallback never fired.

## What a second provider changed, mid-review

A Google Drive folder was granted while this branch was under test, and it moved the numbers:

- Drive reports **`/storage`** as the path of a Drive folder — a prefix of every path on the device. The descent therefore matched a Drive root for device books and listed it, over the network, before reaching the tree that actually held the book: **379 ms**, against 101 ms for the same book with one tree.
- Sorting roots deepest-first put it back to **98–122 ms**. That 379 ms is self-evidencing: an unreadable tree reports `isDirectory = false` and is dropped before any of this, so the cost can only have come from a Drive tree that was answering.
- The old code would have been far worse in the same configuration — a full *recursive* walk of a cloud tree per open.

## Why the fallback stays

Three things a provider may do leave the descent no route: a display name containing `/`, two children of one directory sharing a name, and a root that reports no path at all. None is reachable on external storage and none can be tested against a single provider, so the walk still runs before a book is declared missing — at the price every open used to pay, in the case that would otherwise fail outright.

Its condition is deliberately the **old**, looser one rather than the descent's: a root with no path composes children as `/<name>` and the import wrote exactly that into the book row, so the walk still matches where the descent could not even start. A fallback that filters more than what it falls back from is not a fallback. This was found by testing, not by reasoning — the first version filtered on the descent's condition and would have made such a book unopenable.

## Tests

`pathSegmentsUnder` is a pure function with 12 JVM tests (112 in the suite, up from 100). It also fixes a boundary the old prefix check was missing: a tree at `/Books` claimed `/BooksOld/novel.fb2`, harmless only because the full-path comparison that followed rejected it. The tests were checked to fail, not merely to pass: dropping the boundary check fails exactly the sibling-directory test.

`lintDebug` green.

## Not covered

**A book that lives on a cloud provider has never been opened.** Importing one needs the Drive tree to be answering, and it alternates — see the follow-up issue, which also covers the `/storage` prefix trap in `getStorageFiles` (with Drive granted, the device folder disappears from Browse entirely).
