### PR TITLE
Fix the lost light/dark switch: read the night mode from resources, not LocalConfiguration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,15 +50,21 @@ android {
         // debug, because release-debug is the variant performance is measured on —
         // a debug build runs several times slower, so its timings are only ever
         // comparable with each other.
+        // THEME_TRACE logs the system's night mode as each layer of the process
+        // sees it, under the "ThemeTrace" tag. Same variants as BOOK_TIMING, and
+        // for a stronger reason: the bug it chases takes hours of ordinary
+        // reading to appear, and release-debug is what that reading happens on.
         getByName("debug") {
             applicationIdSuffix = ".debug"
             buildConfigField("boolean", "BOOK_TIMING", "true")
+            buildConfigField("boolean", "THEME_TRACE", "true")
         }
 
         getByName("release") {
             isMinifyEnabled = true
             isShrinkResources = false
             buildConfigField("boolean", "BOOK_TIMING", "false")
+            buildConfigField("boolean", "THEME_TRACE", "false")
 
             proguardFiles("proguard-rules.pro")
         }
@@ -68,6 +74,7 @@ android {
             applicationIdSuffix = ".release.debug"
             signingConfig = signingConfigs.getByName("debug")
             buildConfigField("boolean", "BOOK_TIMING", "true")
+            buildConfigField("boolean", "THEME_TRACE", "true")
         }
     }
 

--- a/app/src/main/java/ua/acclorite/book_story/core/log/ThemeTrace.kt
+++ b/app/src/main/java/ua/acclorite/book_story/core/log/ThemeTrace.kt
@@ -1,6 +1,7 @@
 /*
  * Book's Story — free and open-source Material You eBook reader.
  * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
  * SPDX-License-Identifier: GPL-3.0-only
  */
 

--- a/app/src/main/java/ua/acclorite/book_story/core/log/ThemeTrace.kt
+++ b/app/src/main/java/ua/acclorite/book_story/core/log/ThemeTrace.kt
@@ -1,0 +1,99 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.core.log
+
+import android.app.UiModeManager
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import ua.acclorite.book_story.BuildConfig
+
+private const val THEME_TAG = "ThemeTrace"
+
+/**
+ * Whether the night mode the app thinks it is in is logged — read with
+ * `adb logcat -s ThemeTrace`.
+ *
+ * On for `debug` and `release-debug`, off for `release`, like [BOOK_TIMING] and
+ * for the same reason: `release-debug` is the variant used in daily reading, and
+ * this bug takes hours of ordinary use to show up.
+ */
+const val THEME_TRACE = BuildConfig.THEME_TRACE
+
+/**
+ * Logs where the system's night mode stands, from every source that could
+ * disagree with the others.
+ *
+ * A system dark/light switch can be lost: the app keeps drawing the old theme
+ * for hours, across foreground/background cycles, until some unrelated
+ * configuration change (a rotation) arrives. The platform's own bookkeeping says
+ * the new configuration was delivered — both `ActivityRecord` and the window
+ * report it — so the disagreement is somewhere inside the process, and only the
+ * app can see which layer went stale:
+ *
+ * - **activity** — `LocalConfiguration` is fed from here, so this is what
+ *   `isSystemInDarkTheme` ends up reading;
+ * - **app** — the application context's resources, a separate `Configuration`;
+ * - **system** — the framework's own resources, updated by `ResourcesManager`;
+ * - **setting** — what the user chose, which never goes stale and is here to
+ *   date the switch in the log.
+ *
+ * If the activity disagrees with the other three, a re-read at `ON_START` is
+ * enough to fix the bug. If they all agree and the composition still resolved
+ * the other way, the staleness is in Compose and the fix has to invalidate it.
+ *
+ * Costs nothing when [THEME_TRACE] is off: the line is never built.
+ */
+fun themeTrace(where: String, context: Context) {
+    if (!THEME_TRACE) return
+
+    val setting = when (
+        (context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager).nightMode
+    ) {
+        UiModeManager.MODE_NIGHT_AUTO -> "auto"
+        UiModeManager.MODE_NIGHT_NO -> "no"
+        UiModeManager.MODE_NIGHT_YES -> "yes"
+        else -> "custom"
+    }
+
+    logI(
+        THEME_TAG,
+        "$where: activity=${context.resources.night()} " +
+                "app=${context.applicationContext.resources.night()} " +
+                "system=${Resources.getSystem().night()} " +
+                "setting=$setting"
+    )
+}
+
+/**
+ * Logs what the composition actually resolved, which is the value the user sees.
+ * Fires on entering composition and on every later change, so a line here
+ * without a matching [themeTrace] line means the app reacted to something other
+ * than a lifecycle event.
+ *
+ * Compiles to nothing when [THEME_TRACE] is off.
+ */
+@Composable
+fun ThemeTraceComposed(isDark: Boolean) {
+    if (!THEME_TRACE) return
+
+    val systemDark = isSystemInDarkTheme()
+    LaunchedEffect(isDark, systemDark) {
+        logI(THEME_TAG, "composed: isDark=$isDark isSystemInDarkTheme=$systemDark")
+    }
+}
+
+private fun Resources.night(): String {
+    return when (configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) {
+        Configuration.UI_MODE_NIGHT_YES -> "dark"
+        Configuration.UI_MODE_NIGHT_NO -> "light"
+        else -> "undefined"
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/presentation/main/MainActivity.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/main/MainActivity.kt
@@ -9,6 +9,7 @@
 package ua.acclorite.book_story.presentation.main
 
 import android.annotation.SuppressLint
+import android.content.res.Configuration
 import android.database.CursorWindow
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -23,6 +24,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.collections.immutable.persistentListOf
 import ua.acclorite.book_story.R
+import ua.acclorite.book_story.core.log.ThemeTraceComposed
+import ua.acclorite.book_story.core.log.themeTrace
 import ua.acclorite.book_story.data.model.file.CachedFile
 import ua.acclorite.book_story.data.settings.SettingsManager
 import ua.acclorite.book_story.presentation.browse.BrowseModel
@@ -76,6 +79,8 @@ class MainActivity : AppCompatActivity() {
         enableEdgeToEdge()
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
+        themeTrace("onCreate", this)
+
         setContent {
             // Initializing Screen Models
             val libraryModel = hiltViewModel<LibraryModel>()
@@ -114,9 +119,12 @@ class MainActivity : AppCompatActivity() {
                 MainActivityKeyboardManager()
 
                 if (settings.initialized.collectAsStateWithLifecycle().value) {
+                    val isDark = settings.darkTheme.value.isDark()
+                    ThemeTraceComposed(isDark)
+
                     BookStoryTheme(
                         theme = settings.theme.value,
-                        isDark = settings.darkTheme.value.isDark(),
+                        isDark = isDark,
                         isPureDark = settings.pureDark.value.isPureDark(this),
                         themeContrast = settings.themeContrast.value
                     ) {
@@ -178,6 +186,23 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    // The three moments a lost uiMode change could have been noticed, and was
+    // not — see issue #50. Compile to nothing when THEME_TRACE is off.
+    override fun onStart() {
+        super.onStart()
+        themeTrace("onStart", this)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        themeTrace("onResume", this)
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        themeTrace("onConfigurationChanged", this)
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/ua/acclorite/book_story/ui/theme/SystemDarkTheme.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/theme/SystemDarkTheme.kt
@@ -1,6 +1,7 @@
 /*
  * Book's Story — free and open-source Material You eBook reader.
  * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -19,6 +20,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 
 /**
@@ -35,41 +37,59 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
  * composition still resolved dark.
  *
  * So the value is read from the activity's `resources`, which the trace proved
- * correct, and re-read at each of the moments the stale one was missed: every
- * `ON_START`/`ON_RESUME`, and every configuration change Compose *does* see.
- * A missed invalidation then costs one resume rather than lasting until the
- * user happens to rotate the screen.
+ * correct, and re-read by a [SystemNightModeWatcher] at each of the moments the
+ * stale one was missed: every `ON_START`/`ON_RESUME`, and every configuration
+ * change Compose *does* see. A missed invalidation then costs one resume rather
+ * than lasting until the user happens to rotate the screen.
  */
 @Composable
 fun systemInDarkTheme(): Boolean {
     val resources = LocalContext.current.resources
     val lifecycleOwner = LocalLifecycleOwner.current
 
-    var isDark by remember(resources) { mutableStateOf(resources.isNightMode()) }
+    val watcher = remember(resources) {
+        SystemNightModeWatcher { resources.isNightMode() }
+    }
 
-    // Adding the observer replays the current state, so this also seeds the value.
-    DisposableEffect(lifecycleOwner, resources) {
-        val observer = LifecycleEventObserver { _, event ->
-            when (event) {
-                Lifecycle.Event.ON_START, Lifecycle.Event.ON_RESUME -> {
-                    isDark = resources.isNightMode()
-                }
-
-                else -> Unit
-            }
-        }
-
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    DisposableEffect(lifecycleOwner, watcher) {
+        lifecycleOwner.lifecycle.addObserver(watcher)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(watcher) }
     }
 
     // The path that already worked — a switch while the app is in the foreground.
     val configuration = LocalConfiguration.current
-    LaunchedEffect(configuration, resources) {
-        isDark = resources.isNightMode()
+    LaunchedEffect(configuration, watcher) { watcher.refresh() }
+
+    return watcher.isNight
+}
+
+/**
+ * Holds the system's night mode, re-reading [readIsNight] whenever the activity
+ * is started or resumed.
+ *
+ * That re-read is the whole point, and it is not an optimisation to be tidied
+ * away later: the value it guards against is one that changed while the app was
+ * in the background and that nothing else will announce. Writing the same value
+ * back costs nothing — snapshot state only invalidates on a real change — so
+ * this does not recompose the app on every resume.
+ */
+internal class SystemNightModeWatcher(
+    private val readIsNight: () -> Boolean
+) : LifecycleEventObserver {
+
+    var isNight by mutableStateOf(readIsNight())
+        private set
+
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        when (event) {
+            Lifecycle.Event.ON_START, Lifecycle.Event.ON_RESUME -> refresh()
+            else -> Unit
+        }
     }
 
-    return isDark
+    fun refresh() {
+        isNight = readIsNight()
+    }
 }
 
 private fun Resources.isNightMode(): Boolean {

--- a/app/src/main/java/ua/acclorite/book_story/ui/theme/SystemDarkTheme.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/theme/SystemDarkTheme.kt
@@ -1,0 +1,78 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.theme
+
+import android.content.res.Configuration
+import android.content.res.Resources
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+/**
+ * Whether the system is in dark mode — the replacement for `isSystemInDarkTheme`,
+ * which cannot be trusted here.
+ *
+ * `isSystemInDarkTheme` reads `LocalConfiguration`, and that copy can go stale
+ * for hours: when the system switches night mode while the app sits in the
+ * background, the activity's resources are updated and `onConfigurationChanged`
+ * arrives, but nothing invalidates the composition, so the reader keeps drawing
+ * the old theme through any number of resumes. It corrects itself only when an
+ * unrelated configuration change — a rotation — happens to come along. See
+ * issue #50, where the trace shows every resource reporting light while the
+ * composition still resolved dark.
+ *
+ * So the value is read from the activity's `resources`, which the trace proved
+ * correct, and re-read at each of the moments the stale one was missed: every
+ * `ON_START`/`ON_RESUME`, and every configuration change Compose *does* see.
+ * A missed invalidation then costs one resume rather than lasting until the
+ * user happens to rotate the screen.
+ */
+@Composable
+fun systemInDarkTheme(): Boolean {
+    val resources = LocalContext.current.resources
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    var isDark by remember(resources) { mutableStateOf(resources.isNightMode()) }
+
+    // Adding the observer replays the current state, so this also seeds the value.
+    DisposableEffect(lifecycleOwner, resources) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_START, Lifecycle.Event.ON_RESUME -> {
+                    isDark = resources.isNightMode()
+                }
+
+                else -> Unit
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // The path that already worked — a switch while the app is in the foreground.
+    val configuration = LocalConfiguration.current
+    LaunchedEffect(configuration, resources) {
+        isDark = resources.isNightMode()
+    }
+
+    return isDark
+}
+
+private fun Resources.isNightMode(): Boolean {
+    return (configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+            Configuration.UI_MODE_NIGHT_YES
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/theme/model/DarkTheme.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/theme/model/DarkTheme.kt
@@ -7,9 +7,9 @@
 package ua.acclorite.book_story.ui.theme.model
 
 import androidx.annotation.StringRes
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import ua.acclorite.book_story.R
+import ua.acclorite.book_story.ui.theme.systemInDarkTheme
 
 enum class DarkTheme(@StringRes val title: Int) {
     FOLLOW_SYSTEM(R.string.dark_theme_follow_system),
@@ -19,7 +19,8 @@ enum class DarkTheme(@StringRes val title: Int) {
     @Composable
     fun isDark(): Boolean {
         return when (this) {
-            FOLLOW_SYSTEM -> isSystemInDarkTheme()
+            // Not isSystemInDarkTheme: its LocalConfiguration goes stale — see #50.
+            FOLLOW_SYSTEM -> systemInDarkTheme()
             ON -> true
             OFF -> false
         }

--- a/app/src/test/java/ua/acclorite/book_story/ui/theme/SystemNightModeWatcherTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/ui/theme/SystemNightModeWatcherTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.theme
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The contract behind the fix for issue #50.
+ *
+ * The system's night mode can change while the app is in the background without
+ * anything invalidating the composition, so the app kept drawing the old theme
+ * for hours — through repeated resumes — until an unrelated configuration change
+ * happened along. These checks pin the property that fixes it: the value is
+ * re-read from its source when the activity starts, whether or not anyone
+ * announced a change.
+ *
+ * If someone ever "simplifies" [systemInDarkTheme] back to `isSystemInDarkTheme`,
+ * or drops the lifecycle observer as redundant, this test is what fails.
+ */
+class SystemNightModeWatcherTest {
+
+    /** Drives lifecycle events without a Looper — `createUnsafe` skips the main-thread check. */
+    private class TestOwner : LifecycleOwner {
+        val registry = LifecycleRegistry.createUnsafe(this)
+        override val lifecycle: Lifecycle get() = registry
+    }
+
+    @Test
+    fun `takes its initial value from the source`() {
+        assertTrue(SystemNightModeWatcher { true }.isNight)
+        assertFalse(SystemNightModeWatcher { false }.isNight)
+    }
+
+    @Test
+    fun `picks up a change that happened while the app was stopped`() {
+        var night = false
+        val watcher = SystemNightModeWatcher { night }
+        val owner = TestOwner()
+        owner.registry.addObserver(watcher)
+        owner.registry.currentState = Lifecycle.State.RESUMED
+        assertFalse("nothing changed yet", watcher.isNight)
+
+        // The app goes to the background and the system switches underneath it —
+        // silently, which is the whole bug.
+        owner.registry.currentState = Lifecycle.State.CREATED
+        night = true
+        assertFalse("still stopped, nothing has re-read it", watcher.isNight)
+
+        owner.registry.currentState = Lifecycle.State.STARTED
+        assertTrue("ON_START must re-read the source", watcher.isNight)
+    }
+
+    @Test
+    fun `re-reads on every start, in both directions`() {
+        var night = true
+        val watcher = SystemNightModeWatcher { night }
+        val owner = TestOwner()
+        owner.registry.addObserver(watcher)
+        owner.registry.currentState = Lifecycle.State.RESUMED
+        assertTrue(watcher.isNight)
+
+        owner.registry.currentState = Lifecycle.State.CREATED
+        night = false
+        owner.registry.currentState = Lifecycle.State.RESUMED
+        assertFalse("dark to light must be picked up too", watcher.isNight)
+
+        owner.registry.currentState = Lifecycle.State.CREATED
+        night = true
+        owner.registry.currentState = Lifecycle.State.RESUMED
+        assertTrue("and back again", watcher.isNight)
+    }
+
+    @Test
+    fun `refresh re-reads without any lifecycle event`() {
+        var night = false
+        val watcher = SystemNightModeWatcher { night }
+
+        night = true
+        watcher.refresh()
+
+        assertTrue(watcher.isNight)
+    }
+
+    @Test
+    fun `stopping does not clobber the value`() {
+        var night = true
+        val watcher = SystemNightModeWatcher { night }
+        val owner = TestOwner()
+        owner.registry.addObserver(watcher)
+        owner.registry.currentState = Lifecycle.State.RESUMED
+
+        // A source that lies once the app is no longer visible must not be read
+        // on the way down, only on the way back up.
+        night = false
+        owner.registry.currentState = Lifecycle.State.CREATED
+
+        assertTrue("ON_PAUSE/ON_STOP must not re-read", watcher.isNight)
+    }
+}


### PR DESCRIPTION
Fixes the lost light/dark switch: the app could keep drawing the old theme for
hours after the system changed night mode, correcting itself only when an
unrelated configuration change — a rotation — happened along.

Closes #50.

## The bug

Caught live on the tablet on 2026-08-06 and dissected before it healed. At
06:41:30 the system went light. Every source agreed — the activity's resources,
the application context, the framework's own — and `onConfigurationChanged`
arrived, and the activity was then resumed three separate times:

```
08-06 06:41:30 onConfigurationChanged: activity=light app=light system=light
08-06 06:41:30 onStart / onResume:     activity=light app=light system=light
08-06 06:43:32 onStart / onResume:     activity=light app=light system=light
08-06 06:45:31 onStart / onResume:     activity=light app=light system=light
```

And no `composed:` line follows any of them. The last one was 5½ hours earlier,
saying `isDark=true`. So the composition still resolved
`isSystemInDarkTheme() == true` while everything it reads from said light.
Confirmed at 06:49 with the app still in that state: same pid, no restart, the
app drawing dark, `dumpsys uimode` reporting `mSetUiMode=0x11`, and the
activity's `mLastReportedConfiguration` carrying no `night` token.

`DarkTheme.isDark()`'s FOLLOW_SYSTEM branch was the only thing reading the
system's night mode, and `isSystemInDarkTheme()` reads `LocalConfiguration`.
`MainActivity` declares `uiMode` in `android:configChanges`, so the activity is
never recreated — nothing re-read that value at any lifecycle event, ever.

## The fix

`systemInDarkTheme()` reads the activity's `resources`, which the trace proved
correct, and a `SystemNightModeWatcher` re-reads them on `ON_START`/`ON_RESUME`
and on any configuration change Compose *does* see. A missed invalidation now
costs one resume instead of lasting until the user happens to rotate the device.

Self-contained — no `MainActivity` wiring — so every caller of `isDark()` is
covered, the reader included: its built-in colour presets follow the same call.

## What is proven, and what is not

**Proven.** The cause was read off a live broken state, not inferred. The unit
test drives a `LifecycleRegistry` through the exact shape of the bug — the
source changes while the app is stopped, with nothing to announce it — and is
verified by mutation: dropping the `ON_START`/`ON_RESUME` re-read fails two of
its five checks.

**Not proven.** There is no deterministic reproduction. Seven compressed
attempts all behaved correctly — foreground, backgrounded, screen off for 8 s,
13 min, minimised behind the launcher, forced deep Doze, and with the
orientation pinned so that waking could not smuggle in the configuration change
that hides the bug. The last of those was also run on a build *without* this
fix, which rules out the fix masking the failure. Whatever system condition
produces it is not reachable in minutes.

**Field.** One clean night since the fix: both switches picked up, `composed:`
following each, no regression. That is one night, not a proof — but the failure
had appeared two days running before it.

## The diagnostic stays in

`ThemeTrace`, gated on a `THEME_TRACE` `BuildConfig` flag with the same variants
as `BOOK_TIMING` — off in `release`, on in `debug` and `release-debug`. It is
how this was diagnosed and how the fix keeps being checked: a line reading
`isDark=false isSystemInDarkTheme=true` is the bug occurring and being corrected
in place. Worth keeping until such a line is seen, or until enough time passes
without one.

## Known cosmetic detail

A switch while the app is in the foreground now settles one effect later —
about 130 ms measured — because the value arrives through a lifecycle/effect
path rather than synchronously from `LocalConfiguration`. Invisible under the
existing 300 ms colour animation. The alternative, reading fresh during every
composition, would recompose the whole app on every resume instead.

## Testing

- 5 new JVM tests, mutation-verified; full suite green.
- `release-debug` and `release` both compile.
- Device QA on the tablet across both directions of the switch, foreground and
  from the background.
