### PR TITLE
Reading statistics: sessions, coverage, words and speed

### DIFF
--- a/app/schemas/ua.acclorite.book_story.data.local.room.BookDatabase/18.json
+++ b/app/schemas/ua.acclorite.book_story.data.local.room.BookDatabase/18.json
@@ -1,0 +1,403 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 18,
+    "identityHash": "f366f3e880ac55f4911c9f6af7ecf073",
+    "entities": [
+      {
+        "tableName": "BookEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `description` TEXT, `filePath` TEXT NOT NULL, `scrollIndex` INTEGER NOT NULL, `scrollOffset` INTEGER NOT NULL, `progress` REAL NOT NULL, `image` TEXT, `categories` TEXT NOT NULL DEFAULT '[]')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrollIndex",
+            "columnName": "scrollIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrollOffset",
+            "columnName": "scrollOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "HistoryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER NOT NULL, `time` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ColorPresetEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `backgroundColor` INTEGER NOT NULL, `fontColor` INTEGER NOT NULL, `isSelected` INTEGER NOT NULL, `order` INTEGER NOT NULL, `type` TEXT NOT NULL DEFAULT 'CUSTOM')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "backgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontColor",
+            "columnName": "fontColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSelected",
+            "columnName": "isSelected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'CUSTOM'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "CategoryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `order` INTEGER NOT NULL, `sortOrder` TEXT NOT NULL DEFAULT 'LAST_READ', `sortOrderDescending` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LAST_READ'"
+          },
+          {
+            "fieldPath": "sortOrderDescending",
+            "columnName": "sortOrderDescending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ReadingSessionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER, `startTime` INTEGER NOT NULL, `endTime` INTEGER NOT NULL, `wordsRead` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "endTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordsRead",
+            "columnName": "wordsRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ReadingSessionEntity_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReadingSessionEntity_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_ReadingSessionEntity_startTime",
+            "unique": false,
+            "columnNames": [
+              "startTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReadingSessionEntity_startTime` ON `${TABLE_NAME}` (`startTime`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ReadBookEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `totalTimeMs` INTEGER NOT NULL, `totalWords` INTEGER NOT NULL, `sessions` INTEGER NOT NULL, `firstReadAt` INTEGER NOT NULL, `lastReadAt` INTEGER NOT NULL, `finished` INTEGER NOT NULL, `coveragePercent` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalTimeMs",
+            "columnName": "totalTimeMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalWords",
+            "columnName": "totalWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessions",
+            "columnName": "sessions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstReadAt",
+            "columnName": "firstReadAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadAt",
+            "columnName": "lastReadAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finished",
+            "columnName": "finished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coveragePercent",
+            "columnName": "coveragePercent",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ReadBookEntity_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReadBookEntity_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ReadingCoverageEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` INTEGER NOT NULL, `itemCount` INTEGER NOT NULL, `bookWords` INTEGER NOT NULL, `intervals` TEXT NOT NULL, `coveredWords` INTEGER NOT NULL, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookWords",
+            "columnName": "bookWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intervals",
+            "columnName": "intervals",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coveredWords",
+            "columnName": "coveredWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f366f3e880ac55f4911c9f6af7ecf073')"
+    ]
+  }
+}

--- a/app/schemas/ua.acclorite.book_story.data.local.room.BookDatabase/19.json
+++ b/app/schemas/ua.acclorite.book_story.data.local.room.BookDatabase/19.json
@@ -1,0 +1,410 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 19,
+    "identityHash": "2267b2742fba8a42bae177d1920ba55e",
+    "entities": [
+      {
+        "tableName": "BookEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `description` TEXT, `filePath` TEXT NOT NULL, `scrollIndex` INTEGER NOT NULL, `scrollOffset` INTEGER NOT NULL, `progress` REAL NOT NULL, `image` TEXT, `categories` TEXT NOT NULL DEFAULT '[]')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrollIndex",
+            "columnName": "scrollIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrollOffset",
+            "columnName": "scrollOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "HistoryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER NOT NULL, `time` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ColorPresetEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `backgroundColor` INTEGER NOT NULL, `fontColor` INTEGER NOT NULL, `isSelected` INTEGER NOT NULL, `order` INTEGER NOT NULL, `type` TEXT NOT NULL DEFAULT 'CUSTOM')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "backgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontColor",
+            "columnName": "fontColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSelected",
+            "columnName": "isSelected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'CUSTOM'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "CategoryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `order` INTEGER NOT NULL, `sortOrder` TEXT NOT NULL DEFAULT 'LAST_READ', `sortOrderDescending` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LAST_READ'"
+          },
+          {
+            "fieldPath": "sortOrderDescending",
+            "columnName": "sortOrderDescending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ReadingSessionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER, `startTime` INTEGER NOT NULL, `endTime` INTEGER NOT NULL, `wordsRead` INTEGER NOT NULL, `overlayMs` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "endTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordsRead",
+            "columnName": "wordsRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overlayMs",
+            "columnName": "overlayMs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ReadingSessionEntity_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReadingSessionEntity_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_ReadingSessionEntity_startTime",
+            "unique": false,
+            "columnNames": [
+              "startTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReadingSessionEntity_startTime` ON `${TABLE_NAME}` (`startTime`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ReadBookEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `totalTimeMs` INTEGER NOT NULL, `totalWords` INTEGER NOT NULL, `sessions` INTEGER NOT NULL, `firstReadAt` INTEGER NOT NULL, `lastReadAt` INTEGER NOT NULL, `finished` INTEGER NOT NULL, `coveragePercent` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalTimeMs",
+            "columnName": "totalTimeMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalWords",
+            "columnName": "totalWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessions",
+            "columnName": "sessions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstReadAt",
+            "columnName": "firstReadAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadAt",
+            "columnName": "lastReadAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finished",
+            "columnName": "finished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coveragePercent",
+            "columnName": "coveragePercent",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ReadBookEntity_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReadBookEntity_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ReadingCoverageEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` INTEGER NOT NULL, `itemCount` INTEGER NOT NULL, `bookWords` INTEGER NOT NULL, `intervals` TEXT NOT NULL, `coveredWords` INTEGER NOT NULL, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookWords",
+            "columnName": "bookWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intervals",
+            "columnName": "intervals",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coveredWords",
+            "columnName": "coveredWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2267b2742fba8a42bae177d1920ba55e')"
+    ]
+  }
+}

--- a/app/schemas/ua.acclorite.book_story.data.local.room.BookDatabase/20.json
+++ b/app/schemas/ua.acclorite.book_story.data.local.room.BookDatabase/20.json
@@ -1,0 +1,415 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 20,
+    "identityHash": "d171f2b124de19000d25d3972b899a82",
+    "entities": [
+      {
+        "tableName": "BookEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `description` TEXT, `filePath` TEXT NOT NULL, `scrollIndex` INTEGER NOT NULL, `scrollOffset` INTEGER NOT NULL, `progress` REAL NOT NULL, `image` TEXT, `categories` TEXT NOT NULL DEFAULT '[]')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrollIndex",
+            "columnName": "scrollIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrollOffset",
+            "columnName": "scrollOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "HistoryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER NOT NULL, `time` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ColorPresetEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `backgroundColor` INTEGER NOT NULL, `fontColor` INTEGER NOT NULL, `isSelected` INTEGER NOT NULL, `order` INTEGER NOT NULL, `type` TEXT NOT NULL DEFAULT 'CUSTOM')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "backgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontColor",
+            "columnName": "fontColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSelected",
+            "columnName": "isSelected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'CUSTOM'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "CategoryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `order` INTEGER NOT NULL, `sortOrder` TEXT NOT NULL DEFAULT 'LAST_READ', `sortOrderDescending` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LAST_READ'"
+          },
+          {
+            "fieldPath": "sortOrderDescending",
+            "columnName": "sortOrderDescending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ReadingSessionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER, `startTime` INTEGER NOT NULL, `endTime` INTEGER NOT NULL, `wordsRead` INTEGER NOT NULL, `overlayMs` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "endTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordsRead",
+            "columnName": "wordsRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overlayMs",
+            "columnName": "overlayMs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ReadingSessionEntity_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReadingSessionEntity_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_ReadingSessionEntity_startTime",
+            "unique": false,
+            "columnNames": [
+              "startTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReadingSessionEntity_startTime` ON `${TABLE_NAME}` (`startTime`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ReadBookEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `totalTimeMs` INTEGER NOT NULL, `totalWords` INTEGER NOT NULL, `sessions` INTEGER NOT NULL, `firstReadAt` INTEGER NOT NULL, `lastReadAt` INTEGER NOT NULL, `finished` INTEGER NOT NULL, `coveragePercent` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalTimeMs",
+            "columnName": "totalTimeMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalWords",
+            "columnName": "totalWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessions",
+            "columnName": "sessions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstReadAt",
+            "columnName": "firstReadAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadAt",
+            "columnName": "lastReadAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finished",
+            "columnName": "finished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coveragePercent",
+            "columnName": "coveragePercent",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ReadBookEntity_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReadBookEntity_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ReadingCoverageEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` INTEGER NOT NULL, `itemCount` INTEGER NOT NULL, `bookWords` INTEGER NOT NULL, `intervals` TEXT NOT NULL, `coveredWords` INTEGER NOT NULL, `wordsBeforeBookmark` INTEGER, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookWords",
+            "columnName": "bookWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intervals",
+            "columnName": "intervals",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coveredWords",
+            "columnName": "coveredWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordsBeforeBookmark",
+            "columnName": "wordsBeforeBookmark",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd171f2b124de19000d25d3972b899a82')"
+    ]
+  }
+}

--- a/app/schemas/ua.acclorite.book_story.data.local.room.BookDatabase/21.json
+++ b/app/schemas/ua.acclorite.book_story.data.local.room.BookDatabase/21.json
@@ -1,0 +1,415 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 21,
+    "identityHash": "dcbcf8c06ae768d5b540d78d4e604ad1",
+    "entities": [
+      {
+        "tableName": "BookEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `description` TEXT, `filePath` TEXT NOT NULL, `scrollIndex` INTEGER NOT NULL, `scrollOffset` INTEGER NOT NULL, `progress` REAL NOT NULL, `image` TEXT, `categories` TEXT NOT NULL DEFAULT '[]')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrollIndex",
+            "columnName": "scrollIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrollOffset",
+            "columnName": "scrollOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "HistoryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER NOT NULL, `time` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ColorPresetEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `backgroundColor` INTEGER NOT NULL, `fontColor` INTEGER NOT NULL, `isSelected` INTEGER NOT NULL, `order` INTEGER NOT NULL, `type` TEXT NOT NULL DEFAULT 'CUSTOM')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "backgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontColor",
+            "columnName": "fontColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSelected",
+            "columnName": "isSelected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'CUSTOM'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "CategoryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `order` INTEGER NOT NULL, `sortOrder` TEXT NOT NULL DEFAULT 'LAST_READ', `sortOrderDescending` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LAST_READ'"
+          },
+          {
+            "fieldPath": "sortOrderDescending",
+            "columnName": "sortOrderDescending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ReadingSessionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER, `startTime` INTEGER NOT NULL, `endTime` INTEGER NOT NULL, `wordsRead` INTEGER NOT NULL, `overlayMs` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "endTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordsRead",
+            "columnName": "wordsRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overlayMs",
+            "columnName": "overlayMs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ReadingSessionEntity_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReadingSessionEntity_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_ReadingSessionEntity_startTime",
+            "unique": false,
+            "columnNames": [
+              "startTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReadingSessionEntity_startTime` ON `${TABLE_NAME}` (`startTime`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ReadBookEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `totalTimeMs` INTEGER NOT NULL, `totalWords` INTEGER NOT NULL, `sessions` INTEGER NOT NULL, `firstReadAt` INTEGER NOT NULL, `lastReadAt` INTEGER NOT NULL, `finished` INTEGER NOT NULL, `coveragePercent` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalTimeMs",
+            "columnName": "totalTimeMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalWords",
+            "columnName": "totalWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessions",
+            "columnName": "sessions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstReadAt",
+            "columnName": "firstReadAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadAt",
+            "columnName": "lastReadAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finished",
+            "columnName": "finished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coveragePercent",
+            "columnName": "coveragePercent",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ReadBookEntity_bookId",
+            "unique": true,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_ReadBookEntity_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ReadingCoverageEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` INTEGER NOT NULL, `itemCount` INTEGER NOT NULL, `bookWords` INTEGER NOT NULL, `intervals` TEXT NOT NULL, `coveredWords` INTEGER NOT NULL, `wordsBeforeBookmark` INTEGER, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookWords",
+            "columnName": "bookWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intervals",
+            "columnName": "intervals",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coveredWords",
+            "columnName": "coveredWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordsBeforeBookmark",
+            "columnName": "wordsBeforeBookmark",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dcbcf8c06ae768d5b540d78d4e604ad1')"
+    ]
+  }
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/di/RepositoryModule.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/di/RepositoryModule.kt
@@ -34,12 +34,14 @@ import ua.acclorite.book_story.data.repository.ColorPresetRepositoryImpl
 import ua.acclorite.book_story.data.repository.FileSystemRepositoryImpl
 import ua.acclorite.book_story.data.repository.HistoryRepositoryImpl
 import ua.acclorite.book_story.data.repository.PermissionRepositoryImpl
+import ua.acclorite.book_story.data.repository.StatisticsRepositoryImpl
 import ua.acclorite.book_story.domain.repository.BookRepository
 import ua.acclorite.book_story.domain.repository.CategoryRepository
 import ua.acclorite.book_story.domain.repository.ColorPresetRepository
 import ua.acclorite.book_story.domain.repository.FileSystemRepository
 import ua.acclorite.book_story.domain.repository.HistoryRepository
 import ua.acclorite.book_story.domain.repository.PermissionRepository
+import ua.acclorite.book_story.domain.repository.StatisticsRepository
 import javax.inject.Singleton
 
 @Module
@@ -62,6 +64,12 @@ abstract class RepositoryModule {
     abstract fun bindHistoryRepository(
         historyRepositoryImpl: HistoryRepositoryImpl
     ): HistoryRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindStatisticsRepository(
+        statisticsRepositoryImpl: StatisticsRepositoryImpl
+    ): StatisticsRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/ua/acclorite/book_story/data/local/dto/ReadBookEntity.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/dto/ReadBookEntity.kt
@@ -23,8 +23,13 @@ import androidx.room.PrimaryKey
  *
  * The per-book totals here duplicate a `SUM` over that book's sessions, which is
  * unavoidable: once those sessions are anonymised, that `SUM` no longer exists.
+ *
+ * The index on [bookId] is **unique**, which states the invariant rather than
+ * trusting every writer to keep it: one record per live book. Deleted books are
+ * exempt by construction — SQLite counts NULLs as distinct, so any number of
+ * anonymised rows sit under it happily, which is exactly the rule wanted.
  */
-@Entity(indices = [Index("bookId")])
+@Entity(indices = [Index(value = ["bookId"], unique = true)])
 data class ReadBookEntity(
     @PrimaryKey(true)
     val id: Int = 0,

--- a/app/src/main/java/ua/acclorite/book_story/data/local/dto/ReadBookEntity.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/dto/ReadBookEntity.kt
@@ -1,0 +1,48 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.local.dto
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * One row per book that has ever been read — the durable layer, never deleted.
+ * It is what lets a book leave a trace after its file is gone: the shelf of
+ * everything read, and the "books read" count.
+ *
+ * Written from the first session and updated as reading goes, *not* folded in
+ * at deletion time: [finished] has to be recorded when it happens, because by
+ * the time a book is deleted the reason is lost — one abandoned at 40 % looks
+ * exactly like one whose file simply moved.
+ *
+ * The per-book totals here duplicate a `SUM` over that book's sessions, which is
+ * unavoidable: once those sessions are anonymised, that `SUM` no longer exists.
+ */
+@Entity(indices = [Index("bookId")])
+data class ReadBookEntity(
+    @PrimaryKey(true)
+    val id: Int = 0,
+    /** The live book, or null once it has been deleted from the library. */
+    val bookId: Int?,
+    val title: String,
+    val author: String,
+    val totalTimeMs: Long,
+    val totalWords: Int,
+    val sessions: Int,
+    val firstReadAt: Long,
+    val lastReadAt: Long,
+    /**
+     * A statement by the reader, not a measurement: set automatically on
+     * reaching the end, and toggleable by hand at any time. People skip
+     * appendices, abandon at 97 %, or finish someone else's foreword.
+     */
+    val finished: Boolean,
+    /** Snapshot of coverage; the interval detail dies with the book. */
+    val coveragePercent: Float
+)

--- a/app/src/main/java/ua/acclorite/book_story/data/local/dto/ReadingCoverageEntity.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/dto/ReadingCoverageEntity.kt
@@ -1,0 +1,39 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.local.dto
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Which parts of a book have actually been read, as opposed to where its
+ * bookmark sits. Open a three-novel omnibus at the last novel and read it to the
+ * end: the bookmark says 100 %, correctly, but only a third was read. Progress
+ * deltas would credit the jump; these intervals do not.
+ *
+ * One row per book, dropped when the book is deleted — without the text the
+ * indices mean nothing. [ReadBookEntity.coveragePercent] keeps the final figure.
+ */
+@Entity
+data class ReadingCoverageEntity(
+    @PrimaryKey
+    val bookId: Int,
+    /**
+     * Item count of the parse these intervals were recorded against. A parser
+     * change shifts every index, so on a mismatch the intervals are discarded —
+     * and *only* the intervals: the words and time already banked in the
+     * sessions are history and are never touched.
+     */
+    val itemCount: Int,
+    /** Total words of the book's text, for "time left". */
+    val bookWords: Int,
+    /** Covered item ranges, `"12-480,3900-5200"`. */
+    val intervals: String,
+    /** Words inside [intervals] — unique, unlike a session's `wordsRead`. */
+    val coveredWords: Int
+)

--- a/app/src/main/java/ua/acclorite/book_story/data/local/dto/ReadingCoverageEntity.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/dto/ReadingCoverageEntity.kt
@@ -35,5 +35,11 @@ data class ReadingCoverageEntity(
     /** Covered item ranges, `"12-480,3900-5200"`. */
     val intervals: String,
     /** Words inside [intervals] — unique, unlike a session's `wordsRead`. */
-    val coveredWords: Int
+    val coveredWords: Int,
+    /**
+     * Words before the bookmark, for "left to read". Nullable rather than
+     * defaulted: a row written before this column existed does not know where
+     * its bookmark stood, and 0 would claim the whole book is still ahead.
+     */
+    val wordsBeforeBookmark: Int?
 )

--- a/app/src/main/java/ua/acclorite/book_story/data/local/dto/ReadingSessionEntity.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/dto/ReadingSessionEntity.kt
@@ -1,0 +1,41 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.local.dto
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * One reading session: from the moment a book's text is shown to the moment the
+ * reader is stopped. The detail layer of the statistics — per-book figures are
+ * read from here.
+ *
+ * Deleting a book does **not** delete its sessions; it sets [bookId] to null.
+ * The per-book detail then stops matching `WHERE bookId = :id` and disappears,
+ * while the day, the duration and the words stay in the lifetime totals. A
+ * deleted book therefore cannot retroactively shorten a streak or shrink the
+ * total time, and "forget this book entirely" is still available later as a
+ * plain delete.
+ */
+@Entity(indices = [Index("bookId"), Index("startTime")])
+data class ReadingSessionEntity(
+    @PrimaryKey(true)
+    val id: Int = 0,
+    /** The book read, or null once that book has been deleted. */
+    val bookId: Int?,
+    val startTime: Long,
+    /**
+     * End of the session. Trailing idle is capped when the row is written, so
+     * a device left open on a page cannot inflate it; idle *between* two
+     * reading spells is kept in full, deliberately.
+     */
+    val endTime: Long,
+    /** Words credited to this session — the volume read, repeats included. */
+    val wordsRead: Int
+)

--- a/app/src/main/java/ua/acclorite/book_story/data/local/dto/ReadingSessionEntity.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/dto/ReadingSessionEntity.kt
@@ -7,6 +7,7 @@
 
 package ua.acclorite.book_story.data.local.dto
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -37,5 +38,21 @@ data class ReadingSessionEntity(
      */
     val endTime: Long,
     /** Words credited to this session — the volume read, repeats included. */
-    val wordsRead: Int
+    val wordsRead: Int,
+    /**
+     * How much of the session the text was covered by something that earns no
+     * words: the full-screen image viewer, the settings sheet, the chapters
+     * drawer. Kept beside the interval rather than subtracted from it, so time
+     * in the book, days and streaks stay readable off `startTime`/`endTime`
+     * while speed can divide by the time in which words were actually possible.
+     *
+     * The note sheet is deliberately not counted here: its words are credited,
+     * so its time belongs in that denominator.
+     *
+     * Rows written before this was measured hold 0, which is the truth about
+     * them rather than an approximation — hence the SQL default, without which
+     * the auto migration has nothing to put in the existing rows.
+     */
+    @ColumnInfo(defaultValue = "0")
+    val overlayMs: Long = 0
 )

--- a/app/src/main/java/ua/acclorite/book_story/data/local/dto/SessionPace.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/dto/SessionPace.kt
@@ -1,0 +1,14 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.local.dto
+
+/** Just enough of a session to work out a pace from it. */
+data class SessionPace(
+    val durationMs: Long,
+    val wordsRead: Int
+)

--- a/app/src/main/java/ua/acclorite/book_story/data/local/dto/SessionSpan.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/dto/SessionSpan.kt
@@ -1,0 +1,15 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.local.dto
+
+/** A session reduced to what the library-wide figures need of it. */
+data class SessionSpan(
+    val startTime: Long,
+    val endTime: Long,
+    val wordsRead: Int
+)

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDatabase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDatabase.kt
@@ -34,7 +34,7 @@ import java.io.File
         ReadBookEntity::class,
         ReadingCoverageEntity::class
     ],
-    version = 19,
+    version = 20,
     autoMigrations = [
         AutoMigration(1, 2),
         AutoMigration(2, 3),
@@ -54,6 +54,7 @@ import java.io.File
         AutoMigration(16, 17), // ColorPresetEntity.type (default CUSTOM)
         AutoMigration(17, 18), // reading statistics: sessions, read books, coverage
         AutoMigration(18, 19), // ReadingSessionEntity.overlayMs (default 0)
+        AutoMigration(19, 20), // ReadingCoverageEntity.wordsBeforeBookmark (nullable)
     ],
     exportSchema = true
 )

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDatabase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDatabase.kt
@@ -34,7 +34,7 @@ import java.io.File
         ReadBookEntity::class,
         ReadingCoverageEntity::class
     ],
-    version = 18,
+    version = 19,
     autoMigrations = [
         AutoMigration(1, 2),
         AutoMigration(2, 3),
@@ -53,6 +53,7 @@ import java.io.File
         AutoMigration(15, 16, spec = DatabaseHelper.AUTO_MIGRATION_15_16::class),
         AutoMigration(16, 17), // ColorPresetEntity.type (default CUSTOM)
         AutoMigration(17, 18), // reading statistics: sessions, read books, coverage
+        AutoMigration(18, 19), // ReadingSessionEntity.overlayMs (default 0)
     ],
     exportSchema = true
 )

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDatabase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDatabase.kt
@@ -19,6 +19,9 @@ import ua.acclorite.book_story.data.local.dto.BookEntity
 import ua.acclorite.book_story.data.local.dto.CategoryEntity
 import ua.acclorite.book_story.data.local.dto.ColorPresetEntity
 import ua.acclorite.book_story.data.local.dto.HistoryEntity
+import ua.acclorite.book_story.data.local.dto.ReadBookEntity
+import ua.acclorite.book_story.data.local.dto.ReadingCoverageEntity
+import ua.acclorite.book_story.data.local.dto.ReadingSessionEntity
 import java.io.File
 
 @Database(
@@ -26,9 +29,12 @@ import java.io.File
         BookEntity::class,
         HistoryEntity::class,
         ColorPresetEntity::class,
-        CategoryEntity::class
+        CategoryEntity::class,
+        ReadingSessionEntity::class,
+        ReadBookEntity::class,
+        ReadingCoverageEntity::class
     ],
-    version = 17,
+    version = 18,
     autoMigrations = [
         AutoMigration(1, 2),
         AutoMigration(2, 3),
@@ -46,6 +52,7 @@ import java.io.File
         AutoMigration(14, 15),
         AutoMigration(15, 16, spec = DatabaseHelper.AUTO_MIGRATION_15_16::class),
         AutoMigration(16, 17), // ColorPresetEntity.type (default CUSTOM)
+        AutoMigration(17, 18), // reading statistics: sessions, read books, coverage
     ],
     exportSchema = true
 )

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDatabase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDatabase.kt
@@ -34,7 +34,7 @@ import java.io.File
         ReadBookEntity::class,
         ReadingCoverageEntity::class
     ],
-    version = 20,
+    version = 21,
     autoMigrations = [
         AutoMigration(1, 2),
         AutoMigration(2, 3),
@@ -55,6 +55,7 @@ import java.io.File
         AutoMigration(17, 18), // reading statistics: sessions, read books, coverage
         AutoMigration(18, 19), // ReadingSessionEntity.overlayMs (default 0)
         AutoMigration(19, 20), // ReadingCoverageEntity.wordsBeforeBookmark (nullable)
+        AutoMigration(20, 21), // ReadBookEntity.bookId is unique (one record per book)
     ],
     exportSchema = true
 )

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDatabase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDatabase.kt
@@ -61,6 +61,7 @@ abstract class BookDatabase : RoomDatabase() {
     abstract val historyDao: HistoryDao
     abstract val colorPresetDao: ColorPresetDao
     abstract val categoryDao: CategoryDao
+    abstract val statisticsDao: StatisticsDao
 }
 
 @Suppress("ClassName")

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
@@ -91,13 +91,100 @@ interface StatisticsDao {
     suspend fun getReadBook(bookId: Int): ReadBookEntity?
 
     /**
-     * Folds one finished session into the book's record, in SQL rather than by
-     * reading the row and writing it back — the totals are accumulated where
-     * they live.
+     * Folds one finished session into the book's record, starting that record
+     * on the first session.
+     *
+     * Both halves in one transaction, because the pair is a read-then-write:
+     * the update reports whether a record existed, and between two separate
+     * writes another writer could insert a second record for the same book. The
+     * unique index on `bookId` would reject that insert, so without the
+     * transaction the invariant would be enforced by an exception rather than
+     * held by construction.
+     */
+    @Transaction
+    suspend fun addSessionToBookRecord(
+        bookId: Int,
+        timeMs: Long,
+        words: Int,
+        endedAt: Long,
+        coveragePercent: Float,
+        reachedEnd: Boolean,
+        title: String,
+        author: String
+    ) {
+        val updated = accumulateSessionInReadBook(
+            bookId = bookId,
+            timeMs = timeMs,
+            words = words,
+            lastReadAt = endedAt,
+            coveragePercent = coveragePercent,
+            reachedEnd = reachedEnd,
+            title = title,
+            author = author
+        )
+        if (updated > 0) return
+
+        // First session with this book: the record starts here, which is also
+        // the only moment its firstReadAt is knowable.
+        insertReadBook(
+            ReadBookEntity(
+                bookId = bookId,
+                title = title,
+                author = author,
+                totalTimeMs = timeMs,
+                totalWords = words,
+                sessions = 1,
+                firstReadAt = endedAt - timeMs,
+                lastReadAt = endedAt,
+                finished = reachedEnd,
+                coveragePercent = coveragePercent
+            )
+        )
+    }
+
+    /**
+     * The reader's own statement, set rather than accumulated — and recorded
+     * even for a book this build has never measured, which is every book
+     * already in the library: there is no backfill, so an empty record is the
+     * truthful one. Transactional for the same reason as
+     * [addSessionToBookRecord].
+     */
+    @Transaction
+    suspend fun setBookFinished(
+        bookId: Int,
+        title: String,
+        author: String,
+        finished: Boolean,
+        now: Long
+    ) {
+        val updated = updateFinished(bookId = bookId, finished = finished)
+        if (updated > 0) return
+
+        insertReadBook(
+            ReadBookEntity(
+                bookId = bookId,
+                title = title,
+                author = author,
+                totalTimeMs = 0,
+                totalWords = 0,
+                sessions = 0,
+                firstReadAt = now,
+                lastReadAt = now,
+                finished = finished,
+                coveragePercent = 0f
+            )
+        )
+    }
+
+    /**
+     * Accumulates in SQL rather than by reading the row and writing it back —
+     * the totals are added where they live.
      *
      * `finished` only ever goes up: [reachedEnd] says this session got to the
      * end of the book, and a later session that stops earlier must not take
      * that back. Returns 0 when the book has no record yet.
+     *
+     * Called only from [addSessionToBookRecord], which supplies the transaction.
      */
     @Query(
         """
@@ -113,7 +200,7 @@ interface StatisticsDao {
         WHERE bookId = :bookId
         """
     )
-    suspend fun addSessionToReadBook(
+    suspend fun accumulateSessionInReadBook(
         bookId: Int,
         timeMs: Long,
         words: Int,
@@ -124,12 +211,20 @@ interface StatisticsDao {
         author: String
     ): Int
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    /**
+     * Aborts on a duplicate rather than replacing it. `REPLACE` would delete the
+     * existing record and insert this one, silently discarding the time, words
+     * and sessions already accumulated against that book; aborting costs one
+     * unrecorded update and says so in the log. Both callers hold a transaction
+     * that should make the conflict unreachable — this is what happens if it
+     * ever is not.
+     */
+    @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insertReadBook(readBook: ReadBookEntity)
 
-    /** The reader's own statement, so this one is set rather than accumulated. */
+    /** Called only from [setBookFinished], which supplies the transaction. */
     @Query("UPDATE ReadBookEntity SET finished = :finished WHERE bookId = :bookId")
-    suspend fun setFinished(bookId: Int, finished: Boolean): Int
+    suspend fun updateFinished(bookId: Int, finished: Boolean): Int
 
     /**
      * Keeps the record of a deleted book, without the book: its time, dates and

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
@@ -15,6 +15,7 @@ import ua.acclorite.book_story.data.local.dto.ReadBookEntity
 import ua.acclorite.book_story.data.local.dto.ReadingCoverageEntity
 import ua.acclorite.book_story.data.local.dto.ReadingSessionEntity
 import ua.acclorite.book_story.data.local.dto.SessionPace
+import ua.acclorite.book_story.data.local.dto.SessionSpan
 
 @Dao
 interface StatisticsDao {
@@ -50,6 +51,13 @@ interface StatisticsDao {
         """
     )
     suspend fun getSessionPaces(bookId: Int): List<SessionPace>
+
+    /** Every session's span and words, for figures that need the days too. */
+    @Query("SELECT startTime, endTime, wordsRead FROM ReadingSessionEntity")
+    suspend fun getSessionSpans(): List<SessionSpan>
+
+    @Query("SELECT COUNT(*) FROM ReadBookEntity WHERE finished = 1")
+    suspend fun countBooksRead(): Int
 
     /** Days on which this book was read at all, in the reader's own time zone. */
     @Query(

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
@@ -14,6 +14,7 @@ import androidx.room.Query
 import ua.acclorite.book_story.data.local.dto.ReadBookEntity
 import ua.acclorite.book_story.data.local.dto.ReadingCoverageEntity
 import ua.acclorite.book_story.data.local.dto.ReadingSessionEntity
+import ua.acclorite.book_story.data.local.dto.SessionPace
 
 @Dao
 interface StatisticsDao {
@@ -29,6 +30,36 @@ interface StatisticsDao {
      */
     @Query("UPDATE ReadingSessionEntity SET bookId = NULL WHERE bookId = :bookId")
     suspend fun anonymiseBookSessions(bookId: Int)
+
+    /** Pace of every session that has words to divide, for a typical figure. */
+    @Query(
+        """
+        SELECT (endTime - startTime) AS durationMs, wordsRead AS wordsRead
+        FROM ReadingSessionEntity
+        WHERE wordsRead > 0
+        """
+    )
+    suspend fun getSessionPaces(): List<SessionPace>
+
+    /** The same, for one book. */
+    @Query(
+        """
+        SELECT (endTime - startTime) AS durationMs, wordsRead AS wordsRead
+        FROM ReadingSessionEntity
+        WHERE bookId = :bookId AND wordsRead > 0
+        """
+    )
+    suspend fun getSessionPaces(bookId: Int): List<SessionPace>
+
+    /** Days on which this book was read at all, in the reader's own time zone. */
+    @Query(
+        """
+        SELECT COUNT(DISTINCT date(startTime / 1000, 'unixepoch', 'localtime'))
+        FROM ReadingSessionEntity
+        WHERE bookId = :bookId
+        """
+    )
+    suspend fun countActiveDays(bookId: Int): Int
 
     @Query("SELECT * FROM readingcoverageentity WHERE bookId = :bookId")
     suspend fun getCoverage(bookId: Int): ReadingCoverageEntity?
@@ -85,10 +116,14 @@ interface StatisticsDao {
     suspend fun setFinished(bookId: Int, finished: Boolean): Int
 
     /**
-     * Keeps the record of a deleted book, without the book. It stays on the
-     * shelf, with its time and its dates; a re-import is a new book and starts
-     * a record of its own.
+     * Keeps the record of a deleted book, without the book: its time, dates and
+     * counts stay in the lifetime figures, but it stops being named.
+     *
+     * Deleting a book in this app already means "gone" — the reader's history
+     * for it is deleted too — so a record that went on naming it would quietly
+     * break that promise. What is left is an unnamed row. A re-import is a new
+     * book and starts a record of its own.
      */
-    @Query("UPDATE ReadBookEntity SET bookId = NULL WHERE bookId = :bookId")
+    @Query("UPDATE ReadBookEntity SET bookId = NULL, title = '', author = '' WHERE bookId = :bookId")
     suspend fun unlinkReadBook(bookId: Int)
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
@@ -11,6 +11,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import ua.acclorite.book_story.data.local.dto.ReadBookEntity
 import ua.acclorite.book_story.data.local.dto.ReadingCoverageEntity
 import ua.acclorite.book_story.data.local.dto.ReadingSessionEntity
@@ -141,4 +142,26 @@ interface StatisticsDao {
      */
     @Query("UPDATE ReadBookEntity SET bookId = NULL, title = '', author = '' WHERE bookId = :bookId")
     suspend fun unlinkReadBook(bookId: Int)
+
+    /**
+     * Erases every measurement. Unlike deleting a book — which anonymises its
+     * sessions so the reading still counts towards the lifetime totals — this
+     * leaves nothing behind anywhere, because that is the only thing it could
+     * honestly mean.
+     */
+    @Transaction
+    suspend fun deleteAllStatistics() {
+        deleteAllSessions()
+        deleteAllReadBooks()
+        deleteAllCoverage()
+    }
+
+    @Query("DELETE FROM ReadingSessionEntity")
+    suspend fun deleteAllSessions()
+
+    @Query("DELETE FROM ReadBookEntity")
+    suspend fun deleteAllReadBooks()
+
+    @Query("DELETE FROM ReadingCoverageEntity")
+    suspend fun deleteAllCoverage()
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
@@ -11,6 +11,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import ua.acclorite.book_story.data.local.dto.ReadBookEntity
 import ua.acclorite.book_story.data.local.dto.ReadingCoverageEntity
 import ua.acclorite.book_story.data.local.dto.ReadingSessionEntity
 
@@ -38,4 +39,56 @@ interface StatisticsDao {
     /** Unlike sessions, coverage goes: without the text its indices mean nothing. */
     @Query("DELETE FROM readingcoverageentity WHERE bookId = :bookId")
     suspend fun deleteCoverage(bookId: Int)
+
+    @Query("SELECT * FROM readbookentity WHERE bookId = :bookId")
+    suspend fun getReadBook(bookId: Int): ReadBookEntity?
+
+    /**
+     * Folds one finished session into the book's record, in SQL rather than by
+     * reading the row and writing it back — the totals are accumulated where
+     * they live.
+     *
+     * `finished` only ever goes up: [reachedEnd] says this session got to the
+     * end of the book, and a later session that stops earlier must not take
+     * that back. Returns 0 when the book has no record yet.
+     */
+    @Query(
+        """
+        UPDATE ReadBookEntity
+        SET totalTimeMs = totalTimeMs + :timeMs,
+            totalWords = totalWords + :words,
+            sessions = sessions + 1,
+            lastReadAt = :lastReadAt,
+            coveragePercent = :coveragePercent,
+            finished = MAX(finished, :reachedEnd),
+            title = :title,
+            author = :author
+        WHERE bookId = :bookId
+        """
+    )
+    suspend fun addSessionToReadBook(
+        bookId: Int,
+        timeMs: Long,
+        words: Int,
+        lastReadAt: Long,
+        coveragePercent: Float,
+        reachedEnd: Boolean,
+        title: String,
+        author: String
+    ): Int
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertReadBook(readBook: ReadBookEntity)
+
+    /** The reader's own statement, so this one is set rather than accumulated. */
+    @Query("UPDATE ReadBookEntity SET finished = :finished WHERE bookId = :bookId")
+    suspend fun setFinished(bookId: Int, finished: Boolean): Int
+
+    /**
+     * Keeps the record of a deleted book, without the book. It stays on the
+     * shelf, with its time and its dates; a re-import is a new book and starts
+     * a record of its own.
+     */
+    @Query("UPDATE ReadBookEntity SET bookId = NULL WHERE bookId = :bookId")
+    suspend fun unlinkReadBook(bookId: Int)
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
@@ -9,7 +9,9 @@ package ua.acclorite.book_story.data.local.room
 
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import ua.acclorite.book_story.data.local.dto.ReadingCoverageEntity
 import ua.acclorite.book_story.data.local.dto.ReadingSessionEntity
 
 @Dao
@@ -26,4 +28,14 @@ interface StatisticsDao {
      */
     @Query("UPDATE ReadingSessionEntity SET bookId = NULL WHERE bookId = :bookId")
     suspend fun anonymiseBookSessions(bookId: Int)
+
+    @Query("SELECT * FROM readingcoverageentity WHERE bookId = :bookId")
+    suspend fun getCoverage(bookId: Int): ReadingCoverageEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun saveCoverage(coverage: ReadingCoverageEntity)
+
+    /** Unlike sessions, coverage goes: without the text its indices mean nothing. */
+    @Query("DELETE FROM readingcoverageentity WHERE bookId = :bookId")
+    suspend fun deleteCoverage(bookId: Int)
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
@@ -1,0 +1,29 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.local.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import ua.acclorite.book_story.data.local.dto.ReadingSessionEntity
+
+@Dao
+interface StatisticsDao {
+
+    @Insert
+    suspend fun insertSession(session: ReadingSessionEntity)
+
+    /**
+     * Unlinks a deleted book's sessions instead of deleting them. The per-book
+     * detail stops matching `WHERE bookId = :bookId` and disappears, while the
+     * day, the duration and the words stay in the lifetime totals — so deleting
+     * a book cannot retroactively shorten a streak or shrink the total time.
+     */
+    @Query("UPDATE ReadingSessionEntity SET bookId = NULL WHERE bookId = :bookId")
+    suspend fun anonymiseBookSessions(bookId: Int)
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/StatisticsDao.kt
@@ -32,10 +32,17 @@ interface StatisticsDao {
     @Query("UPDATE ReadingSessionEntity SET bookId = NULL WHERE bookId = :bookId")
     suspend fun anonymiseBookSessions(bookId: Int)
 
-    /** Pace of every session that has words to divide, for a typical figure. */
+    /**
+     * Pace of every session that has words to divide, for a typical figure.
+     *
+     * The duration is the *reading* time: overlay time earns no words, so
+     * leaving it in the denominator would let a few minutes in the image viewer
+     * halve a session's words per minute. Time in the book, days and streaks
+     * still read the interval whole.
+     */
     @Query(
         """
-        SELECT (endTime - startTime) AS durationMs, wordsRead AS wordsRead
+        SELECT (endTime - startTime - overlayMs) AS durationMs, wordsRead AS wordsRead
         FROM ReadingSessionEntity
         WHERE wordsRead > 0
         """
@@ -45,7 +52,7 @@ interface StatisticsDao {
     /** The same, for one book. */
     @Query(
         """
-        SELECT (endTime - startTime) AS durationMs, wordsRead AS wordsRead
+        SELECT (endTime - startTime - overlayMs) AS durationMs, wordsRead AS wordsRead
         FROM ReadingSessionEntity
         WHERE bookId = :bookId AND wordsRead > 0
         """

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
@@ -1,0 +1,47 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import ua.acclorite.book_story.core.helpers.runCatchingCancellable
+import ua.acclorite.book_story.data.local.dto.ReadingSessionEntity
+import ua.acclorite.book_story.data.local.room.BookDatabase
+import ua.acclorite.book_story.domain.model.statistics.ReadingSession
+import ua.acclorite.book_story.domain.repository.StatisticsRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class StatisticsRepositoryImpl @Inject constructor(
+    private val database: BookDatabase
+) : StatisticsRepository {
+
+    // Mapped here rather than through a Mapper class: the row is the model, with
+    // nothing to join and no UI type to build.
+    override suspend fun addSession(session: ReadingSession): Result<Unit> =
+        runCatchingCancellable {
+            withContext(Dispatchers.IO) {
+                database.statisticsDao.insertSession(
+                    ReadingSessionEntity(
+                        bookId = session.bookId,
+                        startTime = session.startTime,
+                        endTime = session.endTime,
+                        wordsRead = session.wordsRead
+                    )
+                )
+            }
+        }
+
+    override suspend fun anonymiseBookSessions(bookId: Int): Result<Unit> =
+        runCatchingCancellable {
+            withContext(Dispatchers.IO) {
+                database.statisticsDao.anonymiseBookSessions(bookId = bookId)
+            }
+        }
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
@@ -65,7 +65,8 @@ class StatisticsRepositoryImpl @Inject constructor(
                         itemCount = entity.itemCount,
                         bookWords = entity.bookWords,
                         covered = CoverageCodec.decode(entity.intervals),
-                        coveredWords = entity.coveredWords
+                        coveredWords = entity.coveredWords,
+                        wordsBeforeBookmark = entity.wordsBeforeBookmark
                     )
                 }
             }
@@ -80,7 +81,8 @@ class StatisticsRepositoryImpl @Inject constructor(
                         itemCount = coverage.itemCount,
                         bookWords = coverage.bookWords,
                         intervals = CoverageCodec.encode(coverage.covered),
-                        coveredWords = coverage.coveredWords
+                        coveredWords = coverage.coveredWords,
+                        wordsBeforeBookmark = coverage.wordsBeforeBookmark
                     )
                 )
             }

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
@@ -15,11 +15,15 @@ import ua.acclorite.book_story.data.local.dto.ReadingCoverageEntity
 import ua.acclorite.book_story.data.local.dto.ReadingSessionEntity
 import ua.acclorite.book_story.data.local.room.BookDatabase
 import ua.acclorite.book_story.domain.model.statistics.CoverageCodec
+import ua.acclorite.book_story.domain.model.statistics.LibraryStatistics
 import ua.acclorite.book_story.domain.model.statistics.ReadBook
+import ua.acclorite.book_story.domain.model.statistics.ReadingDays
 import ua.acclorite.book_story.domain.model.statistics.ReadingPace
 import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
 import ua.acclorite.book_story.domain.model.statistics.ReadingSession
 import ua.acclorite.book_story.domain.repository.StatisticsRepository
+import java.time.LocalDate
+import java.time.ZoneId
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -200,6 +204,40 @@ class StatisticsRepositoryImpl @Inject constructor(
         runCatchingCancellable {
             withContext(Dispatchers.IO) {
                 database.statisticsDao.countActiveDays(bookId)
+            }
+        }
+
+    override suspend fun getLibraryStatistics(): Result<LibraryStatistics> =
+        runCatchingCancellable {
+            withContext(Dispatchers.IO) {
+                val sessions = database.statisticsDao.getSessionSpans()
+                val zone = ZoneId.systemDefault()
+
+                // Days are counted from the sessions rather than stored, and a
+                // session that runs past midnight lands on both days.
+                val days = mutableSetOf<LocalDate>()
+                var totalTimeMs = 0L
+                var words = 0L
+
+                sessions.forEach { session ->
+                    totalTimeMs += (session.endTime - session.startTime).coerceAtLeast(0)
+                    words += session.wordsRead
+                    ReadingDays.split(session.startTime, session.endTime, zone).forEach {
+                        days.add(it.day)
+                    }
+                }
+
+                LibraryStatistics(
+                    totalTimeMs = totalTimeMs,
+                    wordsRead = words,
+                    wordsPerMinute = ReadingPace.typical(
+                        database.statisticsDao.getSessionPaces().mapNotNull { pace ->
+                            ReadingPace.wordsPerMinute(pace.durationMs, pace.wordsRead)
+                        }
+                    ),
+                    booksRead = database.statisticsDao.countBooksRead(),
+                    daysRead = days.size
+                )
             }
         }
 

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
@@ -10,8 +10,11 @@ package ua.acclorite.book_story.data.repository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import ua.acclorite.book_story.core.helpers.runCatchingCancellable
+import ua.acclorite.book_story.data.local.dto.ReadingCoverageEntity
 import ua.acclorite.book_story.data.local.dto.ReadingSessionEntity
 import ua.acclorite.book_story.data.local.room.BookDatabase
+import ua.acclorite.book_story.domain.model.statistics.CoverageCodec
+import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
 import ua.acclorite.book_story.domain.model.statistics.ReadingSession
 import ua.acclorite.book_story.domain.repository.StatisticsRepository
 import javax.inject.Inject
@@ -42,6 +45,43 @@ class StatisticsRepositoryImpl @Inject constructor(
         runCatchingCancellable {
             withContext(Dispatchers.IO) {
                 database.statisticsDao.anonymiseBookSessions(bookId = bookId)
+            }
+        }
+
+    override suspend fun getCoverage(bookId: Int): Result<ReadingCoverage?> =
+        runCatchingCancellable {
+            withContext(Dispatchers.IO) {
+                database.statisticsDao.getCoverage(bookId)?.let { entity ->
+                    ReadingCoverage(
+                        bookId = entity.bookId,
+                        itemCount = entity.itemCount,
+                        bookWords = entity.bookWords,
+                        covered = CoverageCodec.decode(entity.intervals),
+                        coveredWords = entity.coveredWords
+                    )
+                }
+            }
+        }
+
+    override suspend fun saveCoverage(coverage: ReadingCoverage): Result<Unit> =
+        runCatchingCancellable {
+            withContext(Dispatchers.IO) {
+                database.statisticsDao.saveCoverage(
+                    ReadingCoverageEntity(
+                        bookId = coverage.bookId,
+                        itemCount = coverage.itemCount,
+                        bookWords = coverage.bookWords,
+                        intervals = CoverageCodec.encode(coverage.covered),
+                        coveredWords = coverage.coveredWords
+                    )
+                )
+            }
+        }
+
+    override suspend fun deleteCoverage(bookId: Int): Result<Unit> =
+        runCatchingCancellable {
+            withContext(Dispatchers.IO) {
+                database.statisticsDao.deleteCoverage(bookId = bookId)
             }
         }
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
@@ -10,7 +10,6 @@ package ua.acclorite.book_story.data.repository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import ua.acclorite.book_story.core.helpers.runCatchingCancellable
-import ua.acclorite.book_story.data.local.dto.ReadBookEntity
 import ua.acclorite.book_story.data.local.dto.ReadingCoverageEntity
 import ua.acclorite.book_story.data.local.dto.ReadingSessionEntity
 import ua.acclorite.book_story.data.local.room.BookDatabase
@@ -134,33 +133,17 @@ class StatisticsRepositoryImpl @Inject constructor(
         reachedEnd: Boolean
     ): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
-            val updated = database.statisticsDao.addSessionToReadBook(
+            // Updating an existing record or starting one is a single
+            // transaction in the DAO: the two halves must not be separable.
+            database.statisticsDao.addSessionToBookRecord(
                 bookId = bookId,
                 timeMs = timeMs,
                 words = words,
-                lastReadAt = endedAt,
+                endedAt = endedAt,
                 coveragePercent = coveragePercent,
                 reachedEnd = reachedEnd,
                 title = title,
                 author = author
-            )
-            if (updated > 0) return@withContext
-
-            // First session with this book: the record starts here, which is
-            // also the only moment its firstReadAt is knowable.
-            database.statisticsDao.insertReadBook(
-                ReadBookEntity(
-                    bookId = bookId,
-                    title = title,
-                    author = author,
-                    totalTimeMs = timeMs,
-                    totalWords = words,
-                    sessions = 1,
-                    firstReadAt = endedAt - timeMs,
-                    lastReadAt = endedAt,
-                    finished = reachedEnd,
-                    coveragePercent = coveragePercent
-                )
             )
         }
     }
@@ -172,25 +155,14 @@ class StatisticsRepositoryImpl @Inject constructor(
         finished: Boolean
     ): Result<Unit> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
-            val updated = database.statisticsDao.setFinished(bookId = bookId, finished = finished)
-            if (updated > 0) return@withContext
-
-            // Marked without ever having been read here — an empty record is
-            // still the truthful one.
-            val now = System.currentTimeMillis()
-            database.statisticsDao.insertReadBook(
-                ReadBookEntity(
-                    bookId = bookId,
-                    title = title,
-                    author = author,
-                    totalTimeMs = 0,
-                    totalWords = 0,
-                    sessions = 0,
-                    firstReadAt = now,
-                    lastReadAt = now,
-                    finished = finished,
-                    coveragePercent = 0f
-                )
+            // Marking a book never read here starts an empty record, in the
+            // same transaction as the update that found none.
+            database.statisticsDao.setBookFinished(
+                bookId = bookId,
+                title = title,
+                author = author,
+                finished = finished,
+                now = System.currentTimeMillis()
             )
         }
     }

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
@@ -16,6 +16,7 @@ import ua.acclorite.book_story.data.local.dto.ReadingSessionEntity
 import ua.acclorite.book_story.data.local.room.BookDatabase
 import ua.acclorite.book_story.domain.model.statistics.CoverageCodec
 import ua.acclorite.book_story.domain.model.statistics.ReadBook
+import ua.acclorite.book_story.domain.model.statistics.ReadingPace
 import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
 import ua.acclorite.book_story.domain.model.statistics.ReadingSession
 import ua.acclorite.book_story.domain.repository.StatisticsRepository
@@ -179,6 +180,28 @@ class StatisticsRepositoryImpl @Inject constructor(
             )
         }
     }
+
+    override suspend fun getTypicalWordsPerMinute(bookId: Int?): Result<Int?> =
+        runCatchingCancellable {
+            withContext(Dispatchers.IO) {
+                val paces =
+                    if (bookId == null) database.statisticsDao.getSessionPaces()
+                    else database.statisticsDao.getSessionPaces(bookId)
+
+                ReadingPace.typical(
+                    paces.mapNotNull { pace ->
+                        ReadingPace.wordsPerMinute(pace.durationMs, pace.wordsRead)
+                    }
+                )
+            }
+        }
+
+    override suspend fun countActiveDays(bookId: Int): Result<Int> =
+        runCatchingCancellable {
+            withContext(Dispatchers.IO) {
+                database.statisticsDao.countActiveDays(bookId)
+            }
+        }
 
     override suspend fun unlinkReadBook(bookId: Int): Result<Unit> =
         runCatchingCancellable {

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
@@ -42,7 +42,8 @@ class StatisticsRepositoryImpl @Inject constructor(
                         bookId = session.bookId,
                         startTime = session.startTime,
                         endTime = session.endTime,
-                        wordsRead = session.wordsRead
+                        wordsRead = session.wordsRead,
+                        overlayMs = session.overlayMs
                     )
                 )
             }

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
@@ -88,6 +88,13 @@ class StatisticsRepositoryImpl @Inject constructor(
             }
         }
 
+    override suspend fun deleteAllStatistics(): Result<Unit> =
+        runCatchingCancellable {
+            withContext(Dispatchers.IO) {
+                database.statisticsDao.deleteAllStatistics()
+            }
+        }
+
     override suspend fun deleteCoverage(bookId: Int): Result<Unit> =
         runCatchingCancellable {
             withContext(Dispatchers.IO) {

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/StatisticsRepositoryImpl.kt
@@ -10,10 +10,12 @@ package ua.acclorite.book_story.data.repository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import ua.acclorite.book_story.core.helpers.runCatchingCancellable
+import ua.acclorite.book_story.data.local.dto.ReadBookEntity
 import ua.acclorite.book_story.data.local.dto.ReadingCoverageEntity
 import ua.acclorite.book_story.data.local.dto.ReadingSessionEntity
 import ua.acclorite.book_story.data.local.room.BookDatabase
 import ua.acclorite.book_story.domain.model.statistics.CoverageCodec
+import ua.acclorite.book_story.domain.model.statistics.ReadBook
 import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
 import ua.acclorite.book_story.domain.model.statistics.ReadingSession
 import ua.acclorite.book_story.domain.repository.StatisticsRepository
@@ -82,6 +84,106 @@ class StatisticsRepositoryImpl @Inject constructor(
         runCatchingCancellable {
             withContext(Dispatchers.IO) {
                 database.statisticsDao.deleteCoverage(bookId = bookId)
+            }
+        }
+
+    override suspend fun getReadBook(bookId: Int): Result<ReadBook?> =
+        runCatchingCancellable {
+            withContext(Dispatchers.IO) {
+                database.statisticsDao.getReadBook(bookId)?.let { entity ->
+                    ReadBook(
+                        id = entity.id,
+                        bookId = entity.bookId,
+                        title = entity.title,
+                        author = entity.author,
+                        totalTimeMs = entity.totalTimeMs,
+                        totalWords = entity.totalWords,
+                        sessions = entity.sessions,
+                        firstReadAt = entity.firstReadAt,
+                        lastReadAt = entity.lastReadAt,
+                        finished = entity.finished,
+                        coveragePercent = entity.coveragePercent
+                    )
+                }
+            }
+        }
+
+    override suspend fun addSessionToReadBook(
+        bookId: Int,
+        title: String,
+        author: String,
+        timeMs: Long,
+        words: Int,
+        endedAt: Long,
+        coveragePercent: Float,
+        reachedEnd: Boolean
+    ): Result<Unit> = runCatchingCancellable {
+        withContext(Dispatchers.IO) {
+            val updated = database.statisticsDao.addSessionToReadBook(
+                bookId = bookId,
+                timeMs = timeMs,
+                words = words,
+                lastReadAt = endedAt,
+                coveragePercent = coveragePercent,
+                reachedEnd = reachedEnd,
+                title = title,
+                author = author
+            )
+            if (updated > 0) return@withContext
+
+            // First session with this book: the record starts here, which is
+            // also the only moment its firstReadAt is knowable.
+            database.statisticsDao.insertReadBook(
+                ReadBookEntity(
+                    bookId = bookId,
+                    title = title,
+                    author = author,
+                    totalTimeMs = timeMs,
+                    totalWords = words,
+                    sessions = 1,
+                    firstReadAt = endedAt - timeMs,
+                    lastReadAt = endedAt,
+                    finished = reachedEnd,
+                    coveragePercent = coveragePercent
+                )
+            )
+        }
+    }
+
+    override suspend fun setFinished(
+        bookId: Int,
+        title: String,
+        author: String,
+        finished: Boolean
+    ): Result<Unit> = runCatchingCancellable {
+        withContext(Dispatchers.IO) {
+            val updated = database.statisticsDao.setFinished(bookId = bookId, finished = finished)
+            if (updated > 0) return@withContext
+
+            // Marked without ever having been read here — an empty record is
+            // still the truthful one.
+            val now = System.currentTimeMillis()
+            database.statisticsDao.insertReadBook(
+                ReadBookEntity(
+                    bookId = bookId,
+                    title = title,
+                    author = author,
+                    totalTimeMs = 0,
+                    totalWords = 0,
+                    sessions = 0,
+                    firstReadAt = now,
+                    lastReadAt = now,
+                    finished = finished,
+                    coveragePercent = 0f
+                )
+            )
+        }
+    }
+
+    override suspend fun unlinkReadBook(bookId: Int): Result<Unit> =
+        runCatchingCancellable {
+            withContext(Dispatchers.IO) {
+                database.statisticsDao.unlinkReadBook(bookId = bookId)
             }
         }
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/settings/SettingsManager.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/settings/SettingsManager.kt
@@ -120,6 +120,16 @@ class SettingsManager @Inject constructor(
         key = booleanPreferencesKey("cache_images_in_books"), default = false
     )
 
+    /**
+     * Whether reading is measured at all. Gates the *writes* only — turning it
+     * off stops new sessions and coverage from being recorded, and leaves
+     * everything already recorded alone, which is what "stop collecting" means.
+     * Erasing is a separate, explicit action.
+     */
+    val collectStatistics = setting<Boolean, Boolean>(
+        key = booleanPreferencesKey("collect_statistics"), default = true
+    )
+
     /* ------ Reader ----------------------------- */
     val fontFamily = setting<FontWithName, String>(
         key = stringPreferencesKey("font"), default = ReaderData.fonts[0],

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/BookStatistics.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/BookStatistics.kt
@@ -1,0 +1,51 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * What the book's card shows. Every figure that cannot be trusted yet is null
+ * rather than zero, so the card can leave it out instead of stating something
+ * false.
+ */
+@Immutable
+data class BookStatistics(
+    val totalTimeMs: Long,
+    val sessions: Int,
+    val finished: Boolean,
+    /** Share of the book actually read — not where the bookmark sits. */
+    val coveragePercent: Float,
+    val bookWords: Int,
+    val coveredWords: Int,
+    /** Pace in this book, and across all reading, for comparison. */
+    val wordsPerMinute: Int?,
+    val typicalWordsPerMinute: Int?,
+    val timeLeftMs: Long?,
+    val finishedBy: Long?
+) {
+    val wordsLeft: Int get() = (bookWords - coveredWords).coerceAtLeast(0)
+
+    /** Nothing has been read here yet, so the card has nothing to say. */
+    val isEmpty: Boolean get() = sessions == 0 && totalTimeMs == 0L
+
+    companion object {
+        val none = BookStatistics(
+            totalTimeMs = 0,
+            sessions = 0,
+            finished = false,
+            coveragePercent = 0f,
+            bookWords = 0,
+            coveredWords = 0,
+            wordsPerMinute = null,
+            typicalWordsPerMinute = null,
+            timeLeftMs = null,
+            finishedBy = null
+        )
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/BookStatistics.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/BookStatistics.kt
@@ -29,8 +29,6 @@ data class BookStatistics(
     val timeLeftMs: Long?,
     val finishedBy: Long?
 ) {
-    val wordsLeft: Int get() = (bookWords - coveredWords).coerceAtLeast(0)
-
     /** Nothing has been read here yet, so the card has nothing to say. */
     val isEmpty: Boolean get() = sessions == 0 && totalTimeMs == 0L
 

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/CoverageCodec.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/CoverageCodec.kt
@@ -1,0 +1,84 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+/**
+ * Coverage is a set of item indices while a book is open — adding to it is a
+ * single call and asking "was this read" is free — and a string of ranges on
+ * disk, where a fully read book is a handful of bytes rather than tens of
+ * thousands of numbers.
+ *
+ * The format is ascending, non-overlapping, comma-separated: `"12-480,3900"`.
+ * A single index is written on its own, without a redundant `12-12`.
+ */
+object CoverageCodec {
+
+    fun encode(covered: Set<Int>): String {
+        if (covered.isEmpty()) return ""
+
+        val sorted = covered.toIntArray()
+        sorted.sort()
+
+        return buildString {
+            var start = sorted.first()
+            var end = start
+
+            for (index in 1 until sorted.size) {
+                val value = sorted[index]
+                if (value == end + 1) {
+                    end = value
+                    continue
+                }
+
+                appendRange(start, end)
+                append(',')
+                start = value
+                end = value
+            }
+
+            appendRange(start, end)
+        }
+    }
+
+    /**
+     * Tolerant on purpose: this string has been through a database, and a
+     * malformed piece of it should cost the range it describes, not the whole
+     * reading history of the book.
+     */
+    fun decode(encoded: String): Set<Int> {
+        if (encoded.isBlank()) return emptySet()
+
+        val covered = mutableSetOf<Int>()
+        for (part in encoded.split(',')) {
+            val range = part.trim()
+            if (range.isEmpty()) continue
+
+            val dash = range.indexOf('-')
+            if (dash == -1) {
+                range.toIntOrNull()?.let { covered.add(it) }
+                continue
+            }
+
+            val start = range.substring(0, dash).trim().toIntOrNull() ?: continue
+            val end = range.substring(dash + 1).trim().toIntOrNull() ?: continue
+            if (end < start) continue
+
+            for (index in start..end) covered.add(index)
+        }
+
+        return covered
+    }
+
+    private fun StringBuilder.appendRange(start: Int, end: Int) {
+        append(start)
+        if (end != start) {
+            append('-')
+            append(end)
+        }
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/LibraryStatistics.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/LibraryStatistics.kt
@@ -1,0 +1,43 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Reading across the whole library, and across books that are no longer in it.
+ *
+ * Every figure is aggregated from the session rows, anonymised ones included, so
+ * deleting a book cannot retroactively shrink the total or shorten the days —
+ * which also means these totals will not add up to the sum of the per-book cards
+ * once anything has been deleted. That is worth saying in the UI rather than
+ * hiding.
+ */
+@Immutable
+data class LibraryStatistics(
+    val totalTimeMs: Long,
+    val wordsRead: Long,
+    /** Median across sessions; null until there is a minute to divide. */
+    val wordsPerMinute: Int?,
+    /** Books the reader marked, or reaching the end marked, as finished. */
+    val booksRead: Int,
+    /** Days with any reading at all. Not consecutive — nothing to break. */
+    val daysRead: Int
+) {
+    val isEmpty: Boolean get() = totalTimeMs == 0L && daysRead == 0
+
+    companion object {
+        val none = LibraryStatistics(
+            totalTimeMs = 0,
+            wordsRead = 0,
+            wordsPerMinute = null,
+            booksRead = 0,
+            daysRead = 0
+        )
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadBook.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadBook.kt
@@ -28,19 +28,12 @@ data class ReadBook(
     val lastReadAt: Long,
     val finished: Boolean,
     val coveragePercent: Float
-) {
-    /**
-     * Words per minute over everything ever read of this book. Null until there
-     * is enough to divide by — a first short sitting says nothing about pace.
-     */
-    val wordsPerMinute: Int?
-        get() {
-            if (totalTimeMs < MIN_TIME_FOR_PACE_MS || totalWords <= 0) return null
-            return (totalWords * 60_000.0 / totalTimeMs).toInt()
-        }
+)
 
-    companion object {
-        /** Below this a pace is noise: one page and a distraction. */
-        const val MIN_TIME_FOR_PACE_MS = 60_000L
-    }
-}
+/*
+ * There is deliberately no pace on this row. [totalTimeMs] is time spent with
+ * the book, overlay time included, and this row does not carry the overlay
+ * separately to take it back out — so a pace divided from it would be the one
+ * figure the image viewer could still distort. A book's pace is a median over
+ * its sessions instead, where the overlay is known.
+ */

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadBook.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadBook.kt
@@ -1,0 +1,46 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * A book's own reading record, kept for as long as the statistics are — the
+ * shelf of everything ever read. Unlike the sessions it is built from, it
+ * survives the book being deleted: the row is unlinked, not removed.
+ */
+@Immutable
+data class ReadBook(
+    val id: Int,
+    /** The live book, or null once it has been deleted from the library. */
+    val bookId: Int?,
+    val title: String,
+    val author: String,
+    val totalTimeMs: Long,
+    val totalWords: Int,
+    val sessions: Int,
+    val firstReadAt: Long,
+    val lastReadAt: Long,
+    val finished: Boolean,
+    val coveragePercent: Float
+) {
+    /**
+     * Words per minute over everything ever read of this book. Null until there
+     * is enough to divide by — a first short sitting says nothing about pace.
+     */
+    val wordsPerMinute: Int?
+        get() {
+            if (totalTimeMs < MIN_TIME_FOR_PACE_MS || totalWords <= 0) return null
+            return (totalWords * 60_000.0 / totalTimeMs).toInt()
+        }
+
+    companion object {
+        /** Below this a pace is noise: one page and a distraction. */
+        const val MIN_TIME_FOR_PACE_MS = 60_000L
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReaderTextWords.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReaderTextWords.kt
@@ -7,6 +7,7 @@
 
 package ua.acclorite.book_story.domain.model.statistics
 
+import androidx.compose.ui.text.AnnotatedString
 import ua.acclorite.book_story.domain.model.reader.ReaderText
 
 /**
@@ -22,6 +23,13 @@ fun ReaderText.wordCount(): Int = when (this) {
     is ReaderText.Image -> caption?.line?.text?.countWords() ?: 0
     ReaderText.Separator -> 0
 }
+
+/**
+ * How many words a footnote is worth. Notes live outside the text list, so they
+ * are counted on their own — never as part of the book's total, which is what
+ * coverage is measured against.
+ */
+fun AnnotatedString.wordCount(): Int = text.countWords()
 
 /**
  * Runs of non-whitespace. Deliberately allocation-free: this runs over every

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReaderTextWords.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReaderTextWords.kt
@@ -25,6 +25,22 @@ fun ReaderText.wordCount(): Int = when (this) {
 }
 
 /**
+ * Words before each item: entry `i` totals items `0 until i`, so the last entry
+ * is the whole book. Built by the same single pass that produces that total, and
+ * it is what turns a bookmark index into "how much is still ahead of me" — a
+ * different question from how much coverage has never seen.
+ */
+fun List<ReaderText>.wordPrefixSums(): IntArray {
+    val prefix = IntArray(size + 1)
+
+    for (index in indices) {
+        prefix[index + 1] = prefix[index] + this[index].wordCount()
+    }
+
+    return prefix
+}
+
+/**
  * How many words a footnote is worth. Notes live outside the text list, so they
  * are counted on their own — never as part of the book's total, which is what
  * coverage is measured against.

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReaderTextWords.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReaderTextWords.kt
@@ -1,0 +1,44 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+import ua.acclorite.book_story.domain.model.reader.ReaderText
+
+/**
+ * How many words this item is worth. Counted from what the reader actually sees,
+ * so a chapter heading and a table's cells count while a separator does not, and
+ * an image counts only its caption.
+ */
+fun ReaderText.wordCount(): Int = when (this) {
+    is ReaderText.Text -> line.text.countWords()
+    is ReaderText.Chapter -> title.countWords()
+    is ReaderText.Poem -> lines.sumOf { it.line.text.countWords() }
+    is ReaderText.Table -> rows.sumOf { row -> row.sumOf { cell -> cell.text.countWords() } }
+    is ReaderText.Image -> caption?.line?.text?.countWords() ?: 0
+    ReaderText.Separator -> 0
+}
+
+/**
+ * Runs of non-whitespace. Deliberately allocation-free: this runs over every
+ * item of the book once, and over the visible ones on every settled scroll.
+ */
+internal fun String.countWords(): Int {
+    var words = 0
+    var inWord = false
+
+    for (character in this) {
+        if (character.isWhitespace()) {
+            inWord = false
+        } else if (!inWord) {
+            inWord = true
+            words++
+        }
+    }
+
+    return words
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadingCoverage.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadingCoverage.kt
@@ -1,0 +1,47 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+/**
+ * Which parts of a book have been read, as opposed to where its bookmark sits.
+ *
+ * [covered] holds item indices, so it is only meaningful for the parse it was
+ * recorded against — [itemCount] is the sentinel that says so.
+ */
+data class ReadingCoverage(
+    val bookId: Int,
+    val itemCount: Int,
+    /** Words in the whole book, for "how much is left". */
+    val bookWords: Int,
+    val covered: Set<Int>,
+    /** Words inside [covered] — unique, unlike a session's `wordsRead`. */
+    val coveredWords: Int
+) {
+    val percent: Float
+        get() = if (itemCount <= 0) 0f else covered.size.toFloat() / itemCount
+
+    /**
+     * The coverage to start from for a book whose text now has [itemCount]
+     * items. A parser change shifts every index, so on a mismatch the intervals
+     * are dropped — and only they: what the sessions have already banked is
+     * history and is not reachable from here.
+     */
+    fun validFor(itemCount: Int): ReadingCoverage =
+        if (this.itemCount == itemCount) this
+        else copy(itemCount = itemCount, covered = emptySet(), coveredWords = 0)
+
+    companion object {
+        fun empty(bookId: Int, itemCount: Int, bookWords: Int) = ReadingCoverage(
+            bookId = bookId,
+            itemCount = itemCount,
+            bookWords = bookWords,
+            covered = emptySet(),
+            coveredWords = 0
+        )
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadingCoverage.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadingCoverage.kt
@@ -20,7 +20,18 @@ data class ReadingCoverage(
     val bookWords: Int,
     val covered: Set<Int>,
     /** Words inside [covered] — unique, unlike a session's `wordsRead`. */
-    val coveredWords: Int
+    val coveredWords: Int,
+    /**
+     * Words before the bookmark, for "how much is left to read". Deliberately
+     * *not* derived from [coveredWords]: what is ahead of the reader and what
+     * the measurement has never seen are different questions, and only the
+     * first one is a forecast. A book whose statistics began mid-way has most
+     * of itself uncovered while having almost nothing left.
+     *
+     * Null until the book is opened once with this recorded, and the card then
+     * omits the figure rather than approximating it.
+     */
+    val wordsBeforeBookmark: Int?
 ) {
     val percent: Float
         get() = if (itemCount <= 0) 0f else covered.size.toFloat() / itemCount
@@ -28,12 +39,18 @@ data class ReadingCoverage(
     /**
      * The coverage to start from for a book whose text now has [itemCount]
      * items. A parser change shifts every index, so on a mismatch the intervals
-     * are dropped — and only they: what the sessions have already banked is
-     * history and is not reachable from here.
+     * are dropped — and with them [wordsBeforeBookmark], which was counted up to
+     * an index that now points elsewhere. Only those: what the sessions have
+     * already banked is history and is not reachable from here.
      */
     fun validFor(itemCount: Int): ReadingCoverage =
         if (this.itemCount == itemCount) this
-        else copy(itemCount = itemCount, covered = emptySet(), coveredWords = 0)
+        else copy(
+            itemCount = itemCount,
+            covered = emptySet(),
+            coveredWords = 0,
+            wordsBeforeBookmark = null
+        )
 
     companion object {
         fun empty(bookId: Int, itemCount: Int, bookWords: Int) = ReadingCoverage(
@@ -41,7 +58,8 @@ data class ReadingCoverage(
             itemCount = itemCount,
             bookWords = bookWords,
             covered = emptySet(),
-            coveredWords = 0
+            coveredWords = 0,
+            wordsBeforeBookmark = null
         )
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadingDays.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadingDays.kt
@@ -1,0 +1,62 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * Which local days a stretch of reading belongs to.
+ *
+ * A sitting from 23:50 to 00:30 is reading on **both** days, so it is split at
+ * midnight rather than filed under the day it started. Days are the reader's
+ * own, not UTC: a day ends when their night does.
+ *
+ * Nothing here is stored — days are worked out from the session rows when they
+ * are read, so the rows stay plain facts and a change of mind about boundaries
+ * costs nothing.
+ */
+object ReadingDays {
+
+    /** A day, and how much of a session fell inside it. */
+    data class Share(
+        val day: LocalDate,
+        val timeMs: Long
+    )
+
+    /**
+     * The days [startTime]..[endTime] covers, in order, each with its share of
+     * the time. A session that spans a whole day contributes that whole day.
+     */
+    fun split(startTime: Long, endTime: Long, zone: ZoneId): List<Share> {
+        if (endTime <= startTime) {
+            return listOf(Share(dayOf(startTime, zone), 0))
+        }
+
+        val shares = mutableListOf<Share>()
+        var cursor = startTime
+
+        while (cursor < endTime) {
+            val day = dayOf(cursor, zone)
+            val nextMidnight = day.plusDays(1)
+                .atStartOfDay(zone)
+                .toInstant()
+                .toEpochMilli()
+            val until = minOf(nextMidnight, endTime)
+
+            shares.add(Share(day, until - cursor))
+            cursor = until
+        }
+
+        return shares
+    }
+
+    fun dayOf(millis: Long, zone: ZoneId): LocalDate =
+        Instant.ofEpochMilli(millis).atZone(zone).toLocalDate()
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadingPace.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadingPace.kt
@@ -1,0 +1,66 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+/**
+ * Turning time and words into a reading pace, and pace back into time.
+ *
+ * Everything here refuses to answer rather than answer badly: a pace from a
+ * handful of seconds is noise, and a "time left" built on noise is worse than
+ * no figure at all.
+ */
+object ReadingPace {
+
+    /** Below this a pace says nothing: one page and a distraction. */
+    const val MIN_TIME_MS = 60_000L
+
+    fun wordsPerMinute(timeMs: Long, words: Int): Int? {
+        if (timeMs < MIN_TIME_MS || words <= 0) return null
+        return (words * 60_000.0 / timeMs).toInt().takeIf { it > 0 }
+    }
+
+    /**
+     * The **median** of the paces given, not their mean: a device left open on
+     * a page produces one absurdly slow session, and a mean would carry it into
+     * every figure derived from it.
+     */
+    fun typical(paces: List<Int>): Int? {
+        val sorted = paces.filter { it > 0 }.sorted()
+        if (sorted.isEmpty()) return null
+
+        val middle = sorted.size / 2
+        return if (sorted.size % 2 == 1) sorted[middle]
+        else (sorted[middle - 1] + sorted[middle]) / 2
+    }
+
+    /** How long [words] take at [wordsPerMinute]. */
+    fun timeForWords(words: Int, wordsPerMinute: Int?): Long? {
+        if (wordsPerMinute == null || wordsPerMinute <= 0 || words <= 0) return null
+        return (words * 60_000L) / wordsPerMinute
+    }
+
+    /**
+     * When the remaining [timeLeftMs] runs out, given how much reading happens
+     * on a day when any happens at all. Null when there is not yet a day's worth
+     * of evidence.
+     */
+    fun finishedBy(
+        now: Long,
+        timeLeftMs: Long,
+        totalTimeMs: Long,
+        activeDays: Int
+    ): Long? {
+        if (activeDays <= 0 || totalTimeMs <= 0 || timeLeftMs <= 0) return null
+
+        val perActiveDay = totalTimeMs / activeDays
+        if (perActiveDay <= 0) return null
+
+        val days = Math.ceil(timeLeftMs.toDouble() / perActiveDay).toLong()
+        return now + days * 24 * 60 * 60 * 1000L
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadingSession.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadingSession.kt
@@ -20,9 +20,19 @@ data class ReadingSession(
     val startTime: Long,
     val endTime: Long,
     /** Words credited to this session — the volume read, repeats included. */
-    val wordsRead: Int
+    val wordsRead: Int,
+    /** Time of this session with the text covered; see [readingMs]. */
+    val overlayMs: Long = 0
 ) {
     val durationMs: Long get() = (endTime - startTime).coerceAtLeast(0)
+
+    /**
+     * The part of the session in which words could have been earned — the whole
+     * of it, less the time the image viewer, the settings sheet or the chapters
+     * drawer covered the text. This is what a speed divides by; [durationMs] is
+     * what "time in this book" reports, and it keeps the overlay.
+     */
+    val readingMs: Long get() = (durationMs - overlayMs).coerceAtLeast(0)
 
     companion object {
         /** Anything shorter is an open-and-close, not reading. */
@@ -46,7 +56,8 @@ data class ReadingSession(
             startTime: Long,
             lastActiveTime: Long,
             now: Long,
-            wordsRead: Int
+            wordsRead: Int,
+            overlayMs: Long = 0
         ): ReadingSession? {
             val endTime = now
                 .coerceAtMost(lastActiveTime + IDLE_CAP_MS)
@@ -56,7 +67,11 @@ data class ReadingSession(
                 bookId = bookId,
                 startTime = startTime,
                 endTime = endTime,
-                wordsRead = wordsRead
+                wordsRead = wordsRead,
+                // The cap can pull the end back past where an overlay was still
+                // open — left open in the viewer, the whole tail is overlay. It
+                // can never exceed the session it belongs to.
+                overlayMs = overlayMs.coerceIn(0, endTime - startTime)
             ).takeIf { it.durationMs >= MIN_DURATION_MS }
         }
     }

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadingSession.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/ReadingSession.kt
@@ -1,0 +1,63 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * One stretch of reading: from the text becoming visible to the reader being
+ * left or stopped. Built through [endedAt], which is where the two rules about
+ * what counts live.
+ */
+@Immutable
+data class ReadingSession(
+    val bookId: Int,
+    val startTime: Long,
+    val endTime: Long,
+    /** Words credited to this session — the volume read, repeats included. */
+    val wordsRead: Int
+) {
+    val durationMs: Long get() = (endTime - startTime).coerceAtLeast(0)
+
+    companion object {
+        /** Anything shorter is an open-and-close, not reading. */
+        const val MIN_DURATION_MS = 5_000L
+
+        /**
+         * How much idle is kept after the last sign of life. Only the *tail* is
+         * capped: a book left open overnight stops counting five minutes after
+         * the last scroll, while a pause in the middle of a sitting is counted
+         * in full — staring at one page for a while is still reading.
+         */
+        const val IDLE_CAP_MS = 5 * 60 * 1000L
+
+        /**
+         * The session that ran from [startTime] to [now], or null if it is too
+         * short to mean anything. [lastActiveTime] is when the reader last
+         * settled on a position; it caps the trailing idle.
+         */
+        fun endedAt(
+            bookId: Int,
+            startTime: Long,
+            lastActiveTime: Long,
+            now: Long,
+            wordsRead: Int
+        ): ReadingSession? {
+            val endTime = now
+                .coerceAtMost(lastActiveTime + IDLE_CAP_MS)
+                .coerceAtLeast(startTime)
+
+            return ReadingSession(
+                bookId = bookId,
+                startTime = startTime,
+                endTime = endTime,
+                wordsRead = wordsRead
+            ).takeIf { it.durationMs >= MIN_DURATION_MS }
+        }
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/SessionWords.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/statistics/SessionWords.kt
@@ -1,0 +1,40 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+/**
+ * The words one session has credited: body items by index, footnotes by id.
+ *
+ * Both are de-duplicated within the session, so scrolling back over a screen or
+ * re-opening a note adds nothing the second time. Across sessions they are not:
+ * a page genuinely re-read tomorrow is volume read again, which is what volume
+ * means.
+ */
+class SessionWords {
+
+    private val items = mutableSetOf<Int>()
+    private val notes = mutableSetOf<String>()
+
+    /** Words credited so far — repeats across sessions included. */
+    var total = 0
+        private set
+
+    fun creditItem(index: Int, words: Int) {
+        if (items.add(index)) total += words
+    }
+
+    fun creditNote(id: String, words: Int) {
+        if (notes.add(id)) total += words
+    }
+
+    fun clear() {
+        items.clear()
+        notes.clear()
+        total = 0
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/repository/StatisticsRepository.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/repository/StatisticsRepository.kt
@@ -7,6 +7,7 @@
 
 package ua.acclorite.book_story.domain.repository
 
+import ua.acclorite.book_story.domain.model.statistics.ReadBook
 import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
 import ua.acclorite.book_story.domain.model.statistics.ReadingSession
 
@@ -22,4 +23,28 @@ interface StatisticsRepository {
     suspend fun saveCoverage(coverage: ReadingCoverage): Result<Unit>
 
     suspend fun deleteCoverage(bookId: Int): Result<Unit>
+
+    suspend fun getReadBook(bookId: Int): Result<ReadBook?>
+
+    /** Folds a finished session into the book's record, creating it if needed. */
+    suspend fun addSessionToReadBook(
+        bookId: Int,
+        title: String,
+        author: String,
+        timeMs: Long,
+        words: Int,
+        endedAt: Long,
+        coveragePercent: Float,
+        reachedEnd: Boolean
+    ): Result<Unit>
+
+    suspend fun setFinished(
+        bookId: Int,
+        title: String,
+        author: String,
+        finished: Boolean
+    ): Result<Unit>
+
+    /** See [ua.acclorite.book_story.data.local.room.StatisticsDao.unlinkReadBook]. */
+    suspend fun unlinkReadBook(bookId: Int): Result<Unit>
 }

--- a/app/src/main/java/ua/acclorite/book_story/domain/repository/StatisticsRepository.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/repository/StatisticsRepository.kt
@@ -47,4 +47,13 @@ interface StatisticsRepository {
 
     /** See [ua.acclorite.book_story.data.local.room.StatisticsDao.unlinkReadBook]. */
     suspend fun unlinkReadBook(bookId: Int): Result<Unit>
+
+    /**
+     * Median words per minute across sessions — of one book when [bookId] is
+     * given, of all reading otherwise. A median because one session spent
+     * flicking through pages is enough to wreck a mean.
+     */
+    suspend fun getTypicalWordsPerMinute(bookId: Int? = null): Result<Int?>
+
+    suspend fun countActiveDays(bookId: Int): Result<Int>
 }

--- a/app/src/main/java/ua/acclorite/book_story/domain/repository/StatisticsRepository.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/repository/StatisticsRepository.kt
@@ -7,6 +7,7 @@
 
 package ua.acclorite.book_story.domain.repository
 
+import ua.acclorite.book_story.domain.model.statistics.LibraryStatistics
 import ua.acclorite.book_story.domain.model.statistics.ReadBook
 import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
 import ua.acclorite.book_story.domain.model.statistics.ReadingSession
@@ -56,4 +57,7 @@ interface StatisticsRepository {
     suspend fun getTypicalWordsPerMinute(bookId: Int? = null): Result<Int?>
 
     suspend fun countActiveDays(bookId: Int): Result<Int>
+
+    /** Reading across the whole library, deleted books included. */
+    suspend fun getLibraryStatistics(): Result<LibraryStatistics>
 }

--- a/app/src/main/java/ua/acclorite/book_story/domain/repository/StatisticsRepository.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/repository/StatisticsRepository.kt
@@ -1,0 +1,18 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.repository
+
+import ua.acclorite.book_story.domain.model.statistics.ReadingSession
+
+interface StatisticsRepository {
+
+    suspend fun addSession(session: ReadingSession): Result<Unit>
+
+    /** See [ua.acclorite.book_story.data.local.room.StatisticsDao.anonymiseBookSessions]. */
+    suspend fun anonymiseBookSessions(bookId: Int): Result<Unit>
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/repository/StatisticsRepository.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/repository/StatisticsRepository.kt
@@ -7,6 +7,7 @@
 
 package ua.acclorite.book_story.domain.repository
 
+import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
 import ua.acclorite.book_story.domain.model.statistics.ReadingSession
 
 interface StatisticsRepository {
@@ -15,4 +16,10 @@ interface StatisticsRepository {
 
     /** See [ua.acclorite.book_story.data.local.room.StatisticsDao.anonymiseBookSessions]. */
     suspend fun anonymiseBookSessions(bookId: Int): Result<Unit>
+
+    suspend fun getCoverage(bookId: Int): Result<ReadingCoverage?>
+
+    suspend fun saveCoverage(coverage: ReadingCoverage): Result<Unit>
+
+    suspend fun deleteCoverage(bookId: Int): Result<Unit>
 }

--- a/app/src/main/java/ua/acclorite/book_story/domain/repository/StatisticsRepository.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/repository/StatisticsRepository.kt
@@ -60,4 +60,7 @@ interface StatisticsRepository {
 
     /** Reading across the whole library, deleted books included. */
     suspend fun getLibraryStatistics(): Result<LibraryStatistics>
+
+    /** See [ua.acclorite.book_story.data.local.room.StatisticsDao.deleteAllStatistics]. */
+    suspend fun deleteAllStatistics(): Result<Unit>
 }

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/DeleteBookUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/DeleteBookUseCase.kt
@@ -44,6 +44,11 @@ class DeleteBookUseCase @Inject constructor(
             logW(TAG, "Could not anonymise sessions of [${book.title}]: ${it.message}")
         }
 
+        // Coverage does go: its item indices mean nothing without the text.
+        statisticsRepository.deleteCoverage(bookId = book.id).onFailure {
+            logW(TAG, "Could not delete coverage of [${book.title}]: ${it.message}")
+        }
+
         // Deleting book
         bookRepository.deleteBook(book).fold(
             onSuccess = {

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/DeleteBookUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/DeleteBookUseCase.kt
@@ -49,6 +49,11 @@ class DeleteBookUseCase @Inject constructor(
             logW(TAG, "Could not delete coverage of [${book.title}]: ${it.message}")
         }
 
+        // The book's own record stays on the shelf, just without the book.
+        statisticsRepository.unlinkReadBook(bookId = book.id).onFailure {
+            logW(TAG, "Could not unlink record of [${book.title}]: ${it.message}")
+        }
+
         // Deleting book
         bookRepository.deleteBook(book).fold(
             onSuccess = {

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/DeleteBookUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/DeleteBookUseCase.kt
@@ -12,6 +12,7 @@ import ua.acclorite.book_story.core.log.logW
 import ua.acclorite.book_story.domain.model.library.Book
 import ua.acclorite.book_story.domain.repository.BookRepository
 import ua.acclorite.book_story.domain.repository.HistoryRepository
+import ua.acclorite.book_story.domain.repository.StatisticsRepository
 import ua.acclorite.book_story.domain.service.CoverImageHandler
 import javax.inject.Inject
 
@@ -20,6 +21,7 @@ private const val TAG = "DeleteBook"
 class DeleteBookUseCase @Inject constructor(
     private val bookRepository: BookRepository,
     private val historyRepository: HistoryRepository,
+    private val statisticsRepository: StatisticsRepository,
     private val coverImageHandler: CoverImageHandler
 ) {
 
@@ -34,6 +36,12 @@ class DeleteBookUseCase @Inject constructor(
         // Deleting history
         historyRepository.deleteHistoryForBook(bookId = book.id).onFailure {
             logW(TAG, "Could not delete history for [${book.title}] with error: ${it.message}")
+        }
+
+        // Unlinking, not deleting: the book's reading sessions stay in the
+        // lifetime statistics, they just stop being attributable to it.
+        statisticsRepository.anonymiseBookSessions(bookId = book.id).onFailure {
+            logW(TAG, "Could not anonymise sessions of [${book.title}]: ${it.message}")
         }
 
         // Deleting book

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/DeleteStatisticsUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/DeleteStatisticsUseCase.kt
@@ -1,0 +1,36 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.statistics
+
+import ua.acclorite.book_story.core.log.logI
+import ua.acclorite.book_story.core.log.logW
+import ua.acclorite.book_story.domain.repository.StatisticsRepository
+import javax.inject.Inject
+
+private const val TAG = "DeleteStatistics"
+
+class DeleteStatisticsUseCase @Inject constructor(
+    private val statisticsRepository: StatisticsRepository
+) {
+
+    /**
+     * Erases every measurement: sessions, the record of each book ever read,
+     * and the coverage of the books still present.
+     *
+     * Deliberately unlike deleting a *book*, which anonymises its sessions so
+     * the reading still counts towards the lifetime totals. There is no such
+     * middle ground here — "delete statistics" can only mean that nothing is
+     * left, and a book read to the end will start again from zero.
+     */
+    suspend operator fun invoke() {
+        statisticsRepository.deleteAllStatistics().fold(
+            onSuccess = { logI(TAG, "Deleted all statistics.") },
+            onFailure = { logW(TAG, "Could not delete statistics: ${it.message}") }
+        )
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/GetBookCoverageUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/GetBookCoverageUseCase.kt
@@ -1,0 +1,47 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.statistics
+
+import ua.acclorite.book_story.core.log.logI
+import ua.acclorite.book_story.core.log.logW
+import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
+import ua.acclorite.book_story.domain.repository.StatisticsRepository
+import javax.inject.Inject
+
+private const val TAG = "GetBookCoverage"
+
+class GetBookCoverageUseCase @Inject constructor(
+    private val statisticsRepository: StatisticsRepository
+) {
+
+    /**
+     * What of this book has been read, ready for a text of [itemCount] items:
+     * a stale record keeps its word total but drops its intervals, and a book
+     * never read yet starts empty.
+     */
+    suspend operator fun invoke(
+        bookId: Int,
+        itemCount: Int,
+        bookWords: Int
+    ): ReadingCoverage {
+        val stored = statisticsRepository.getCoverage(bookId).getOrElse {
+            logW(TAG, "Could not read coverage of [$bookId]: ${it.message}")
+            null
+        } ?: return ReadingCoverage.empty(bookId, itemCount, bookWords)
+
+        if (stored.itemCount != itemCount) {
+            logI(
+                TAG,
+                "Coverage of [$bookId] was recorded against ${stored.itemCount} " +
+                        "items, text now has $itemCount — dropping its intervals."
+            )
+        }
+
+        return stored.validFor(itemCount)
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/GetBookStatisticsUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/GetBookStatisticsUseCase.kt
@@ -22,7 +22,12 @@ class GetBookStatisticsUseCase @Inject constructor(
      *
      * "Time left" is worked out from the reader's **typical** pace rather than
      * this book's own, so a book only just started still gets an estimate — and
-     * from the words *not covered*, not from where the bookmark sits.
+     * from the words **ahead of the bookmark**. It is a forecast, so it answers
+     * "how much is still in front of me" and not "how much has this measurement
+     * never seen": a book whose statistics began mid-way has most of itself
+     * uncovered while having almost nothing left, and an omnibus read from its
+     * last part onwards has nothing ahead at all. Coverage answers the other
+     * question, one line above on the same card.
      */
     suspend operator fun invoke(bookId: Int): BookStatistics {
         val record = statisticsRepository.getReadBook(bookId).getOrNull()
@@ -42,8 +47,16 @@ class GetBookStatisticsUseCase @Inject constructor(
         // meant to be compared with.
         val inThisBook = statisticsRepository.getTypicalWordsPerMinute(bookId).getOrNull()
 
-        val wordsLeft = (bookWords - coveredWords).coerceAtLeast(0)
-        val timeLeftMs = ReadingPace.timeForWords(wordsLeft, typical ?: inThisBook)
+        // Null until the book has been read once with the bookmark's word count
+        // recorded. The figure is then left out rather than approximated from
+        // the item-based progress: items carry wildly uneven word counts in an
+        // illustrated book, and mixing the two scales is what this replaces.
+        val timeLeftMs = coverage?.wordsBeforeBookmark?.let { before ->
+            ReadingPace.timeForWords(
+                words = (bookWords - before).coerceAtLeast(0),
+                wordsPerMinute = typical ?: inThisBook
+            )
+        }
 
         return BookStatistics(
             totalTimeMs = totalTimeMs,

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/GetBookStatisticsUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/GetBookStatisticsUseCase.kt
@@ -1,0 +1,68 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.statistics
+
+import ua.acclorite.book_story.domain.model.statistics.BookStatistics
+import ua.acclorite.book_story.domain.model.statistics.ReadingPace
+import ua.acclorite.book_story.domain.repository.StatisticsRepository
+import javax.inject.Inject
+
+class GetBookStatisticsUseCase @Inject constructor(
+    private val statisticsRepository: StatisticsRepository
+) {
+
+    /**
+     * Everything the book's card shows, assembled from its record (time, words,
+     * sessions) and its coverage (how much of the text was actually read).
+     *
+     * "Time left" is worked out from the reader's **typical** pace rather than
+     * this book's own, so a book only just started still gets an estimate — and
+     * from the words *not covered*, not from where the bookmark sits.
+     */
+    suspend operator fun invoke(bookId: Int): BookStatistics {
+        val record = statisticsRepository.getReadBook(bookId).getOrNull()
+        val coverage = statisticsRepository.getCoverage(bookId).getOrNull()
+
+        if (record == null && coverage == null) return BookStatistics.none
+
+        val totalTimeMs = record?.totalTimeMs ?: 0
+        val bookWords = coverage?.bookWords ?: 0
+        val coveredWords = coverage?.coveredWords ?: 0
+
+        val typical = statisticsRepository.getTypicalWordsPerMinute().getOrNull()
+
+        // A median of this book's own sessions rather than its total words over
+        // its total time: one session spent flicking through pages would carry
+        // a mean away, and the figure sits right next to the typical pace it is
+        // meant to be compared with.
+        val inThisBook = statisticsRepository.getTypicalWordsPerMinute(bookId).getOrNull()
+
+        val wordsLeft = (bookWords - coveredWords).coerceAtLeast(0)
+        val timeLeftMs = ReadingPace.timeForWords(wordsLeft, typical ?: inThisBook)
+
+        return BookStatistics(
+            totalTimeMs = totalTimeMs,
+            sessions = record?.sessions ?: 0,
+            finished = record?.finished == true,
+            coveragePercent = coverage?.percent ?: record?.coveragePercent ?: 0f,
+            bookWords = bookWords,
+            coveredWords = coveredWords,
+            wordsPerMinute = inThisBook,
+            typicalWordsPerMinute = typical,
+            timeLeftMs = timeLeftMs,
+            finishedBy = timeLeftMs?.let {
+                ReadingPace.finishedBy(
+                    now = System.currentTimeMillis(),
+                    timeLeftMs = it,
+                    totalTimeMs = totalTimeMs,
+                    activeDays = statisticsRepository.countActiveDays(bookId).getOrNull() ?: 0
+                )
+            }
+        )
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/GetLibraryStatisticsUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/GetLibraryStatisticsUseCase.kt
@@ -1,0 +1,26 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.statistics
+
+import ua.acclorite.book_story.core.log.logW
+import ua.acclorite.book_story.domain.model.statistics.LibraryStatistics
+import ua.acclorite.book_story.domain.repository.StatisticsRepository
+import javax.inject.Inject
+
+private const val TAG = "GetLibraryStatistics"
+
+class GetLibraryStatisticsUseCase @Inject constructor(
+    private val statisticsRepository: StatisticsRepository
+) {
+
+    suspend operator fun invoke(): LibraryStatistics =
+        statisticsRepository.getLibraryStatistics().getOrElse {
+            logW(TAG, "Could not read library statistics: ${it.message}")
+            LibraryStatistics.none
+        }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/GetReadBookUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/GetReadBookUseCase.kt
@@ -1,0 +1,27 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.statistics
+
+import ua.acclorite.book_story.core.log.logW
+import ua.acclorite.book_story.domain.model.statistics.ReadBook
+import ua.acclorite.book_story.domain.repository.StatisticsRepository
+import javax.inject.Inject
+
+private const val TAG = "GetReadBook"
+
+class GetReadBookUseCase @Inject constructor(
+    private val statisticsRepository: StatisticsRepository
+) {
+
+    /** The book's reading record, or null when it has never been read here. */
+    suspend operator fun invoke(bookId: Int): ReadBook? =
+        statisticsRepository.getReadBook(bookId).getOrElse {
+            logW(TAG, "Could not read record of [$bookId]: ${it.message}")
+            null
+        }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/RecordReadingSessionUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/RecordReadingSessionUseCase.kt
@@ -1,0 +1,53 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.statistics
+
+import ua.acclorite.book_story.core.log.logE
+import ua.acclorite.book_story.core.log.logI
+import ua.acclorite.book_story.domain.model.statistics.ReadingSession
+import ua.acclorite.book_story.domain.repository.StatisticsRepository
+import javax.inject.Inject
+
+private const val TAG = "RecordReadingSession"
+
+class RecordReadingSessionUseCase @Inject constructor(
+    private val statisticsRepository: StatisticsRepository
+) {
+
+    suspend operator fun invoke(
+        bookId: Int,
+        startTime: Long,
+        lastActiveTime: Long,
+        endTime: Long,
+        wordsRead: Int
+    ) {
+        val session = ReadingSession.endedAt(
+            bookId = bookId,
+            startTime = startTime,
+            lastActiveTime = lastActiveTime,
+            now = endTime,
+            wordsRead = wordsRead
+        )
+
+        if (session == null) {
+            logI(TAG, "Session for [$bookId] too short to record.")
+            return
+        }
+
+        logI(TAG, "Recording ${session.durationMs}ms session for [$bookId].")
+
+        statisticsRepository.addSession(session).fold(
+            onSuccess = {
+                logI(TAG, "Successfully recorded session for [$bookId].")
+            },
+            onFailure = {
+                logE(TAG, "Could not record session for [$bookId] with error: ${it.message}")
+            }
+        )
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/RecordReadingSessionUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/RecordReadingSessionUseCase.kt
@@ -25,14 +25,16 @@ class RecordReadingSessionUseCase @Inject constructor(
         startTime: Long,
         lastActiveTime: Long,
         endTime: Long,
-        wordsRead: Int
+        wordsRead: Int,
+        overlayMs: Long
     ): ReadingSession? {
         val session = ReadingSession.endedAt(
             bookId = bookId,
             startTime = startTime,
             lastActiveTime = lastActiveTime,
             now = endTime,
-            wordsRead = wordsRead
+            wordsRead = wordsRead,
+            overlayMs = overlayMs
         )
 
         if (session == null) {

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/RecordReadingSessionUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/RecordReadingSessionUseCase.kt
@@ -9,6 +9,7 @@ package ua.acclorite.book_story.domain.use_case.statistics
 
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
+import ua.acclorite.book_story.data.settings.SettingsManager
 import ua.acclorite.book_story.domain.model.statistics.ReadingSession
 import ua.acclorite.book_story.domain.repository.StatisticsRepository
 import javax.inject.Inject
@@ -16,10 +17,16 @@ import javax.inject.Inject
 private const val TAG = "RecordReadingSession"
 
 class RecordReadingSessionUseCase @Inject constructor(
-    private val statisticsRepository: StatisticsRepository
+    private val statisticsRepository: StatisticsRepository,
+    private val settings: SettingsManager
 ) {
 
-    /** The session as it was recorded, or null when it was too short to keep. */
+    /**
+     * The session as it was recorded, or null when it was too short to keep —
+     * or when statistics are not being collected at all. The caller already
+     * treats null as "nothing was banked", so switching collection off needs no
+     * second path through the reader.
+     */
     suspend operator fun invoke(
         bookId: Int,
         startTime: Long,
@@ -28,6 +35,8 @@ class RecordReadingSessionUseCase @Inject constructor(
         wordsRead: Int,
         overlayMs: Long
     ): ReadingSession? {
+        if (!settings.collectStatistics.lastValue) return null
+
         val session = ReadingSession.endedAt(
             bookId = bookId,
             startTime = startTime,

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/RecordReadingSessionUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/RecordReadingSessionUseCase.kt
@@ -19,13 +19,14 @@ class RecordReadingSessionUseCase @Inject constructor(
     private val statisticsRepository: StatisticsRepository
 ) {
 
+    /** The session as it was recorded, or null when it was too short to keep. */
     suspend operator fun invoke(
         bookId: Int,
         startTime: Long,
         lastActiveTime: Long,
         endTime: Long,
         wordsRead: Int
-    ) {
+    ): ReadingSession? {
         val session = ReadingSession.endedAt(
             bookId = bookId,
             startTime = startTime,
@@ -36,7 +37,7 @@ class RecordReadingSessionUseCase @Inject constructor(
 
         if (session == null) {
             logI(TAG, "Session for [$bookId] too short to record.")
-            return
+            return null
         }
 
         logI(TAG, "Recording ${session.durationMs}ms session for [$bookId].")
@@ -49,5 +50,7 @@ class RecordReadingSessionUseCase @Inject constructor(
                 logE(TAG, "Could not record session for [$bookId] with error: ${it.message}")
             }
         )
+
+        return session
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/SaveBookCoverageUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/SaveBookCoverageUseCase.kt
@@ -1,0 +1,26 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.statistics
+
+import ua.acclorite.book_story.core.log.logW
+import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
+import ua.acclorite.book_story.domain.repository.StatisticsRepository
+import javax.inject.Inject
+
+private const val TAG = "SaveBookCoverage"
+
+class SaveBookCoverageUseCase @Inject constructor(
+    private val statisticsRepository: StatisticsRepository
+) {
+
+    suspend operator fun invoke(coverage: ReadingCoverage) {
+        statisticsRepository.saveCoverage(coverage).onFailure {
+            logW(TAG, "Could not save coverage of [${coverage.bookId}]: ${it.message}")
+        }
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/SaveBookCoverageUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/SaveBookCoverageUseCase.kt
@@ -8,6 +8,7 @@
 package ua.acclorite.book_story.domain.use_case.statistics
 
 import ua.acclorite.book_story.core.log.logW
+import ua.acclorite.book_story.data.settings.SettingsManager
 import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
 import ua.acclorite.book_story.domain.repository.StatisticsRepository
 import javax.inject.Inject
@@ -15,10 +16,19 @@ import javax.inject.Inject
 private const val TAG = "SaveBookCoverage"
 
 class SaveBookCoverageUseCase @Inject constructor(
-    private val statisticsRepository: StatisticsRepository
+    private val statisticsRepository: StatisticsRepository,
+    private val settings: SettingsManager
 ) {
 
+    /**
+     * Coverage is a measurement like any other, so it stops with the rest when
+     * collection is off. Reading it back is deliberately *not* gated: what was
+     * already measured stays legible, and switching collection back on resumes
+     * from it rather than starting the book over.
+     */
     suspend operator fun invoke(coverage: ReadingCoverage) {
+        if (!settings.collectStatistics.lastValue) return
+
         statisticsRepository.saveCoverage(coverage).onFailure {
             logW(TAG, "Could not save coverage of [${coverage.bookId}]: ${it.message}")
         }

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/SetBookFinishedUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/SetBookFinishedUseCase.kt
@@ -1,0 +1,36 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.statistics
+
+import ua.acclorite.book_story.core.log.logW
+import ua.acclorite.book_story.domain.model.library.Book
+import ua.acclorite.book_story.domain.repository.StatisticsRepository
+import javax.inject.Inject
+
+private const val TAG = "SetBookFinished"
+
+class SetBookFinishedUseCase @Inject constructor(
+    private val statisticsRepository: StatisticsRepository
+) {
+
+    /**
+     * Whether the reader considers this book read. Their statement, not a
+     * measurement: people skip appendices, abandon at 97 %, or finish someone
+     * else's foreword, so it can be turned off again as freely as on.
+     */
+    suspend operator fun invoke(book: Book, finished: Boolean) {
+        statisticsRepository.setFinished(
+            bookId = book.id,
+            title = book.title,
+            author = book.author.getAsString() ?: "",
+            finished = finished
+        ).onFailure {
+            logW(TAG, "Could not set finished on [${book.id}]: ${it.message}")
+        }
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/UpdateReadBookUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/statistics/UpdateReadBookUseCase.kt
@@ -1,0 +1,46 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.statistics
+
+import ua.acclorite.book_story.core.log.logW
+import ua.acclorite.book_story.domain.model.statistics.ReadingSession
+import ua.acclorite.book_story.domain.repository.StatisticsRepository
+import javax.inject.Inject
+
+private const val TAG = "UpdateReadBook"
+
+class UpdateReadBookUseCase @Inject constructor(
+    private val statisticsRepository: StatisticsRepository
+) {
+
+    /**
+     * Folds a session that was actually recorded into the book's lasting record.
+     * Called with the same session the statistics kept, so a sitting too short
+     * to count does not quietly bump the totals either.
+     */
+    suspend operator fun invoke(
+        session: ReadingSession,
+        title: String,
+        author: String,
+        coveragePercent: Float,
+        reachedEnd: Boolean
+    ) {
+        statisticsRepository.addSessionToReadBook(
+            bookId = session.bookId,
+            title = title,
+            author = author,
+            timeMs = session.durationMs,
+            words = session.wordsRead,
+            endedAt = session.endTime,
+            coveragePercent = coveragePercent,
+            reachedEnd = reachedEnd
+        ).onFailure {
+            logW(TAG, "Could not update record of [${session.bookId}]: ${it.message}")
+        }
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/presentation/book_info/BookInfoEvent.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/book_info/BookInfoEvent.kt
@@ -27,6 +27,11 @@ sealed class BookInfoEvent {
 
     data object OnCheckCoverReset : BookInfoEvent()
 
+    /** The reader saying whether they consider this book read. */
+    data class OnSetFinished(
+        val finished: Boolean
+    ) : BookInfoEvent()
+
     data object OnDismissBottomSheet : BookInfoEvent()
 
     data object OnShowTitleDialog : BookInfoEvent()

--- a/app/src/main/java/ua/acclorite/book_story/presentation/book_info/BookInfoModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/book_info/BookInfoModel.kt
@@ -25,6 +25,8 @@ import ua.acclorite.book_story.domain.use_case.book.DeleteBookUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetBookUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetFileFromBookUseCase
 import ua.acclorite.book_story.domain.use_case.book.ResetCoverImageUseCase
+import ua.acclorite.book_story.domain.use_case.statistics.GetBookStatisticsUseCase
+import ua.acclorite.book_story.domain.use_case.statistics.SetBookFinishedUseCase
 import ua.acclorite.book_story.domain.use_case.book.UpdateBookUseCase
 import ua.acclorite.book_story.domain.use_case.book.UpdateCoverImageUseCase
 import ua.acclorite.book_story.presentation.browse.BrowseScreen
@@ -41,7 +43,9 @@ class BookInfoModel @Inject constructor(
     private val getFileFromBookUseCase: GetFileFromBookUseCase,
     private val deleteBookUseCase: DeleteBookUseCase,
     private val canResetCoverImageUseCase: CanResetCoverImageUseCase,
-    private val resetCoverImageUseCase: ResetCoverImageUseCase
+    private val resetCoverImageUseCase: ResetCoverImageUseCase,
+    private val getBookStatisticsUseCase: GetBookStatisticsUseCase,
+    private val setBookFinishedUseCase: SetBookFinishedUseCase
 ) : ViewModel() {
 
     private val mutex = Mutex()
@@ -152,6 +156,22 @@ class BookInfoModel @Inject constructor(
                         _state.update {
                             it.copy(
                                 canResetCover = canResetCover
+                            )
+                        }
+                    }
+                }
+
+                is BookInfoEvent.OnSetFinished -> {
+                    withContext(Dispatchers.Default) {
+                        if (_state.value.book.id == -1) return@withContext
+
+                        setBookFinishedUseCase(
+                            book = _state.value.book,
+                            finished = event.finished
+                        )
+                        _state.update {
+                            it.copy(
+                                statistics = it.statistics?.copy(finished = event.finished)
                             )
                         }
                     }
@@ -378,6 +398,10 @@ class BookInfoModel @Inject constructor(
 
             if (changePath) onEvent(BookInfoEvent.OnShowPathDialog)
             onEvent(BookInfoEvent.OnCheckCoverReset)
+
+            _state.update {
+                it.copy(statistics = getBookStatisticsUseCase(bookId))
+            }
 
             val file = getFileFromBookUseCase(bookId)
             _state.update {

--- a/app/src/main/java/ua/acclorite/book_story/presentation/book_info/BookInfoModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/book_info/BookInfoModel.kt
@@ -25,10 +25,10 @@ import ua.acclorite.book_story.domain.use_case.book.DeleteBookUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetBookUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetFileFromBookUseCase
 import ua.acclorite.book_story.domain.use_case.book.ResetCoverImageUseCase
-import ua.acclorite.book_story.domain.use_case.statistics.GetBookStatisticsUseCase
-import ua.acclorite.book_story.domain.use_case.statistics.SetBookFinishedUseCase
 import ua.acclorite.book_story.domain.use_case.book.UpdateBookUseCase
 import ua.acclorite.book_story.domain.use_case.book.UpdateCoverImageUseCase
+import ua.acclorite.book_story.domain.use_case.statistics.GetBookStatisticsUseCase
+import ua.acclorite.book_story.domain.use_case.statistics.SetBookFinishedUseCase
 import ua.acclorite.book_story.presentation.browse.BrowseScreen
 import ua.acclorite.book_story.presentation.history.HistoryScreen
 import ua.acclorite.book_story.presentation.library.LibraryScreen

--- a/app/src/main/java/ua/acclorite/book_story/presentation/book_info/BookInfoScreen.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/book_info/BookInfoScreen.kt
@@ -78,6 +78,7 @@ data class BookInfoScreen(val bookId: Int) : Screen, Parcelable {
         if (state.value.book.id == bookId) {
             BookInfoContent(
                 book = state.value.book,
+                statistics = state.value.statistics,
                 file = state.value.file,
                 loadingFile = state.value.loadingFile,
                 categories = categories,
@@ -104,6 +105,7 @@ data class BookInfoScreen(val bookId: Int) : Screen, Parcelable {
                 showMoveDialog = screenModel::onEvent,
                 actionMoveDialog = screenModel::onEvent,
                 showDeleteDialog = screenModel::onEvent,
+                setFinished = screenModel::onEvent,
                 actionDeleteDialog = screenModel::onEvent,
                 navigateToReader = screenModel::onEvent,
                 navigateToLibrarySettings = screenModel::onEvent,

--- a/app/src/main/java/ua/acclorite/book_story/presentation/book_info/BookInfoState.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/book_info/BookInfoState.kt
@@ -11,6 +11,7 @@ import ua.acclorite.book_story.core.BottomSheet
 import ua.acclorite.book_story.core.Dialog
 import ua.acclorite.book_story.domain.model.file.File
 import ua.acclorite.book_story.domain.model.library.Book
+import ua.acclorite.book_story.domain.model.statistics.BookStatistics
 
 @Immutable
 data class BookInfoState(
@@ -20,6 +21,9 @@ data class BookInfoState(
     val loadingFile: Boolean = true,
 
     val canResetCover: Boolean = false,
+
+    /** Null until read back; [BookStatistics.none] when nothing was ever read. */
+    val statistics: BookStatistics? = null,
 
     val dialog: Dialog? = null,
     val bottomSheet: BottomSheet? = null

--- a/app/src/main/java/ua/acclorite/book_story/presentation/history/HistoryEffect.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/history/HistoryEffect.kt
@@ -21,6 +21,8 @@ sealed class HistoryEffect {
 
     data object OnNavigateToLibrary : HistoryEffect()
 
+    data object OnNavigateToStatistics : HistoryEffect()
+
     data class OnNavigateToBookInfo(
         val bookId: Int
     ) : HistoryEffect()

--- a/app/src/main/java/ua/acclorite/book_story/presentation/history/HistoryEvent.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/history/HistoryEvent.kt
@@ -44,6 +44,8 @@ sealed class HistoryEvent {
 
     data object OnNavigateToLibrary : HistoryEvent()
 
+    data object OnNavigateToStatistics : HistoryEvent()
+
     data class OnNavigateToBookInfo(
         val bookId: Int
     ) : HistoryEvent()

--- a/app/src/main/java/ua/acclorite/book_story/presentation/history/HistoryModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/history/HistoryModel.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.withContext
 import ua.acclorite.book_story.domain.model.history.History
 import ua.acclorite.book_story.domain.use_case.book.GetBookUseCase
 import ua.acclorite.book_story.domain.use_case.history.AddHistoryUseCase
+import ua.acclorite.book_story.domain.use_case.statistics.GetLibraryStatisticsUseCase
 import ua.acclorite.book_story.domain.use_case.history.DeleteHistoryUseCase
 import ua.acclorite.book_story.domain.use_case.history.DeleteWholeHistoryUseCase
 import ua.acclorite.book_story.domain.use_case.history.GetHistoryUseCase
@@ -38,6 +39,7 @@ import kotlin.coroutines.coroutineContext
 class HistoryModel @Inject constructor(
     private val getHistoryUseCase: GetHistoryUseCase,
     private val addHistoryUseCase: AddHistoryUseCase,
+    private val getLibraryStatisticsUseCase: GetLibraryStatisticsUseCase,
     private val deleteHistoryUseCase: DeleteHistoryUseCase,
     private val deleteWholeHistoryUseCase: DeleteWholeHistoryUseCase,
     private val getBookUseCase: GetBookUseCase
@@ -120,9 +122,14 @@ class HistoryModel @Inject constructor(
                             if (_state.value.showSearch) _state.value.searchQuery
                             else ""
                         )
+                        // Alongside the list, because the same refresh follows
+                        // every session: leaving the reader is exactly when
+                        // these figures have changed.
+                        val statistics = getLibraryStatisticsUseCase()
                         _state.update {
                             it.copy(
                                 history = history,
+                                statistics = statistics,
                                 isLoading = false
                             )
                         }
@@ -260,6 +267,10 @@ class HistoryModel @Inject constructor(
 
                 is HistoryEvent.OnNavigateToLibrary -> {
                     _effects.emit(HistoryEffect.OnNavigateToLibrary)
+                }
+
+                is HistoryEvent.OnNavigateToStatistics -> {
+                    _effects.emit(HistoryEffect.OnNavigateToStatistics)
                 }
 
                 is HistoryEvent.OnNavigateToBookInfo -> {

--- a/app/src/main/java/ua/acclorite/book_story/presentation/history/HistoryModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/history/HistoryModel.kt
@@ -26,10 +26,10 @@ import kotlinx.coroutines.withContext
 import ua.acclorite.book_story.domain.model.history.History
 import ua.acclorite.book_story.domain.use_case.book.GetBookUseCase
 import ua.acclorite.book_story.domain.use_case.history.AddHistoryUseCase
-import ua.acclorite.book_story.domain.use_case.statistics.GetLibraryStatisticsUseCase
 import ua.acclorite.book_story.domain.use_case.history.DeleteHistoryUseCase
 import ua.acclorite.book_story.domain.use_case.history.DeleteWholeHistoryUseCase
 import ua.acclorite.book_story.domain.use_case.history.GetHistoryUseCase
+import ua.acclorite.book_story.domain.use_case.statistics.GetLibraryStatisticsUseCase
 import ua.acclorite.book_story.presentation.library.LibraryScreen
 import java.util.Date
 import javax.inject.Inject

--- a/app/src/main/java/ua/acclorite/book_story/presentation/history/HistoryScreen.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/history/HistoryScreen.kt
@@ -87,6 +87,7 @@ object HistoryScreen : Screen, Parcelable {
             snackbarState = snackbarState,
             listState = listState,
             history = state.value.history,
+            statistics = state.value.statistics,
             dialog = state.value.dialog,
             canScrollBackward = listState.canScrollBackward,
             showSearch = state.value.showSearch,
@@ -105,7 +106,8 @@ object HistoryScreen : Screen, Parcelable {
             dismissDialog = screenModel::onEvent,
             navigateToLibrary = screenModel::onEvent,
             navigateToBookInfo = screenModel::onEvent,
-            navigateToReader = screenModel::onEvent
+            navigateToReader = screenModel::onEvent,
+            navigateToStatistics = screenModel::onEvent
         )
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/presentation/history/HistoryState.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/history/HistoryState.kt
@@ -8,11 +8,15 @@ package ua.acclorite.book_story.presentation.history
 
 import androidx.compose.runtime.Immutable
 import ua.acclorite.book_story.core.Dialog
+import ua.acclorite.book_story.domain.model.statistics.LibraryStatistics
 import ua.acclorite.book_story.presentation.history.model.GroupedHistory
 
 @Immutable
 data class HistoryState(
     val history: List<GroupedHistory> = emptyList(),
+
+    /** Null until read back; the card stays out of the way until then. */
+    val statistics: LibraryStatistics? = null,
 
     val isRefreshing: Boolean = false,
     val isLoading: Boolean = true,

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
@@ -50,6 +50,7 @@ import ua.acclorite.book_story.domain.use_case.history.GetHistoryForBookUseCase
 import ua.acclorite.book_story.domain.use_case.statistics.GetBookCoverageUseCase
 import ua.acclorite.book_story.domain.use_case.statistics.RecordReadingSessionUseCase
 import ua.acclorite.book_story.domain.use_case.statistics.SaveBookCoverageUseCase
+import ua.acclorite.book_story.domain.use_case.statistics.UpdateReadBookUseCase
 import ua.acclorite.book_story.presentation.history.HistoryScreen
 import ua.acclorite.book_story.presentation.library.LibraryScreen
 import ua.acclorite.book_story.presentation.reader.model.Checkpoint
@@ -68,7 +69,8 @@ class ReaderModel @Inject constructor(
     private val keepOnlyBookImagesUseCase: KeepOnlyBookImagesUseCase,
     private val recordReadingSessionUseCase: RecordReadingSessionUseCase,
     private val getBookCoverageUseCase: GetBookCoverageUseCase,
-    private val saveBookCoverageUseCase: SaveBookCoverageUseCase
+    private val saveBookCoverageUseCase: SaveBookCoverageUseCase,
+    private val updateReadBookUseCase: UpdateReadBookUseCase
 ) : ViewModel() {
 
     private val mutex = Mutex()
@@ -134,6 +136,13 @@ class ReaderModel @Inject constructor(
      * dragging the progress slider would credit every screen it paused on.
      */
     private var landingAfterJump = false
+
+    /**
+     * Whether this session got to the end of the book. Carried to the book's
+     * record when the session is written, rather than set the moment it
+     * happens: there may be no record yet to set it on.
+     */
+    private var reachedEnd = false
 
     fun onEvent(event: ReaderEvent) {
         viewModelScope.launch {
@@ -617,7 +626,7 @@ class ReaderModel @Inject constructor(
             )
         }
 
-        recordReadingSessionUseCase(
+        val session = recordReadingSessionUseCase(
             bookId = _state.value.book.id,
             startTime = startTime,
             lastActiveTime = sessionLastActive,
@@ -625,8 +634,23 @@ class ReaderModel @Inject constructor(
             wordsRead = sessionWords
         )
 
+        // Only a session the statistics kept: one too short to count must not
+        // quietly bump the book's totals either.
+        if (session != null) {
+            val book = _state.value.book
+            updateReadBookUseCase(
+                session = session,
+                title = book.title,
+                author = book.author.getAsString() ?: "",
+                coveragePercent = if (coverageItemCount <= 0) 0f
+                else coveredItems.size.toFloat() / coverageItemCount,
+                reachedEnd = reachedEnd
+            )
+        }
+
         sessionSeen.clear()
         sessionWords = 0
+        reachedEnd = false
     }
 
     private suspend fun loadCoverage(text: List<ReaderText>) {
@@ -729,6 +753,8 @@ class ReaderModel @Inject constructor(
             ) return@collectLatest
 
             val progress = calculateProgress(index)
+            if (progress >= 1f) reachedEnd = true
+
             val (currentChapter, currentChapterProgress) = getChapterProgressUseCase(
                 index = index,
                 text = _state.value.text

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
@@ -44,6 +44,7 @@ import ua.acclorite.book_story.domain.use_case.book.KeepOnlyBookImagesUseCase
 import ua.acclorite.book_story.domain.use_case.book.LoadBookImagesUseCase
 import ua.acclorite.book_story.domain.use_case.book.UpdateBookUseCase
 import ua.acclorite.book_story.domain.use_case.history.GetHistoryForBookUseCase
+import ua.acclorite.book_story.domain.use_case.statistics.RecordReadingSessionUseCase
 import ua.acclorite.book_story.presentation.history.HistoryScreen
 import ua.acclorite.book_story.presentation.library.LibraryScreen
 import ua.acclorite.book_story.presentation.reader.model.Checkpoint
@@ -59,7 +60,8 @@ class ReaderModel @Inject constructor(
     private val getHistoryForBookUseCase: GetHistoryForBookUseCase,
     private val getChapterProgressUseCase: GetChapterProgressUseCase,
     private val loadBookImagesUseCase: LoadBookImagesUseCase,
-    private val keepOnlyBookImagesUseCase: KeepOnlyBookImagesUseCase
+    private val keepOnlyBookImagesUseCase: KeepOnlyBookImagesUseCase,
+    private val recordReadingSessionUseCase: RecordReadingSessionUseCase
 ) : ViewModel() {
 
     private val mutex = Mutex()
@@ -87,6 +89,16 @@ class ReaderModel @Inject constructor(
 
     private var scrollJob: Job? = null
     private val eventStack = mutableListOf<Job>()
+
+    /** Start of the running reading session, or null when none is running. */
+    private var sessionStartTime: Long? = null
+
+    /**
+     * When the reader last settled on a position. Only the idle *after* it is
+     * capped, so a device left open on a page stops counting while a pause in
+     * the middle of a sitting does not.
+     */
+    private var sessionLastActive: Long = 0L
 
     fun onEvent(event: ReaderEvent) {
         viewModelScope.launch {
@@ -150,6 +162,11 @@ class ReaderModel @Inject constructor(
                         }
                         BookOpenTrace.mark("text in state")
                         ensureActive()
+
+                        // The session starts when there is something to read,
+                        // not when the book was opened: a cold parse is not
+                        // reading time.
+                        startSession()
 
                         updateBookUseCase(_state.value.book)
 
@@ -339,6 +356,11 @@ class ReaderModel @Inject constructor(
                         )
                     }
 
+                    // Before the position-saving block below, which is guarded
+                    // by conditions of its own and must not decide whether a
+                    // session was read.
+                    endSession()
+
                     if (
                         !_state.value.isLoading &&
                         _state.value.listState.layoutInfo.totalItemsCount > 0 &&
@@ -504,11 +526,59 @@ class ReaderModel @Inject constructor(
         }
     }
 
+    /**
+     * The reader became visible. Starts a session if there is text to read —
+     * on the way in the text is not loaded yet and [ReaderEvent.OnLoadText]
+     * starts it instead, but coming back from a call or the home screen lands
+     * here with the book already in memory.
+     */
+    fun onEnterForeground() {
+        startSession()
+    }
+
+    /**
+     * The reader stopped being visible — a call, the home gesture, the screen
+     * going off, another app. All of them mean the reading stopped, and none of
+     * them is a deliberate exit, so nothing else would have recorded it.
+     */
+    fun onLeaveForeground() {
+        viewModelScope.launch { endSession() }
+    }
+
+    private fun startSession() {
+        if (sessionStartTime != null) return
+        if (_state.value.text.isEmpty()) return
+
+        val now = System.currentTimeMillis()
+        sessionStartTime = now
+        sessionLastActive = now
+    }
+
+    private suspend fun endSession() {
+        val startTime = sessionStartTime ?: return
+        sessionStartTime = null
+
+        recordReadingSessionUseCase(
+            bookId = _state.value.book.id,
+            startTime = startTime,
+            lastActiveTime = sessionLastActive,
+            endTime = System.currentTimeMillis(),
+            // Words are credited from what is on screen; that pass is not
+            // written yet, so every session records zero for now.
+            wordsRead = 0
+        )
+    }
+
     fun clearAsync() {
         viewModelScope.launch { clear() }
     }
 
     suspend fun clear() {
+        // First, while the state still names the book it belongs to: [init]
+        // clears before loading another one, and a session left running would
+        // be recorded against the new book.
+        endSession()
+
         eventStack.forEach { job ->
             job.cancel()
             job.join()
@@ -535,6 +605,10 @@ class ReaderModel @Inject constructor(
         snapshotFlow {
             listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
         }.distinctUntilChanged().debounce(300).collectLatest { (index, offset) ->
+            // Every settled position is a sign of life, even one the guard below
+            // discards: the reader is being scrolled either way.
+            sessionLastActive = System.currentTimeMillis()
+
             if (
                 _state.value.isLoading ||
                 listState.layoutInfo.totalItemsCount == 0 ||

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
@@ -373,7 +373,7 @@ class ReaderModel @Inject constructor(
                             .takeIf { it != -1 }
                         if (chapterIndex == null) return@withContext
 
-                    _state.value.listState.requestScrollToItem(
+                        _state.value.listState.requestScrollToItem(
                             index = chapterIndex,
                             scrollOffset = 0
                         )
@@ -397,7 +397,7 @@ class ReaderModel @Inject constructor(
                         val scrollTo = (_state.value.text.lastIndex * event.progress).roundToInt()
 
                         jumpedToPosition()
-                    _state.value.listState.requestScrollToItem(
+                        _state.value.listState.requestScrollToItem(
                             index = scrollTo,
                             scrollOffset = 0
                         )
@@ -417,7 +417,7 @@ class ReaderModel @Inject constructor(
                             )
                         }
 
-                    _state.value.listState.requestScrollToItem(
+                        _state.value.listState.requestScrollToItem(
                             index = event.checkpoint.index,
                             scrollOffset = event.checkpoint.offset
                         )
@@ -805,6 +805,13 @@ class ReaderModel @Inject constructor(
      * emits those in between.
      */
     private fun creditVisible(visible: List<LazyListItemInfo>) {
+        // Nothing is credited outside a session, the way a note is not: the
+        // coverage pass finishes on its own thread and can land after the
+        // session that started it has been banked and its ledger cleared — a
+        // book opened and left at once would then pay its last screen into the
+        // *next* book's first session.
+        if (sessionStartTime == null) return
+
         if (landingAfterJump) {
             landingAfterJump = false
             return

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
@@ -39,6 +39,7 @@ import ua.acclorite.book_story.domain.model.reader.BookImageStore
 import ua.acclorite.book_story.domain.model.reader.ReaderText
 import ua.acclorite.book_story.domain.model.reader.ReaderText.Chapter
 import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
+import ua.acclorite.book_story.domain.model.statistics.SessionWords
 import ua.acclorite.book_story.domain.model.statistics.wordCount
 import ua.acclorite.book_story.domain.use_case.book.GetBookUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetChapterProgressUseCase
@@ -126,9 +127,14 @@ class ReaderModel @Inject constructor(
      */
     private var coverageReady = false
 
-    /** Items credited this session, so a screen re-read now counts once. */
-    private val sessionSeen = mutableSetOf<Int>()
-    private var sessionWords = 0
+    /** What this session has credited, de-duplicated; see [SessionWords]. */
+    private val sessionWords = SessionWords()
+
+    /**
+     * The note the sheet is showing. Credited when it closes rather than when it
+     * opens, so a mis-tap that is dismissed at once counts nothing.
+     */
+    private var openNoteId: String? = null
 
     /**
      * Set while dragging the progress slider, whose landings are screens nobody
@@ -497,6 +503,8 @@ class ReaderModel @Inject constructor(
                     val id = event.tag.substringAfter(':')
                     val note = _state.value.notes[id] ?: return@launch
 
+                    markActive()
+                    openNoteId = id
                     _state.update {
                         it.copy(
                             bottomSheet = ReaderScreen.NOTE_BOTTOM_SHEET,
@@ -525,6 +533,8 @@ class ReaderModel @Inject constructor(
                 }
 
                 is ReaderEvent.OnDismissBottomSheet -> {
+                    markActive()
+                    creditOpenNote()
                     _state.update {
                         it.copy(
                             bottomSheet = null
@@ -615,6 +625,10 @@ class ReaderModel @Inject constructor(
 
     private suspend fun endSession() {
         val startTime = sessionStartTime ?: return
+
+        // A note still open when the reader is stopped was read like any other:
+        // credit it before the session's words are written.
+        creditOpenNote()
         sessionStartTime = null
 
         if (coverageReady) {
@@ -634,7 +648,7 @@ class ReaderModel @Inject constructor(
             startTime = startTime,
             lastActiveTime = sessionLastActive,
             endTime = System.currentTimeMillis(),
-            wordsRead = sessionWords
+            wordsRead = sessionWords.total
         )
 
         // Only a session the statistics kept: one too short to count must not
@@ -651,9 +665,35 @@ class ReaderModel @Inject constructor(
             )
         }
 
-        sessionSeen.clear()
-        sessionWords = 0
+        sessionWords.clear()
         reachedEnd = false
+    }
+
+    /**
+     * Something that is not a scroll but is still the reader at work — opening
+     * or closing a note. Without it the idle cap would measure from the last
+     * scroll, and ten minutes spent in a long note would be cut off the end of
+     * the session as if the device had been put down.
+     */
+    private fun markActive() {
+        sessionLastActive = System.currentTimeMillis()
+    }
+
+    /**
+     * Credits the note the sheet was showing, if any.
+     *
+     * Note words are **volume only**: notes are not items, so they enter neither
+     * [coveredItems] nor [coverageBookWords]. Putting them in the book's total
+     * would mean no book could ever reach 100 % coverage without opening every
+     * note; leaving them out of the session's words leaves the time counted and
+     * the words not, which drags every speed figure down.
+     */
+    private fun creditOpenNote() {
+        val id = openNoteId ?: return
+        openNoteId = null
+
+        if (sessionStartTime == null) return
+        sessionWords.creditNote(id, _state.value.notes[id]?.wordCount() ?: 0)
     }
 
     private suspend fun loadCoverage(text: List<ReaderText>) {
@@ -704,7 +744,7 @@ class ReaderModel @Inject constructor(
             val entry = text.getOrNull(item.index) ?: continue
             val words = entry.wordCount()
 
-            if (sessionSeen.add(item.index)) sessionWords += words
+            sessionWords.creditItem(item.index, words)
             if (coveredItems.add(item.index)) coveredWords += words
         }
     }
@@ -726,6 +766,7 @@ class ReaderModel @Inject constructor(
         coverageItemCount = 0
         coverageBookWords = 0
         landingAfterJump = false
+        openNoteId = null
 
         eventStack.forEach { job ->
             job.cancel()

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
@@ -131,9 +131,15 @@ class ReaderModel @Inject constructor(
     private var sessionWords = 0
 
     /**
-     * Set when the reader moves the list itself. The settled position that
-     * follows is where a jump landed, not something that was read — otherwise
-     * dragging the progress slider would credit every screen it paused on.
+     * Set while dragging the progress slider, whose landings are screens nobody
+     * read — it stops wherever the drag pauses.
+     *
+     * Deliberately *not* set for the other ways the reader moves the list
+     * itself. Restoring the bookmark, opening a chapter and returning to a
+     * checkpoint all land where the reading is about to happen, and that landing
+     * is the only sample that screen will ever get: suppressing it left the
+     * first screen of every book uncredited, so reading one cover to cover
+     * stopped short of 100 % (found in device QA, 2026-08-05).
      */
     private var landingAfterJump = false
 
@@ -250,7 +256,6 @@ class ReaderModel @Inject constructor(
                 is ReaderEvent.OnRestoreScroll -> {
                     snapshotFlow { _state.value.listState.layoutInfo.totalItemsCount }.first { it > 0 }
 
-                    jumpedToPosition()
                     _state.value.listState.requestScrollToItem(
                         index = _state.value.book.scrollIndex,
                         scrollOffset = _state.value.book.scrollOffset
@@ -343,7 +348,6 @@ class ReaderModel @Inject constructor(
                             .takeIf { it != -1 }
                         if (chapterIndex == null) return@withContext
 
-                        jumpedToPosition()
                     _state.value.listState.requestScrollToItem(
                             index = chapterIndex,
                             scrollOffset = 0
@@ -388,7 +392,6 @@ class ReaderModel @Inject constructor(
                             )
                         }
 
-                        jumpedToPosition()
                     _state.value.listState.requestScrollToItem(
                             index = event.checkpoint.index,
                             scrollOffset = event.checkpoint.offset
@@ -667,6 +670,16 @@ class ReaderModel @Inject constructor(
         coveredItems.addAll(stored.covered)
         coveredWords = stored.coveredWords
         coverageReady = true
+
+        // Credit what is already on screen. The scroll flow emits its one
+        // opening sample about 300 ms in and then nothing until something
+        // moves, so on a book big enough for this load to lose that race the
+        // first screen would never be credited at all — which is how a fresh
+        // trilogy ended a whole session with empty coverage (device QA,
+        // 2026-08-05). On Main, where every other credit happens.
+        withContext(Dispatchers.Main) {
+            creditVisible(_state.value.listState.layoutInfo.visibleItemsInfo)
+        }
     }
 
     /** The reader is about to move the list itself; see [landingAfterJump]. */

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
@@ -6,6 +6,7 @@
 
 package ua.acclorite.book_story.presentation.reader
 
+import androidx.compose.foundation.lazy.LazyListItemInfo
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
@@ -37,6 +38,8 @@ import ua.acclorite.book_story.core.ui.UIText
 import ua.acclorite.book_story.domain.model.reader.BookImageStore
 import ua.acclorite.book_story.domain.model.reader.ReaderText
 import ua.acclorite.book_story.domain.model.reader.ReaderText.Chapter
+import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
+import ua.acclorite.book_story.domain.model.statistics.wordCount
 import ua.acclorite.book_story.domain.use_case.book.GetBookUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetChapterProgressUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetTextUseCase
@@ -44,7 +47,9 @@ import ua.acclorite.book_story.domain.use_case.book.KeepOnlyBookImagesUseCase
 import ua.acclorite.book_story.domain.use_case.book.LoadBookImagesUseCase
 import ua.acclorite.book_story.domain.use_case.book.UpdateBookUseCase
 import ua.acclorite.book_story.domain.use_case.history.GetHistoryForBookUseCase
+import ua.acclorite.book_story.domain.use_case.statistics.GetBookCoverageUseCase
 import ua.acclorite.book_story.domain.use_case.statistics.RecordReadingSessionUseCase
+import ua.acclorite.book_story.domain.use_case.statistics.SaveBookCoverageUseCase
 import ua.acclorite.book_story.presentation.history.HistoryScreen
 import ua.acclorite.book_story.presentation.library.LibraryScreen
 import ua.acclorite.book_story.presentation.reader.model.Checkpoint
@@ -61,7 +66,9 @@ class ReaderModel @Inject constructor(
     private val getChapterProgressUseCase: GetChapterProgressUseCase,
     private val loadBookImagesUseCase: LoadBookImagesUseCase,
     private val keepOnlyBookImagesUseCase: KeepOnlyBookImagesUseCase,
-    private val recordReadingSessionUseCase: RecordReadingSessionUseCase
+    private val recordReadingSessionUseCase: RecordReadingSessionUseCase,
+    private val getBookCoverageUseCase: GetBookCoverageUseCase,
+    private val saveBookCoverageUseCase: SaveBookCoverageUseCase
 ) : ViewModel() {
 
     private val mutex = Mutex()
@@ -99,6 +106,34 @@ class ReaderModel @Inject constructor(
      * the middle of a sitting does not.
      */
     private var sessionLastActive: Long = 0L
+
+    /**
+     * What of the open book has been read — item indices, loaded with the text
+     * and saved when the session ends. Held apart from [state] because it
+     * changes on every settled scroll and nothing draws it.
+     */
+    private val coveredItems = mutableSetOf<Int>()
+    private var coveredWords = 0
+    private var coverageItemCount = 0
+    private var coverageBookWords = 0
+    private var coverageJob: Job? = null
+
+    /**
+     * Until the stored coverage has been read back, nothing is credited: the
+     * set is about to be replaced by it.
+     */
+    private var coverageReady = false
+
+    /** Items credited this session, so a screen re-read now counts once. */
+    private val sessionSeen = mutableSetOf<Int>()
+    private var sessionWords = 0
+
+    /**
+     * Set when the reader moves the list itself. The settled position that
+     * follows is where a jump landed, not something that was read — otherwise
+     * dragging the progress slider would credit every screen it paused on.
+     */
+    private var landingAfterJump = false
 
     fun onEvent(event: ReaderEvent) {
         viewModelScope.launch {
@@ -168,6 +203,14 @@ class ReaderModel @Inject constructor(
                         // reading time.
                         startSession()
 
+                        // Separately, because counting every word of the book is
+                        // one pass over all of it and the first frame is still
+                        // ahead — [OnRestoreScroll] below is what ends the
+                        // loading placeholder.
+                        coverageJob = viewModelScope.launch(Dispatchers.Default) {
+                            loadCoverage(strippedText)
+                        }
+
                         updateBookUseCase(_state.value.book)
 
                         LibraryScreen.refreshListChannel.trySend(0)
@@ -198,6 +241,7 @@ class ReaderModel @Inject constructor(
                 is ReaderEvent.OnRestoreScroll -> {
                     snapshotFlow { _state.value.listState.layoutInfo.totalItemsCount }.first { it > 0 }
 
+                    jumpedToPosition()
                     _state.value.listState.requestScrollToItem(
                         index = _state.value.book.scrollIndex,
                         scrollOffset = _state.value.book.scrollOffset
@@ -290,7 +334,8 @@ class ReaderModel @Inject constructor(
                             .takeIf { it != -1 }
                         if (chapterIndex == null) return@withContext
 
-                        _state.value.listState.requestScrollToItem(
+                        jumpedToPosition()
+                    _state.value.listState.requestScrollToItem(
                             index = chapterIndex,
                             scrollOffset = 0
                         )
@@ -313,7 +358,8 @@ class ReaderModel @Inject constructor(
 
                         val scrollTo = (_state.value.text.lastIndex * event.progress).roundToInt()
 
-                        _state.value.listState.requestScrollToItem(
+                        jumpedToPosition()
+                    _state.value.listState.requestScrollToItem(
                             index = scrollTo,
                             scrollOffset = 0
                         )
@@ -333,7 +379,8 @@ class ReaderModel @Inject constructor(
                             )
                         }
 
-                        _state.value.listState.requestScrollToItem(
+                        jumpedToPosition()
+                    _state.value.listState.requestScrollToItem(
                             index = event.checkpoint.index,
                             scrollOffset = event.checkpoint.offset
                         )
@@ -558,15 +605,71 @@ class ReaderModel @Inject constructor(
         val startTime = sessionStartTime ?: return
         sessionStartTime = null
 
+        if (coverageReady) {
+            saveBookCoverageUseCase(
+                ReadingCoverage(
+                    bookId = _state.value.book.id,
+                    itemCount = coverageItemCount,
+                    bookWords = coverageBookWords,
+                    covered = coveredItems.toSet(),
+                    coveredWords = coveredWords
+                )
+            )
+        }
+
         recordReadingSessionUseCase(
             bookId = _state.value.book.id,
             startTime = startTime,
             lastActiveTime = sessionLastActive,
             endTime = System.currentTimeMillis(),
-            // Words are credited from what is on screen; that pass is not
-            // written yet, so every session records zero for now.
-            wordsRead = 0
+            wordsRead = sessionWords
         )
+
+        sessionSeen.clear()
+        sessionWords = 0
+    }
+
+    private suspend fun loadCoverage(text: List<ReaderText>) {
+        val bookWords = text.sumOf { it.wordCount() }
+        val stored = getBookCoverageUseCase(
+            bookId = _state.value.book.id,
+            itemCount = text.size,
+            bookWords = bookWords
+        )
+
+        coverageItemCount = text.size
+        coverageBookWords = bookWords
+        coveredItems.clear()
+        coveredItems.addAll(stored.covered)
+        coveredWords = stored.coveredWords
+        coverageReady = true
+    }
+
+    /** The reader is about to move the list itself; see [landingAfterJump]. */
+    private fun jumpedToPosition() {
+        landingAfterJump = true
+    }
+
+    /**
+     * Marks what is on screen as read. Called only for *settled* positions, so
+     * a fling across half the book credits nothing it flew past: the flow never
+     * emits those in between.
+     */
+    private fun creditVisible(visible: List<LazyListItemInfo>) {
+        if (landingAfterJump) {
+            landingAfterJump = false
+            return
+        }
+        if (!coverageReady) return
+
+        val text = _state.value.text
+        for (item in visible) {
+            val entry = text.getOrNull(item.index) ?: continue
+            val words = entry.wordCount()
+
+            if (sessionSeen.add(item.index)) sessionWords += words
+            if (coveredItems.add(item.index)) coveredWords += words
+        }
     }
 
     fun clearAsync() {
@@ -578,6 +681,14 @@ class ReaderModel @Inject constructor(
         // clears before loading another one, and a session left running would
         // be recorded against the new book.
         endSession()
+
+        coverageJob?.cancelAndJoin()
+        coverageReady = false
+        coveredItems.clear()
+        coveredWords = 0
+        coverageItemCount = 0
+        coverageBookWords = 0
+        landingAfterJump = false
 
         eventStack.forEach { job ->
             job.cancel()
@@ -608,6 +719,7 @@ class ReaderModel @Inject constructor(
             // Every settled position is a sign of life, even one the guard below
             // discards: the reader is being scrolled either way.
             sessionLastActive = System.currentTimeMillis()
+            creditVisible(listState.layoutInfo.visibleItemsInfo)
 
             if (
                 _state.value.isLoading ||

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
@@ -41,6 +41,7 @@ import ua.acclorite.book_story.domain.model.reader.ReaderText.Chapter
 import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
 import ua.acclorite.book_story.domain.model.statistics.SessionWords
 import ua.acclorite.book_story.domain.model.statistics.wordCount
+import ua.acclorite.book_story.domain.model.statistics.wordPrefixSums
 import ua.acclorite.book_story.domain.use_case.book.GetBookUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetChapterProgressUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetTextUseCase
@@ -120,6 +121,13 @@ class ReaderModel @Inject constructor(
     private var coverageItemCount = 0
     private var coverageBookWords = 0
     private var coverageJob: Job? = null
+
+    /**
+     * Words before each item, built by the pass that counts the book. It is
+     * what makes "left to read" a forecast: the bookmark's index reads straight
+     * out of it, with no second walk over the text.
+     */
+    private var itemWordPrefix: IntArray? = null
 
     /**
      * Until the stored coverage has been read back, nothing is credited: the
@@ -698,7 +706,8 @@ class ReaderModel @Inject constructor(
                     itemCount = coverageItemCount,
                     bookWords = coverageBookWords,
                     covered = coveredItems.toSet(),
-                    coveredWords = coveredWords
+                    coveredWords = coveredWords,
+                    wordsBeforeBookmark = wordsBeforeBookmark()
                 )
             )
         }
@@ -758,7 +767,8 @@ class ReaderModel @Inject constructor(
     }
 
     private suspend fun loadCoverage(text: List<ReaderText>) {
-        val bookWords = text.sumOf { it.wordCount() }
+        val prefix = text.wordPrefixSums()
+        val bookWords = prefix.last()
         val stored = getBookCoverageUseCase(
             bookId = _state.value.book.id,
             itemCount = text.size,
@@ -767,6 +777,7 @@ class ReaderModel @Inject constructor(
 
         coverageItemCount = text.size
         coverageBookWords = bookWords
+        itemWordPrefix = prefix
         coveredItems.clear()
         coveredItems.addAll(stored.covered)
         coveredWords = stored.coveredWords
@@ -810,6 +821,21 @@ class ReaderModel @Inject constructor(
         }
     }
 
+    /**
+     * Words before the bookmark, as the session leaves it. Recorded here rather
+     * than on every settled scroll because the coverage row is written here
+     * anyway, and the position at the end of a session is the one being
+     * described.
+     *
+     * The index is clamped only to keep the lookup in range; a text that has
+     * been reparsed under the bookmark is caught properly by the coverage row's
+     * item count.
+     */
+    private fun wordsBeforeBookmark(): Int? {
+        val prefix = itemWordPrefix ?: return null
+        return prefix[_state.value.book.scrollIndex.coerceIn(0, prefix.lastIndex)]
+    }
+
     fun clearAsync() {
         viewModelScope.launch { clear() }
     }
@@ -826,6 +852,7 @@ class ReaderModel @Inject constructor(
         coveredWords = 0
         coverageItemCount = 0
         coverageBookWords = 0
+        itemWordPrefix = null
         landingAfterJump = false
         openNoteId = null
         sessionOverlayMs = 0

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
@@ -137,6 +137,17 @@ class ReaderModel @Inject constructor(
     private var openNoteId: String? = null
 
     /**
+     * How long the text has been covered this session by something that earns
+     * no words, and when the covering started. The session's interval is left
+     * alone — this is subtracted only where a speed is divided.
+     *
+     * The note sheet does not count: [creditOpenNote] credits its words, so its
+     * time belongs in that denominator.
+     */
+    private var sessionOverlayMs = 0L
+    private var overlayShownAt: Long? = null
+
+    /**
      * Set while dragging the progress slider, whose landings are screens nobody
      * read — it stops wherever the drag pauses.
      *
@@ -491,6 +502,8 @@ class ReaderModel @Inject constructor(
                 }
 
                 is ReaderEvent.OnShowSettingsBottomSheet -> {
+                    creditOpenNote()
+                    overlayShown()
                     _state.update {
                         it.copy(
                             bottomSheet = ReaderScreen.SETTINGS_BOTTOM_SHEET,
@@ -503,7 +516,10 @@ class ReaderModel @Inject constructor(
                     val id = event.tag.substringAfter(':')
                     val note = _state.value.notes[id] ?: return@launch
 
-                    markActive()
+                    // Whatever it replaces stops covering the text, and the
+                    // note sheet itself never counts as an overlay: its words
+                    // are credited, so its time is reading time.
+                    overlayHidden()
                     openNoteId = id
                     _state.update {
                         it.copy(
@@ -515,6 +531,8 @@ class ReaderModel @Inject constructor(
                 }
 
                 is ReaderEvent.OnOpenImage -> {
+                    creditOpenNote()
+                    overlayShown()
                     _state.update {
                         it.copy(
                             fullscreenImage = event.image,
@@ -525,6 +543,7 @@ class ReaderModel @Inject constructor(
                 }
 
                 is ReaderEvent.OnDismissImage -> {
+                    overlayHidden()
                     _state.update {
                         it.copy(
                             fullscreenImage = null
@@ -533,8 +552,8 @@ class ReaderModel @Inject constructor(
                 }
 
                 is ReaderEvent.OnDismissBottomSheet -> {
-                    markActive()
                     creditOpenNote()
+                    overlayHidden()
                     _state.update {
                         it.copy(
                             bottomSheet = null
@@ -543,6 +562,8 @@ class ReaderModel @Inject constructor(
                 }
 
                 is ReaderEvent.OnShowChaptersDrawer -> {
+                    creditOpenNote()
+                    overlayShown()
                     _state.update {
                         it.copy(
                             drawer = ReaderScreen.CHAPTERS_DRAWER,
@@ -552,6 +573,7 @@ class ReaderModel @Inject constructor(
                 }
 
                 is ReaderEvent.OnDismissDrawer -> {
+                    overlayHidden()
                     _state.update {
                         it.copy(
                             drawer = null
@@ -621,14 +643,52 @@ class ReaderModel @Inject constructor(
         val now = System.currentTimeMillis()
         sessionStartTime = now
         sessionLastActive = now
+        sessionOverlayMs = 0
+
+        // Coming back to a text that is still covered — stopped from inside the
+        // image viewer, say. The span the stop closed out resumes here, or the
+        // whole of it would be counted as reading.
+        overlayShownAt = if (isOverlayShowing()) now else null
+    }
+
+    /** Whether something that earns no words is covering the text right now. */
+    private fun isOverlayShowing(): Boolean = with(_state.value) {
+        fullscreenImage != null ||
+                drawer != null ||
+                bottomSheet == ReaderScreen.SETTINGS_BOTTOM_SHEET
+    }
+
+    private fun overlayShown() {
+        markActive()
+        if (overlayShownAt == null) overlayShownAt = System.currentTimeMillis()
+    }
+
+    private fun overlayHidden() {
+        markActive()
+        accrueOverlay()
+    }
+
+    /**
+     * Banks a running overlay span, without touching [sessionLastActive]. The
+     * end of a session goes through here rather than [overlayHidden]: marking
+     * the reader active at that moment would move the last sign of life to
+     * *now* and so lift the idle cap off every session that ends.
+     */
+    private fun accrueOverlay() {
+        val shownAt = overlayShownAt ?: return
+        overlayShownAt = null
+        sessionOverlayMs += (System.currentTimeMillis() - shownAt).coerceAtLeast(0)
     }
 
     private suspend fun endSession() {
         val startTime = sessionStartTime ?: return
 
         // A note still open when the reader is stopped was read like any other:
-        // credit it before the session's words are written.
+        // credit it before the session's words are written. An overlay still up
+        // is closed out for the same reason — being stopped from inside the
+        // image viewer must not lose the time it was holding.
         creditOpenNote()
+        accrueOverlay()
         sessionStartTime = null
 
         if (coverageReady) {
@@ -648,7 +708,8 @@ class ReaderModel @Inject constructor(
             startTime = startTime,
             lastActiveTime = sessionLastActive,
             endTime = System.currentTimeMillis(),
-            wordsRead = sessionWords.total
+            wordsRead = sessionWords.total,
+            overlayMs = sessionOverlayMs
         )
 
         // Only a session the statistics kept: one too short to count must not
@@ -767,6 +828,8 @@ class ReaderModel @Inject constructor(
         coverageBookWords = 0
         landingAfterJump = false
         openNoteId = null
+        sessionOverlayMs = 0
+        overlayShownAt = null
 
         eventStack.forEach { job ->
             job.cancel()

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderScreen.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderScreen.kt
@@ -42,6 +42,9 @@ import androidx.compose.ui.unit.sp
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.parcelize.Parcelize
 import ua.acclorite.book_story.core.helpers.calculateProgress
@@ -80,6 +83,7 @@ data class ReaderScreen(val bookId: Int) : Screen, Parcelable {
         val settingsState = settingsModel.state.collectAsStateWithLifecycle()
 
         val activity = LocalActivity.current
+        val lifecycleOwner = LocalLifecycleOwner.current
         val density = LocalDensity.current
         val listState = rememberSaveable(
             state.value.listState,
@@ -362,6 +366,20 @@ data class ReaderScreen(val bookId: Int) : Screen, Parcelable {
         // reader turns them back on mid-book.
         LaunchedEffect(settings.images.value, state.value.text) {
             if (settings.images.lastValue) screenModel.onEvent(ReaderEvent.OnLoadImages)
+        }
+
+        // The only place that notices the reading stopping without the reader
+        // being left: a call, the home gesture, the screen going off.
+        DisposableEffect(lifecycleOwner) {
+            val observer = LifecycleEventObserver { _, event ->
+                when (event) {
+                    Lifecycle.Event.ON_START -> screenModel.onEnterForeground()
+                    Lifecycle.Event.ON_STOP -> screenModel.onLeaveForeground()
+                    else -> Unit
+                }
+            }
+            lifecycleOwner.lifecycle.addObserver(observer)
+            onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
         }
 
         DisposableEffect(settings.screenOrientation.value) {

--- a/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsEvent.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsEvent.kt
@@ -87,4 +87,6 @@ sealed class SettingsEvent {
     data object OnClearParseCache : SettingsEvent()
 
     data object OnRefreshParseCacheSize : SettingsEvent()
+
+    data object OnDeleteStatistics : SettingsEvent()
 }

--- a/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsModel.kt
@@ -37,6 +37,8 @@ import ua.acclorite.book_story.domain.use_case.color_preset.UpdateColorPresetUse
 import ua.acclorite.book_story.domain.use_case.permission.GrantPersistableUriPermissionUseCase
 import ua.acclorite.book_story.domain.use_case.permission.ReleasePersistableUriPermissionUseCase
 import ua.acclorite.book_story.domain.use_case.settings.UpdateLanguageUseCase
+import ua.acclorite.book_story.domain.use_case.statistics.DeleteStatisticsUseCase
+import ua.acclorite.book_story.presentation.history.HistoryScreen
 import javax.inject.Inject
 import kotlin.coroutines.coroutineContext
 import kotlin.random.Random
@@ -57,7 +59,8 @@ class SettingsModel @Inject constructor(
     private val updateCategoriesOrderUseCase: UpdateCategoriesOrderUseCase,
     private val deleteCategoryUseCase: DeleteCategoryUseCase,
     private val getParseCacheSizeUseCase: GetParseCacheSizeUseCase,
-    private val clearParseCacheUseCase: ClearParseCacheUseCase
+    private val clearParseCacheUseCase: ClearParseCacheUseCase,
+    private val deleteStatisticsUseCase: DeleteStatisticsUseCase
 ) : ViewModel() {
 
     private val mutex = Mutex()
@@ -489,6 +492,14 @@ class SettingsModel @Inject constructor(
                     _state.update {
                         it.copy(parseCacheSizeBytes = size)
                     }
+                }
+
+                is SettingsEvent.OnDeleteStatistics -> {
+                    deleteStatisticsUseCase()
+
+                    // The History card reads its figures once and would go on
+                    // showing the ones just erased.
+                    HistoryScreen.refreshListChannel.trySend(0)
                 }
             }
         }

--- a/app/src/main/java/ua/acclorite/book_story/presentation/statistics/StatisticsModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/statistics/StatisticsModel.kt
@@ -1,0 +1,22 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.presentation.statistics
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import ua.acclorite.book_story.domain.model.statistics.LibraryStatistics
+import ua.acclorite.book_story.domain.use_case.statistics.GetLibraryStatisticsUseCase
+import javax.inject.Inject
+
+@HiltViewModel
+class StatisticsModel @Inject constructor(
+    private val getLibraryStatisticsUseCase: GetLibraryStatisticsUseCase
+) : ViewModel() {
+
+    suspend fun load(): LibraryStatistics = getLibraryStatisticsUseCase()
+}

--- a/app/src/main/java/ua/acclorite/book_story/presentation/statistics/StatisticsScreen.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/statistics/StatisticsScreen.kt
@@ -1,0 +1,47 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.presentation.statistics
+
+import android.os.Parcelable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import kotlinx.parcelize.Parcelize
+import ua.acclorite.book_story.domain.model.statistics.LibraryStatistics
+import ua.acclorite.book_story.presentation.navigator.Screen
+import ua.acclorite.book_story.ui.navigator.LocalNavigator
+import ua.acclorite.book_story.ui.statistics.StatisticsContent
+
+/**
+ * Reading across the whole library. Read once on entry: the figures cover
+ * everything ever read, so nothing about them changes while the screen is open.
+ */
+@Parcelize
+data object StatisticsScreen : Screen, Parcelable {
+
+    @Composable
+    override fun Content() {
+        val screenModel = hiltViewModel<StatisticsModel>()
+        val navigator = LocalNavigator.current
+
+        var statistics by remember { mutableStateOf<LibraryStatistics?>(null) }
+
+        LaunchedEffect(Unit) {
+            statistics = screenModel.load()
+        }
+
+        StatisticsContent(
+            statistics = statistics,
+            navigateBack = { navigator.pop() }
+        )
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/book_info/BookInfoContent.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/book_info/BookInfoContent.kt
@@ -12,12 +12,14 @@ import ua.acclorite.book_story.core.BottomSheet
 import ua.acclorite.book_story.core.Dialog
 import ua.acclorite.book_story.domain.model.file.File
 import ua.acclorite.book_story.domain.model.library.Book
+import ua.acclorite.book_story.domain.model.statistics.BookStatistics
 import ua.acclorite.book_story.domain.model.library.Category
 import ua.acclorite.book_story.presentation.book_info.BookInfoEvent
 
 @Composable
 fun BookInfoContent(
     book: Book,
+    statistics: BookStatistics?,
     file: File?,
     loadingFile: Boolean,
     categories: List<Category>,
@@ -37,6 +39,7 @@ fun BookInfoContent(
     actionPathDialog: (BookInfoEvent.OnActionPathDialog) -> Unit,
     showMoveDialog: (BookInfoEvent.OnShowMoveDialog) -> Unit,
     showDeleteDialog: (BookInfoEvent.OnShowDeleteDialog) -> Unit,
+    setFinished: (BookInfoEvent.OnSetFinished) -> Unit,
     actionDeleteDialog: (BookInfoEvent.OnActionDeleteDialog) -> Unit,
     actionMoveDialog: (BookInfoEvent.OnActionMoveDialog) -> Unit,
     changeCover: (BookInfoEvent.OnChangeCover) -> Unit,
@@ -79,6 +82,7 @@ fun BookInfoContent(
 
     BookInfoScaffold(
         book = book,
+        statistics = statistics,
         listState = listState,
         showTitleDialog = showTitleDialog,
         showAuthorDialog = showAuthorDialog,
@@ -87,6 +91,7 @@ fun BookInfoContent(
         showDetailsBottomSheet = showDetailsBottomSheet,
         showMoveDialog = showMoveDialog,
         showDeleteDialog = showDeleteDialog,
+        setFinished = setFinished,
         navigateToReader = navigateToReader,
         navigateBack = navigateBack
     )

--- a/app/src/main/java/ua/acclorite/book_story/ui/book_info/BookInfoLayout.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/book_info/BookInfoLayout.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import ua.acclorite.book_story.domain.model.library.Book
+import ua.acclorite.book_story.domain.model.statistics.BookStatistics
 import ua.acclorite.book_story.presentation.book_info.BookInfoEvent
 import ua.acclorite.book_story.ui.common.components.common.LazyColumnWithScrollbar
 import ua.acclorite.book_story.ui.common.data.ScrollbarData
@@ -25,6 +26,7 @@ import ua.acclorite.book_story.ui.common.data.ScrollbarData
 @Composable
 fun BookInfoLayout(
     book: Book,
+    statistics: BookStatistics?,
     listState: LazyListState,
     paddingValues: PaddingValues,
     showChangeCoverBottomSheet: (BookInfoEvent.OnShowChangeCoverBottomSheet) -> Unit,
@@ -33,6 +35,7 @@ fun BookInfoLayout(
     showDescriptionDialog: (BookInfoEvent.OnShowDescriptionDialog) -> Unit,
     showMoveDialog: (BookInfoEvent.OnShowMoveDialog) -> Unit,
     showDeleteDialog: (BookInfoEvent.OnShowDeleteDialog) -> Unit,
+    setFinished: (BookInfoEvent.OnSetFinished) -> Unit,
     navigateToReader: (BookInfoEvent.OnNavigateToReader) -> Unit
 ) {
     LazyColumnWithScrollbar(
@@ -76,6 +79,16 @@ fun BookInfoLayout(
                 book = book,
                 showDescriptionDialog = showDescriptionDialog
             )
+        }
+
+        if (statistics != null) {
+            item {
+                Spacer(Modifier.height(18.dp))
+                BookInfoLayoutStatistics(
+                    statistics = statistics,
+                    setFinished = setFinished
+                )
+            }
         }
 
         item {

--- a/app/src/main/java/ua/acclorite/book_story/ui/book_info/BookInfoLayoutStatistics.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/book_info/BookInfoLayoutStatistics.kt
@@ -1,0 +1,161 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.book_info
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.domain.model.statistics.BookStatistics
+import ua.acclorite.book_story.presentation.book_info.BookInfoEvent
+import ua.acclorite.book_story.ui.common.components.common.StyledText
+import java.text.DateFormat
+import java.util.Date
+import kotlin.math.roundToInt
+
+/**
+ * What reading this book has actually amounted to. Every line is left out when
+ * its figure cannot be trusted yet, so the card grows as the evidence does
+ * rather than opening with a row of zeroes.
+ */
+@Composable
+fun BookInfoLayoutStatistics(
+    statistics: BookStatistics,
+    setFinished: (BookInfoEvent.OnSetFinished) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 18.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        StyledText(
+            text = stringResource(id = R.string.statistics),
+            style = MaterialTheme.typography.titleMedium.copy(
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        )
+
+        if (statistics.isEmpty) {
+            StyledText(
+                text = stringResource(id = R.string.statistics_none),
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            )
+            return@Column
+        }
+
+        StatisticsLine(
+            label = stringResource(id = R.string.statistics_time),
+            value = formatDuration(statistics.totalTimeMs)
+        )
+
+        StatisticsLine(
+            label = stringResource(id = R.string.statistics_read),
+            value = stringResource(
+                R.string.statistics_read_value,
+                (statistics.coveragePercent * 100).roundToInt(),
+                statistics.coveredWords
+            )
+        )
+
+        statistics.wordsPerMinute?.let { pace ->
+            StatisticsLine(
+                label = stringResource(id = R.string.statistics_pace),
+                value = statistics.typicalWordsPerMinute.let { typical ->
+                    // Only worth comparing once the two can differ meaningfully:
+                    // a dense book reads slower than fiction and that is the
+                    // interesting part, not a 1 wpm gap.
+                    if (typical == null || typical == pace) {
+                        stringResource(R.string.statistics_pace_value, pace)
+                    } else {
+                        stringResource(R.string.statistics_pace_value_compared, pace, typical)
+                    }
+                }
+            )
+        }
+
+        statistics.timeLeftMs?.takeIf { !statistics.finished }?.let { left ->
+            StatisticsLine(
+                label = stringResource(id = R.string.statistics_left),
+                value = statistics.finishedBy.let { by ->
+                    if (by == null) formatDuration(left)
+                    else stringResource(
+                        R.string.statistics_left_value_by,
+                        formatDuration(left),
+                        DateFormat.getDateInstance(DateFormat.MEDIUM).format(Date(by))
+                    )
+                }
+            )
+        }
+
+        StatisticsLine(
+            label = stringResource(id = R.string.statistics_sessions),
+            value = statistics.sessions.toString()
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            StyledText(
+                text = stringResource(id = R.string.statistics_finished),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            )
+            Switch(
+                checked = statistics.finished,
+                onCheckedChange = { setFinished(BookInfoEvent.OnSetFinished(it)) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatisticsLine(label: String, value: String) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        StyledText(
+            text = label,
+            modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.bodyMedium.copy(
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        )
+        StyledText(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium.copy(
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        )
+    }
+}
+
+@Composable
+private fun formatDuration(millis: Long): String {
+    val minutes = millis / 60_000
+    return when {
+        minutes < 1 -> stringResource(R.string.duration_under_a_minute)
+        minutes < 60 -> stringResource(R.string.duration_minutes, minutes)
+        minutes % 60 == 0L -> stringResource(R.string.duration_hours, minutes / 60)
+        else -> stringResource(R.string.duration_hours_minutes, minutes / 60, minutes % 60)
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/book_info/BookInfoLayoutStatistics.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/book_info/BookInfoLayoutStatistics.kt
@@ -57,58 +57,61 @@ fun BookInfoLayoutStatistics(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             )
-            return@Column
-        }
-
-        StatisticsLine(
-            label = stringResource(id = R.string.statistics_time),
-            value = formatDuration(statistics.totalTimeMs)
-        )
-
-        StatisticsLine(
-            label = stringResource(id = R.string.statistics_read),
-            value = stringResource(
-                R.string.statistics_read_value,
-                (statistics.coveragePercent * 100).roundToInt(),
-                statistics.coveredWords
-            )
-        )
-
-        statistics.wordsPerMinute?.let { pace ->
+        } else {
             StatisticsLine(
-                label = stringResource(id = R.string.statistics_pace),
-                value = statistics.typicalWordsPerMinute.let { typical ->
-                    // Only worth comparing once the two can differ meaningfully:
-                    // a dense book reads slower than fiction and that is the
-                    // interesting part, not a 1 wpm gap.
-                    if (typical == null || typical == pace) {
-                        stringResource(R.string.statistics_pace_value, pace)
-                    } else {
-                        stringResource(R.string.statistics_pace_value_compared, pace, typical)
+                label = stringResource(id = R.string.statistics_time),
+                value = formatDuration(statistics.totalTimeMs)
+            )
+
+            StatisticsLine(
+                label = stringResource(id = R.string.statistics_read),
+                value = stringResource(
+                    R.string.statistics_read_value,
+                    (statistics.coveragePercent * 100).roundToInt(),
+                    statistics.coveredWords
+                )
+            )
+
+            statistics.wordsPerMinute?.let { pace ->
+                StatisticsLine(
+                    label = stringResource(id = R.string.statistics_pace),
+                    value = statistics.typicalWordsPerMinute.let { typical ->
+                        // Only worth comparing once the two can differ meaningfully:
+                        // a dense book reads slower than fiction and that is the
+                        // interesting part, not a 1 wpm gap.
+                        if (typical == null || typical == pace) {
+                            stringResource(R.string.statistics_pace_value, pace)
+                        } else {
+                            stringResource(R.string.statistics_pace_value_compared, pace, typical)
+                        }
                     }
-                }
-            )
-        }
+                )
+            }
 
-        statistics.timeLeftMs?.takeIf { !statistics.finished }?.let { left ->
+            statistics.timeLeftMs?.takeIf { !statistics.finished }?.let { left ->
+                StatisticsLine(
+                    label = stringResource(id = R.string.statistics_left),
+                    value = statistics.finishedBy.let { by ->
+                        if (by == null) formatDuration(left)
+                        else stringResource(
+                            R.string.statistics_left_value_by,
+                            formatDuration(left),
+                            DateFormat.getDateInstance(DateFormat.MEDIUM).format(Date(by))
+                        )
+                    }
+                )
+            }
+
             StatisticsLine(
-                label = stringResource(id = R.string.statistics_left),
-                value = statistics.finishedBy.let { by ->
-                    if (by == null) formatDuration(left)
-                    else stringResource(
-                        R.string.statistics_left_value_by,
-                        formatDuration(left),
-                        DateFormat.getDateInstance(DateFormat.MEDIUM).format(Date(by))
-                    )
-                }
+                label = stringResource(id = R.string.statistics_sessions),
+                value = statistics.sessions.toString()
             )
         }
 
-        StatisticsLine(
-            label = stringResource(id = R.string.statistics_sessions),
-            value = statistics.sessions.toString()
-        )
-
+        // Outside the branch above on purpose: "finished" is the reader's own
+        // statement, not one of the measurements, so it has to be available on a
+        // book this build has never measured — which, there being no backfill,
+        // is every book already in the library.
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/ua/acclorite/book_story/ui/book_info/BookInfoScaffold.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/book_info/BookInfoScaffold.kt
@@ -17,11 +17,13 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import ua.acclorite.book_story.domain.model.library.Book
+import ua.acclorite.book_story.domain.model.statistics.BookStatistics
 import ua.acclorite.book_story.presentation.book_info.BookInfoEvent
 
 @Composable
 fun BookInfoScaffold(
     book: Book,
+    statistics: BookStatistics?,
     listState: LazyListState,
     showChangeCoverBottomSheet: (BookInfoEvent.OnShowChangeCoverBottomSheet) -> Unit,
     showDetailsBottomSheet: (BookInfoEvent.OnShowDetailsBottomSheet) -> Unit,
@@ -30,6 +32,7 @@ fun BookInfoScaffold(
     showDescriptionDialog: (BookInfoEvent.OnShowDescriptionDialog) -> Unit,
     showMoveDialog: (BookInfoEvent.OnShowMoveDialog) -> Unit,
     showDeleteDialog: (BookInfoEvent.OnShowDeleteDialog) -> Unit,
+    setFinished: (BookInfoEvent.OnSetFinished) -> Unit,
     navigateToReader: (BookInfoEvent.OnNavigateToReader) -> Unit,
     navigateBack: (BookInfoEvent.OnNavigateBack) -> Unit
 ) {
@@ -50,6 +53,7 @@ fun BookInfoScaffold(
     ) { paddingValues ->
         BookInfoLayout(
             book = book,
+            statistics = statistics,
             listState = listState,
             paddingValues = paddingValues,
             showTitleDialog = showTitleDialog,
@@ -58,6 +62,7 @@ fun BookInfoScaffold(
             showChangeCoverBottomSheet = showChangeCoverBottomSheet,
             showMoveDialog = showMoveDialog,
             showDeleteDialog = showDeleteDialog,
+            setFinished = setFinished,
             navigateToReader = navigateToReader
         )
     }

--- a/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryContent.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryContent.kt
@@ -13,12 +13,14 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.focus.FocusRequester
 import ua.acclorite.book_story.core.Dialog
+import ua.acclorite.book_story.domain.model.statistics.LibraryStatistics
 import ua.acclorite.book_story.presentation.history.HistoryEvent
 import ua.acclorite.book_story.presentation.history.model.GroupedHistory
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun HistoryContent(
+    statistics: LibraryStatistics?,
     refreshState: PullRefreshState,
     snackbarState: SnackbarHostState,
     history: List<GroupedHistory>,
@@ -41,7 +43,8 @@ fun HistoryContent(
     dismissDialog: (HistoryEvent.OnDismissDialog) -> Unit,
     navigateToLibrary: (HistoryEvent.OnNavigateToLibrary) -> Unit,
     navigateToBookInfo: (HistoryEvent.OnNavigateToBookInfo) -> Unit,
-    navigateToReader: (HistoryEvent.OnNavigateToReader) -> Unit
+    navigateToReader: (HistoryEvent.OnNavigateToReader) -> Unit,
+    navigateToStatistics: (HistoryEvent.OnNavigateToStatistics) -> Unit
 ) {
     HistoryDialog(
         dialog = dialog,
@@ -68,7 +71,9 @@ fun HistoryContent(
         deleteHistoryEntry = deleteHistoryEntry,
         showDeleteWholeHistoryDialog = showDeleteWholeHistoryDialog,
         navigateToBookInfo = navigateToBookInfo,
-        navigateToReader = navigateToReader
+        navigateToReader = navigateToReader,
+        statistics = statistics,
+        navigateToStatistics = navigateToStatistics
     )
 
     HistoryBackHandler(

--- a/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryEffects.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryEffects.kt
@@ -17,11 +17,11 @@ import ua.acclorite.book_story.R
 import ua.acclorite.book_story.core.log.BookOpenTrace
 import ua.acclorite.book_story.presentation.book_info.BookInfoScreen
 import ua.acclorite.book_story.presentation.history.HistoryEffect
-import ua.acclorite.book_story.presentation.statistics.StatisticsScreen
 import ua.acclorite.book_story.presentation.history.HistoryEvent
 import ua.acclorite.book_story.presentation.history.HistoryScreen.insertHistoryChannel
 import ua.acclorite.book_story.presentation.library.LibraryScreen
 import ua.acclorite.book_story.presentation.reader.ReaderScreen
+import ua.acclorite.book_story.presentation.statistics.StatisticsScreen
 import ua.acclorite.book_story.ui.common.helpers.showToast
 import ua.acclorite.book_story.ui.navigator.LocalNavigator
 

--- a/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryEffects.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryEffects.kt
@@ -17,6 +17,7 @@ import ua.acclorite.book_story.R
 import ua.acclorite.book_story.core.log.BookOpenTrace
 import ua.acclorite.book_story.presentation.book_info.BookInfoScreen
 import ua.acclorite.book_story.presentation.history.HistoryEffect
+import ua.acclorite.book_story.presentation.statistics.StatisticsScreen
 import ua.acclorite.book_story.presentation.history.HistoryEvent
 import ua.acclorite.book_story.presentation.history.HistoryScreen.insertHistoryChannel
 import ua.acclorite.book_story.presentation.library.LibraryScreen
@@ -63,6 +64,10 @@ fun HistoryEffects(
 
                 is HistoryEffect.OnNavigateToLibrary -> {
                     navigator.push(LibraryScreen, saveInBackStack = false)
+                }
+
+                is HistoryEffect.OnNavigateToStatistics -> {
+                    navigator.push(StatisticsScreen)
                 }
 
                 is HistoryEffect.OnNavigateToBookInfo -> {

--- a/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryLayout.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryLayout.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import ua.acclorite.book_story.R
+import ua.acclorite.book_story.domain.model.statistics.LibraryStatistics
 import ua.acclorite.book_story.presentation.history.HistoryEvent
 import ua.acclorite.book_story.presentation.history.model.GroupedHistory
 import ua.acclorite.book_story.ui.common.components.common.LazyColumnWithScrollbar
@@ -27,11 +28,13 @@ import ua.acclorite.book_story.ui.theme.DefaultTransition
 fun HistoryLayout(
     listState: LazyListState,
     history: List<GroupedHistory>,
+    statistics: LibraryStatistics?,
     isLoading: Boolean,
     isRefreshing: Boolean,
     deleteHistoryEntry: (HistoryEvent.OnDeleteHistoryEntry) -> Unit,
     navigateToBookInfo: (HistoryEvent.OnNavigateToBookInfo) -> Unit,
     navigateToReader: (HistoryEvent.OnNavigateToReader) -> Unit,
+    navigateToStatistics: (HistoryEvent.OnNavigateToStatistics) -> Unit,
 ) {
     DefaultTransition(visible = !isLoading) {
         LazyColumnWithScrollbar(
@@ -41,6 +44,18 @@ fun HistoryLayout(
         ) {
             item {
                 Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            if (statistics != null && !statistics.isEmpty) {
+                item(key = "statistics") {
+                    HistoryStatisticsCard(
+                        statistics = statistics,
+                        onClick = {
+                            navigateToStatistics(HistoryEvent.OnNavigateToStatistics)
+                        }
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
             }
 
             history.forEachIndexed { index, groupedHistory ->

--- a/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryScaffold.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryScaffold.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import ua.acclorite.book_story.domain.model.statistics.LibraryStatistics
 import ua.acclorite.book_story.presentation.history.HistoryEvent
 import ua.acclorite.book_story.presentation.history.model.GroupedHistory
 import ua.acclorite.book_story.ui.common.components.common.Snackbar
@@ -27,6 +28,7 @@ import ua.acclorite.book_story.ui.common.components.common.Snackbar
 @Composable
 fun HistoryScaffold(
     refreshState: PullRefreshState,
+    statistics: LibraryStatistics?,
     snackbarState: SnackbarHostState,
     history: List<GroupedHistory>,
     listState: LazyListState,
@@ -44,7 +46,8 @@ fun HistoryScaffold(
     showDeleteWholeHistoryDialog: (HistoryEvent.OnShowDeleteWholeHistoryDialog) -> Unit,
     search: (HistoryEvent.OnSearch) -> Unit,
     navigateToBookInfo: (HistoryEvent.OnNavigateToBookInfo) -> Unit,
-    navigateToReader: (HistoryEvent.OnNavigateToReader) -> Unit
+    navigateToReader: (HistoryEvent.OnNavigateToReader) -> Unit,
+    navigateToStatistics: (HistoryEvent.OnNavigateToStatistics) -> Unit
 ) {
     Scaffold(
         Modifier
@@ -77,6 +80,8 @@ fun HistoryScaffold(
                 .padding(top = paddingValues.calculateTopPadding())
         ) {
             HistoryLayout(
+                statistics = statistics,
+                navigateToStatistics = navigateToStatistics,
                 listState = listState,
                 history = history,
                 isLoading = isLoading,

--- a/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryStatisticsCard.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/history/HistoryStatisticsCard.kt
@@ -1,0 +1,94 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.history
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.domain.model.statistics.LibraryStatistics
+import ua.acclorite.book_story.ui.common.components.common.StyledText
+import ua.acclorite.book_story.ui.statistics.formatLongDuration
+
+/**
+ * The way into the statistics, with enough on it to be worth a glance on its
+ * own. It lives in History because that is already the "what did I read and
+ * when" surface — a screen behind the navigator sheet is one people visit once.
+ */
+@Composable
+fun HistoryStatisticsCard(
+    statistics: LibraryStatistics,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 18.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick),
+        color = MaterialTheme.colorScheme.surfaceContainer
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                StyledText(
+                    text = stringResource(id = R.string.statistics_card_open),
+                    style = MaterialTheme.typography.titleSmall.copy(
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                )
+                StyledText(
+                    text = stringResource(
+                        R.string.statistics_card_summary,
+                        formatLongDuration(statistics.totalTimeMs),
+                        pluralStringResource(
+                            R.plurals.statistics_days_plural,
+                            statistics.daysRead,
+                            statistics.daysRead
+                        ),
+                        pluralStringResource(
+                            R.plurals.statistics_books_finished_plural,
+                            statistics.booksRead,
+                            statistics.booksRead
+                        )
+                    ),
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                )
+            }
+
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/general/GeneralSettingsCategory.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/general/GeneralSettingsCategory.kt
@@ -24,6 +24,8 @@ import ua.acclorite.book_story.ui.settings.components.SettingsSubcategory
 import ua.acclorite.book_story.ui.settings.general.components.AppLanguageOption
 import ua.acclorite.book_story.ui.settings.general.components.CacheImagesOption
 import ua.acclorite.book_story.ui.settings.general.components.ClearParseCacheOption
+import ua.acclorite.book_story.ui.settings.general.components.CollectStatisticsOption
+import ua.acclorite.book_story.ui.settings.general.components.DeleteStatisticsOption
 import ua.acclorite.book_story.ui.settings.general.components.DoublePressExitOption
 import ua.acclorite.book_story.ui.settings.general.components.ParseCacheSizeOption
 
@@ -60,6 +62,21 @@ fun LazyListScope.GeneralSettingsCategory(
 
         item {
             ClearParseCacheOption()
+        }
+    }
+
+    SettingsSubcategory(
+        titleColor = titleColor,
+        title = { stringResource(id = R.string.statistics_option) },
+        showTitle = true,
+        showDivider = false
+    ) {
+        item {
+            CollectStatisticsOption()
+        }
+
+        item {
+            DeleteStatisticsOption()
         }
     }
 

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/general/components/CollectStatisticsOption.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/general/components/CollectStatisticsOption.kt
@@ -1,0 +1,27 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.settings.general.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.ui.common.components.settings.SwitchWithTitle
+import ua.acclorite.book_story.ui.common.helpers.LocalSettings
+
+@Composable
+fun CollectStatisticsOption() {
+    val settings = LocalSettings.current
+
+    SwitchWithTitle(
+        selected = settings.collectStatistics.value,
+        title = stringResource(id = R.string.collect_statistics_option),
+        description = stringResource(id = R.string.collect_statistics_option_desc)
+    ) {
+        settings.collectStatistics.update(!settings.collectStatistics.lastValue)
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/general/components/DeleteStatisticsOption.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/general/components/DeleteStatisticsOption.kt
@@ -1,0 +1,71 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.settings.general.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.presentation.settings.SettingsEvent
+import ua.acclorite.book_story.presentation.settings.SettingsModel
+import ua.acclorite.book_story.ui.common.components.common.StyledText
+import ua.acclorite.book_story.ui.common.components.dialog.Dialog
+
+@Composable
+fun DeleteStatisticsOption() {
+    val settingsModel = hiltViewModel<SettingsModel>()
+
+    var showDialog by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { showDialog = true }
+            .padding(horizontal = 18.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.Center
+    ) {
+        StyledText(
+            text = stringResource(id = R.string.delete_statistics_option),
+            style = MaterialTheme.typography.titleMedium.copy(
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        )
+        StyledText(
+            text = stringResource(id = R.string.delete_statistics_option_desc),
+            style = MaterialTheme.typography.bodySmall.copy(
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        )
+    }
+
+    if (showDialog) {
+        Dialog(
+            title = stringResource(id = R.string.delete_statistics_dialog),
+            description = stringResource(id = R.string.delete_statistics_dialog_desc),
+            actionEnabled = true,
+            withContent = false,
+            onDismiss = { showDialog = false },
+            onAction = {
+                settingsModel.onEvent(SettingsEvent.OnDeleteStatistics)
+                showDialog = false
+            }
+        )
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/statistics/StatisticsContent.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/statistics/StatisticsContent.kt
@@ -1,0 +1,144 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.statistics
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.domain.model.statistics.LibraryStatistics
+import ua.acclorite.book_story.ui.common.components.common.StyledText
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StatisticsContent(
+    statistics: LibraryStatistics?,
+    navigateBack: () -> Unit
+) {
+    BackHandler { navigateBack() }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        containerColor = MaterialTheme.colorScheme.surface,
+        topBar = {
+            TopAppBar(
+                title = { StyledText(text = stringResource(id = R.string.statistics)) },
+                navigationIcon = {
+                    IconButton(onClick = navigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(id = R.string.go_back_content_desc)
+                        )
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 18.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Spacer(Modifier.height(8.dp))
+
+            if (statistics == null) return@Column
+
+            if (statistics.isEmpty) {
+                StyledText(
+                    text = stringResource(id = R.string.statistics_none_library),
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                )
+                return@Column
+            }
+
+            StatisticsRow(
+                label = stringResource(id = R.string.statistics_total_time),
+                value = formatLongDuration(statistics.totalTimeMs)
+            )
+            StatisticsRow(
+                label = stringResource(id = R.string.statistics_words_read),
+                value = statistics.wordsRead.toString()
+            )
+            statistics.wordsPerMinute?.let {
+                StatisticsRow(
+                    label = stringResource(id = R.string.statistics_your_pace),
+                    value = stringResource(R.string.statistics_pace_value, it)
+                )
+            }
+            StatisticsRow(
+                label = stringResource(id = R.string.statistics_books_finished),
+                value = statistics.booksRead.toString()
+            )
+            StatisticsRow(
+                label = stringResource(id = R.string.statistics_days_read),
+                value = statistics.daysRead.toString()
+            )
+
+            Spacer(Modifier.height(8.dp))
+            StyledText(
+                text = stringResource(id = R.string.statistics_includes_deleted),
+                style = MaterialTheme.typography.bodySmall.copy(
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatisticsRow(label: String, value: String) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        StyledText(
+            text = label,
+            modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.bodyLarge.copy(
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        )
+        StyledText(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge.copy(
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        )
+    }
+}
+
+/** Hours and minutes; a lifetime of reading outgrows minutes quickly. */
+@Composable
+fun formatLongDuration(millis: Long): String {
+    val minutes = millis / 60_000
+    return when {
+        minutes < 1 -> stringResource(R.string.duration_under_a_minute)
+        minutes < 60 -> stringResource(R.string.duration_minutes, minutes)
+        minutes % 60 == 0L -> stringResource(R.string.duration_hours, minutes / 60)
+        else -> stringResource(R.string.duration_hours_minutes, minutes / 60, minutes % 60)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,24 @@
     <string name="add_book">Add a book</string>
     <string name="move">Move</string>
     <string name="delete">Delete</string>
+
+    <!-- Reading statistics -->
+    <string name="statistics">Statistics</string>
+    <string name="statistics_none">Nothing read here yet.</string>
+    <string name="statistics_time">Time in this book</string>
+    <string name="statistics_read">Read</string>
+    <string name="statistics_read_value">%1$d%% (%2$d words)</string>
+    <string name="statistics_pace">Your pace here</string>
+    <string name="statistics_pace_value">%1$d wpm</string>
+    <string name="statistics_pace_value_compared">%1$d wpm (usually %2$d)</string>
+    <string name="statistics_left">Left to read</string>
+    <string name="statistics_left_value_by">%1$s, by %2$s</string>
+    <string name="statistics_sessions">Sessions</string>
+    <string name="statistics_finished">Finished</string>
+    <string name="duration_under_a_minute">under a minute</string>
+    <string name="duration_minutes">%1$d min</string>
+    <string name="duration_hours">%1$d h</string>
+    <string name="duration_hours_minutes">%1$d h %2$d min</string>
     <string name="never">Never</string>
     <string name="undo">Undo</string>
     <string name="copy">Copy</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -228,6 +228,13 @@
     <string name="cache_images_option_desc">Also store image data in the cache so books with images open instantly too. Uses more space.</string>
     <string name="clear_parse_cache_option">Clear cache</string>
     <string name="clear_parse_cache_option_desc">Currently using %1$s</string>
+    <string name="statistics_option">Statistics</string>
+    <string name="collect_statistics_option">Collect statistics</string>
+    <string name="collect_statistics_option_desc">Measure time, words and how much of each book you have read. Kept on this device and shown only to you: nothing is sent anywhere, and the app holds no internet permission at all. Turning this off keeps what is already recorded.</string>
+    <string name="delete_statistics_option">Delete statistics</string>
+    <string name="delete_statistics_option_desc">Erases everything measured so far</string>
+    <string name="delete_statistics_dialog">Delete all statistics?</string>
+    <string name="delete_statistics_dialog_desc">This removes every reading session, every book\'s record and how much of each book you have read. It cannot be undone.</string>
     <string name="clear_parse_cache_dialog">Clear parse cache?</string>
     <string name="clear_parse_cache_dialog_desc">This removes all cached parsed books. They will be re-parsed the next time you open them.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,23 @@
     <string name="statistics_left_value_by">%1$s, by %2$s</string>
     <string name="statistics_sessions">Sessions</string>
     <string name="statistics_finished">Finished</string>
+    <string name="statistics_none_library">No reading recorded yet.</string>
+    <string name="statistics_total_time">Time read</string>
+    <string name="statistics_words_read">Words read</string>
+    <string name="statistics_your_pace">Your pace</string>
+    <string name="statistics_books_finished">Books finished</string>
+    <string name="statistics_days_read">Days read</string>
+    <string name="statistics_includes_deleted">Includes books no longer in the library.</string>
+    <string name="statistics_card_open">Statistics</string>
+    <string name="statistics_card_summary">%1$s read over %2$s · %3$s</string>
+    <plurals name="statistics_days_plural">
+        <item quantity="one">%d day</item>
+        <item quantity="other">%d days</item>
+    </plurals>
+    <plurals name="statistics_books_finished_plural">
+        <item quantity="one">%d book finished</item>
+        <item quantity="other">%d books finished</item>
+    </plurals>
     <string name="duration_under_a_minute">under a minute</string>
     <string name="duration_minutes">%1$d min</string>
     <string name="duration_hours">%1$d h</string>

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/CoverageCodecTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/CoverageCodecTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CoverageCodecTest {
+
+    @Test
+    fun `nothing read encodes to nothing`() {
+        assertEquals("", CoverageCodec.encode(emptySet()))
+        assertEquals(emptySet<Int>(), CoverageCodec.decode(""))
+    }
+
+    @Test
+    fun `a run becomes one range`() {
+        assertEquals("3-7", CoverageCodec.encode(setOf(3, 4, 5, 6, 7)))
+    }
+
+    @Test
+    fun `a lone index is written without a redundant range`() {
+        assertEquals("12", CoverageCodec.encode(setOf(12)))
+    }
+
+    @Test
+    fun `gaps split the runs, in order`() {
+        // The set arrives unordered — reading jumps around.
+        val covered = setOf(3900, 13, 12, 5200, 14, 3901)
+
+        assertEquals("12-14,3900-3901,5200", CoverageCodec.encode(covered))
+    }
+
+    @Test
+    fun `round trip keeps exactly what was covered`() {
+        val covered = buildSet {
+            addAll(0..40)
+            addAll(500..502)
+            add(9999)
+        }
+
+        assertEquals(covered, CoverageCodec.decode(CoverageCodec.encode(covered)))
+    }
+
+    @Test
+    fun `reads a single-index range written the long way`() {
+        assertEquals(setOf(12), CoverageCodec.decode("12-12"))
+    }
+
+    @Test
+    fun `a damaged piece costs only itself`() {
+        // The string has been through a database; losing one range must not
+        // lose the reading history of the whole book.
+        assertEquals(setOf(1, 2, 3, 90), CoverageCodec.decode("1-3,oops,90"))
+    }
+
+    @Test
+    fun `a backwards range is discarded rather than guessed at`() {
+        assertEquals(setOf(90), CoverageCodec.decode("40-3,90"))
+    }
+
+    @Test
+    fun `tolerates stray whitespace and empty parts`() {
+        assertEquals(setOf(1, 2, 5), CoverageCodec.decode(" 1-2 , ,5 "))
+    }
+}

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReaderTextWordsTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReaderTextWordsTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+import androidx.compose.ui.text.AnnotatedString
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import ua.acclorite.book_story.domain.model.reader.ReaderImage
+import ua.acclorite.book_story.domain.model.reader.ReaderText
+import ua.acclorite.book_story.domain.model.reader.TableAlignment
+
+private fun text(value: String) = ReaderText.Text(line = AnnotatedString(value))
+
+private fun anImage() = ReaderImage(
+    id = "id",
+    src = "src",
+    bytes = ByteArray(0),
+    width = 100,
+    height = 100
+)
+
+class ReaderTextWordsTest {
+
+    @Test
+    fun `counts the words of a paragraph`() {
+        assertEquals(4, text("one two three four").wordCount())
+    }
+
+    @Test
+    fun `runs of whitespace are one gap`() {
+        assertEquals(2, text("  one \n\t  two  ").wordCount())
+    }
+
+    @Test
+    fun `empty text is no words`() {
+        assertEquals(0, text("").wordCount())
+        assertEquals(0, text("   \n ").wordCount())
+    }
+
+    @Test
+    fun `a chapter counts its title`() {
+        assertEquals(3, ReaderText.Chapter(title = "Part the First").wordCount())
+    }
+
+    @Test
+    fun `a poem counts every line`() {
+        val poem = ReaderText.Poem(
+            lines = listOf(text("one two"), text("three four five"))
+        )
+
+        assertEquals(5, poem.wordCount())
+    }
+
+    @Test
+    fun `a table counts every cell`() {
+        val table = ReaderText.Table(
+            rows = listOf(
+                listOf(AnnotatedString("Name"), AnnotatedString("Year of birth")),
+                listOf(AnnotatedString("Ada"), AnnotatedString("1815"))
+            ),
+            hasHeader = true,
+            alignments = listOf(TableAlignment.Start, TableAlignment.End)
+        )
+
+        assertEquals(6, table.wordCount())
+    }
+
+    @Test
+    fun `a separator is not read`() {
+        assertEquals(0, ReaderText.Separator.wordCount())
+    }
+
+    @Test
+    fun `an image counts only its caption`() {
+        val plain = ReaderText.Image(image = anImage())
+        val captioned = ReaderText.Image(image = anImage(), caption = text("Figure one here"))
+
+        assertEquals(0, plain.wordCount())
+        assertEquals(3, captioned.wordCount())
+    }
+}

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReaderTextWordsTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReaderTextWordsTest.kt
@@ -76,6 +76,12 @@ class ReaderTextWordsTest {
     }
 
     @Test
+    fun `a footnote counts its own words`() {
+        assertEquals(5, AnnotatedString("A note on the matter").wordCount())
+        assertEquals(0, AnnotatedString("").wordCount())
+    }
+
+    @Test
     fun `an image counts only its caption`() {
         val plain = ReaderText.Image(image = anImage())
         val captioned = ReaderText.Image(image = anImage(), caption = text("Figure one here"))

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReaderTextWordsTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReaderTextWordsTest.kt
@@ -8,6 +8,7 @@
 package ua.acclorite.book_story.domain.model.statistics
 
 import androidx.compose.ui.text.AnnotatedString
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import ua.acclorite.book_story.domain.model.reader.ReaderImage
@@ -88,5 +89,44 @@ class ReaderTextWordsTest {
 
         assertEquals(0, plain.wordCount())
         assertEquals(3, captioned.wordCount())
+    }
+
+    @Test
+    fun `prefix sums total the items before each index`() {
+        val prefix = listOf(
+            text("one two"),
+            text("three four five"),
+            text("six")
+        ).wordPrefixSums()
+
+        // Entry i is everything before item i, so the first is always empty and
+        // the last is the whole book.
+        assertArrayEquals(intArrayOf(0, 2, 5, 6), prefix)
+    }
+
+    @Test
+    fun `prefix sums carry wordless items`() {
+        // The case an item-proportional estimate gets wrong: a run of images
+        // and separators is a third of the items and none of the words.
+        val prefix = listOf(
+            text("one two three"),
+            ReaderText.Image(image = anImage()),
+            ReaderText.Separator,
+            text("four")
+        ).wordPrefixSums()
+
+        assertArrayEquals(intArrayOf(0, 3, 3, 3, 4), prefix)
+    }
+
+    @Test
+    fun `an empty text has one entry and no words`() {
+        assertArrayEquals(intArrayOf(0), emptyList<ReaderText>().wordPrefixSums())
+    }
+
+    @Test
+    fun `the last entry is the whole book`() {
+        val text = listOf(text("one two"), ReaderText.Chapter(title = "Part the First"))
+
+        assertEquals(text.sumOf { it.wordCount() }, text.wordPrefixSums().last())
     }
 }

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReadingCoverageTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReadingCoverageTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private fun coverage(
+    itemCount: Int = 100,
+    bookWords: Int = 1_000,
+    covered: Set<Int> = setOf(1, 2, 3),
+    coveredWords: Int = 30,
+    wordsBeforeBookmark: Int? = 900
+) = ReadingCoverage(
+    bookId = 1,
+    itemCount = itemCount,
+    bookWords = bookWords,
+    covered = covered,
+    coveredWords = coveredWords,
+    wordsBeforeBookmark = wordsBeforeBookmark
+)
+
+class ReadingCoverageTest {
+
+    @Test
+    fun `a matching item count keeps everything`() {
+        val stored = coverage(itemCount = 100)
+
+        assertSame(stored, stored.validFor(100))
+    }
+
+    @Test
+    fun `a reparse drops the intervals and the bookmark's words`() {
+        // Both were counted against indices that now point elsewhere. The
+        // book's own word total survives: it is a fact about the text, not
+        // about any position in it.
+        val stale = coverage(itemCount = 100).validFor(120)
+
+        assertEquals(120, stale.itemCount)
+        assertTrue(stale.covered.isEmpty())
+        assertEquals(0, stale.coveredWords)
+        assertNull(stale.wordsBeforeBookmark)
+        assertEquals(1_000, stale.bookWords)
+    }
+
+    @Test
+    fun `a book never read yet knows no bookmark`() {
+        val empty = ReadingCoverage.empty(bookId = 1, itemCount = 100, bookWords = 1_000)
+
+        assertNull(empty.wordsBeforeBookmark)
+        assertEquals(0f, empty.percent, 0f)
+    }
+
+    @Test
+    fun `percent is items covered, not words`() {
+        assertEquals(0.03f, coverage(itemCount = 100, covered = setOf(1, 2, 3)).percent, 0.001f)
+    }
+
+    @Test
+    fun `a text with no items is not a division by zero`() {
+        assertEquals(0f, coverage(itemCount = 0, covered = emptySet()).percent, 0f)
+    }
+}

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReadingDaysTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReadingDaysTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+private val KYIV: ZoneId = ZoneId.of("Europe/Kyiv")
+private const val MINUTE = 60_000L
+
+private fun at(date: String, time: String): Long =
+    LocalDateTime.parse("${date}T$time").atZone(KYIV).toInstant().toEpochMilli()
+
+class ReadingDaysTest {
+
+    @Test
+    fun `an evening's reading is one day`() {
+        val shares = ReadingDays.split(
+            startTime = at("2026-08-05", "21:00"),
+            endTime = at("2026-08-05", "21:40"),
+            zone = KYIV
+        )
+
+        assertEquals(listOf(ReadingDays.Share(LocalDate.parse("2026-08-05"), 40 * MINUTE)), shares)
+    }
+
+    @Test
+    fun `reading past midnight counts on both days`() {
+        // The point of splitting: a streak must not lose the day you read into.
+        val shares = ReadingDays.split(
+            startTime = at("2026-08-05", "23:50"),
+            endTime = at("2026-08-06", "00:30"),
+            zone = KYIV
+        )
+
+        assertEquals(
+            listOf(
+                ReadingDays.Share(LocalDate.parse("2026-08-05"), 10 * MINUTE),
+                ReadingDays.Share(LocalDate.parse("2026-08-06"), 30 * MINUTE)
+            ),
+            shares
+        )
+    }
+
+    @Test
+    fun `a session longer than a day fills the day between`() {
+        val shares = ReadingDays.split(
+            startTime = at("2026-08-05", "23:00"),
+            endTime = at("2026-08-07", "01:00"),
+            zone = KYIV
+        )
+
+        assertEquals(3, shares.size)
+        assertEquals(LocalDate.parse("2026-08-06"), shares[1].day)
+        assertEquals(24 * 60 * MINUTE, shares[1].timeMs)
+        assertEquals(60 * MINUTE, shares[0].timeMs)
+        assertEquals(60 * MINUTE, shares[2].timeMs)
+    }
+
+    @Test
+    fun `the shares add up to the session`() {
+        val start = at("2026-08-05", "22:15")
+        val end = at("2026-08-06", "07:45")
+
+        val total = ReadingDays.split(start, end, KYIV).sumOf { it.timeMs }
+
+        assertEquals(end - start, total)
+    }
+
+    @Test
+    fun `a session ending exactly at midnight stays on its own day`() {
+        val shares = ReadingDays.split(
+            startTime = at("2026-08-05", "23:30"),
+            endTime = at("2026-08-06", "00:00"),
+            zone = KYIV
+        )
+
+        assertEquals(1, shares.size)
+        assertEquals(LocalDate.parse("2026-08-05"), shares.single().day)
+    }
+
+    @Test
+    fun `an instant session still names its day`() {
+        // Zero-length rows should not vanish from the day count.
+        val shares = ReadingDays.split(
+            startTime = at("2026-08-05", "10:00"),
+            endTime = at("2026-08-05", "10:00"),
+            zone = KYIV
+        )
+
+        assertEquals(listOf(ReadingDays.Share(LocalDate.parse("2026-08-05"), 0)), shares)
+    }
+
+    @Test
+    fun `days are the reader's own, not UTC`() {
+        // 01:30 in Kyiv on the 6th is still the 5th in UTC; the reader was
+        // reading on the 6th.
+        val day = ReadingDays.dayOf(at("2026-08-06", "01:30"), KYIV)
+
+        assertEquals(LocalDate.parse("2026-08-06"), day)
+    }
+}

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReadingPaceTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReadingPaceTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+private const val MINUTE = 60_000L
+
+class ReadingPaceTest {
+
+    @Test
+    fun `words per minute over a real sitting`() {
+        assertEquals(200, ReadingPace.wordsPerMinute(timeMs = 10 * MINUTE, words = 2000))
+    }
+
+    @Test
+    fun `refuses a pace from too little time`() {
+        assertNull(ReadingPace.wordsPerMinute(timeMs = 30_000, words = 300))
+    }
+
+    @Test
+    fun `refuses a pace with nothing read`() {
+        assertNull(ReadingPace.wordsPerMinute(timeMs = 10 * MINUTE, words = 0))
+    }
+
+    @Test
+    fun `typical pace ignores a forgotten device`() {
+        // Four ordinary sittings and one where the tablet was left open: the
+        // median holds, a mean would be dragged down by a third.
+        val typical = ReadingPace.typical(listOf(210, 190, 200, 205, 3))
+
+        assertEquals(200, typical)
+    }
+
+    @Test
+    fun `typical pace of an even number of sittings`() {
+        assertEquals(195, ReadingPace.typical(listOf(190, 200, 210, 180)))
+    }
+
+    @Test
+    fun `no sittings, no typical pace`() {
+        assertNull(ReadingPace.typical(emptyList()))
+        assertNull(ReadingPace.typical(listOf(0, -5)))
+    }
+
+    @Test
+    fun `time for the words that are left`() {
+        assertEquals(10 * MINUTE, ReadingPace.timeForWords(words = 2000, wordsPerMinute = 200))
+    }
+
+    @Test
+    fun `no pace, no estimate`() {
+        assertNull(ReadingPace.timeForWords(words = 2000, wordsPerMinute = null))
+        assertNull(ReadingPace.timeForWords(words = 0, wordsPerMinute = 200))
+    }
+
+    @Test
+    fun `finish date rounds up to whole days of reading`() {
+        val now = 1_000_000_000L
+        val day = 24 * 60 * 60 * 1000L
+
+        // 90 minutes over 3 active days is 30 min a day; 61 minutes left is
+        // three more days, not two and a bit.
+        val by = ReadingPace.finishedBy(
+            now = now,
+            timeLeftMs = 61 * MINUTE,
+            totalTimeMs = 90 * MINUTE,
+            activeDays = 3
+        )
+
+        assertEquals(now + 3 * day, by)
+    }
+
+    @Test
+    fun `no finish date without a day of evidence`() {
+        assertNull(
+            ReadingPace.finishedBy(
+                now = 0,
+                timeLeftMs = 60 * MINUTE,
+                totalTimeMs = 30 * MINUTE,
+                activeDays = 0
+            )
+        )
+    }
+}

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReadingSessionTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReadingSessionTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+private const val BOOK_ID = 7
+private const val START = 1_000_000L
+
+class ReadingSessionTest {
+
+    private fun session(
+        lastActiveTime: Long,
+        now: Long,
+        wordsRead: Int = 0
+    ) = ReadingSession.endedAt(
+        bookId = BOOK_ID,
+        startTime = START,
+        lastActiveTime = lastActiveTime,
+        now = now,
+        wordsRead = wordsRead
+    )
+
+    @Test
+    fun `records a session that was read`() {
+        val read = 30_000L
+        val session = session(lastActiveTime = START + read, now = START + read)
+
+        assertEquals(read, session?.durationMs)
+        assertEquals(BOOK_ID, session?.bookId)
+    }
+
+    @Test
+    fun `drops an open and close`() {
+        assertNull(session(lastActiveTime = START, now = START + 4_999))
+    }
+
+    @Test
+    fun `keeps a session exactly at the minimum`() {
+        val session = session(lastActiveTime = START, now = START + ReadingSession.MIN_DURATION_MS)
+
+        assertEquals(ReadingSession.MIN_DURATION_MS, session?.durationMs)
+    }
+
+    @Test
+    fun `caps the idle left after the last settled position`() {
+        val lastActive = START + 60_000
+        val session = session(lastActiveTime = lastActive, now = lastActive + 3 * 60 * 60 * 1000)
+
+        assertEquals(
+            60_000 + ReadingSession.IDLE_CAP_MS,
+            session?.durationMs
+        )
+    }
+
+    @Test
+    fun `counts idle inside a sitting in full`() {
+        // Scrolled at the very end after a long pause: nothing to cap, because
+        // the pause is not trailing. Staring at one page is still reading.
+        val end = START + 40 * 60 * 1000
+        val session = session(lastActiveTime = end, now = end)
+
+        assertEquals(40 * 60 * 1000L, session?.durationMs)
+    }
+
+    @Test
+    fun `a session shorter than the minimum only because of the cap is dropped`() {
+        // Opened, one settled position, then left open for hours: the cap pulls
+        // the end back to a point that is still a real session.
+        val lastActive = START + 1_000
+        val session = session(lastActiveTime = lastActive, now = lastActive + 86_400_000)
+
+        assertEquals(1_000 + ReadingSession.IDLE_CAP_MS, session?.durationMs)
+    }
+
+    @Test
+    fun `never ends before it started`() {
+        // A clock moved backwards must not produce a negative session.
+        val session = session(lastActiveTime = START - 600_000, now = START - 300_000)
+
+        assertNull(session)
+    }
+
+    @Test
+    fun `carries the words it was given`() {
+        val session = session(lastActiveTime = START + 30_000, now = START + 30_000, wordsRead = 412)
+
+        assertEquals(412, session?.wordsRead)
+    }
+}

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReadingSessionTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/ReadingSessionTest.kt
@@ -19,13 +19,15 @@ class ReadingSessionTest {
     private fun session(
         lastActiveTime: Long,
         now: Long,
-        wordsRead: Int = 0
+        wordsRead: Int = 0,
+        overlayMs: Long = 0
     ) = ReadingSession.endedAt(
         bookId = BOOK_ID,
         startTime = START,
         lastActiveTime = lastActiveTime,
         now = now,
-        wordsRead = wordsRead
+        wordsRead = wordsRead,
+        overlayMs = overlayMs
     )
 
     @Test
@@ -86,6 +88,44 @@ class ReadingSessionTest {
         val session = session(lastActiveTime = START - 600_000, now = START - 300_000)
 
         assertNull(session)
+    }
+
+    @Test
+    fun `overlay time is kept in the book's time and taken out of the reading time`() {
+        val session = session(
+            lastActiveTime = START + 20 * 60 * 1000,
+            now = START + 20 * 60 * 1000,
+            overlayMs = 8 * 60 * 1000
+        )
+
+        // Time in the book keeps the whole interval — looking at an
+        // illustration is time spent with the book.
+        assertEquals(20 * 60 * 1000L, session?.durationMs)
+        // The speed divides by the part in which words were possible.
+        assertEquals(12 * 60 * 1000L, session?.readingMs)
+    }
+
+    @Test
+    fun `a session without an overlay reads for the whole of it`() {
+        val session = session(lastActiveTime = START + 30_000, now = START + 30_000)
+
+        assertEquals(session?.durationMs, session?.readingMs)
+    }
+
+    @Test
+    fun `an overlay cannot outlast the session the cap left`() {
+        // Left in the image viewer and never came back: the tail is capped, and
+        // the overlay it was holding is longer than what survives the cap.
+        val lastActive = START + 1_000
+        val session = session(
+            lastActiveTime = lastActive,
+            now = lastActive + 3 * 60 * 60 * 1000,
+            overlayMs = 3 * 60 * 60 * 1000
+        )
+
+        assertEquals(1_000 + ReadingSession.IDLE_CAP_MS, session?.durationMs)
+        assertEquals(1_000 + ReadingSession.IDLE_CAP_MS, session?.overlayMs)
+        assertEquals(0L, session?.readingMs)
     }
 
     @Test

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/SessionWordsTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/statistics/SessionWordsTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.statistics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SessionWordsTest {
+
+    @Test
+    fun `credits every item once`() {
+        val words = SessionWords()
+
+        words.creditItem(index = 1, words = 100)
+        words.creditItem(index = 2, words = 50)
+
+        assertEquals(150, words.total)
+    }
+
+    @Test
+    fun `a screen scrolled back to counts once`() {
+        val words = SessionWords()
+
+        words.creditItem(index = 1, words = 100)
+        words.creditItem(index = 2, words = 50)
+        words.creditItem(index = 1, words = 100)
+
+        assertEquals(150, words.total)
+    }
+
+    @Test
+    fun `a note counts once however often it is opened`() {
+        val words = SessionWords()
+
+        words.creditNote(id = "n1", words = 40)
+        words.creditNote(id = "n1", words = 40)
+
+        assertEquals(40, words.total)
+    }
+
+    @Test
+    fun `notes and items are counted apart`() {
+        // An item index and a note id are different namespaces: note "1" must
+        // not be swallowed by item 1.
+        val words = SessionWords()
+
+        words.creditItem(index = 1, words = 100)
+        words.creditNote(id = "1", words = 40)
+
+        assertEquals(140, words.total)
+    }
+
+    @Test
+    fun `the next session starts from nothing`() {
+        val words = SessionWords()
+        words.creditItem(index = 1, words = 100)
+        words.creditNote(id = "n1", words = 40)
+
+        words.clear()
+
+        assertEquals(0, words.total)
+
+        // And a page genuinely re-read tomorrow is volume read again.
+        words.creditItem(index = 1, words = 100)
+        words.creditNote(id = "n1", words = 40)
+
+        assertEquals(140, words.total)
+    }
+}


### PR DESCRIPTION
Reading statistics: how long a book is read, how much of it was really read,
and how fast.

Closes #53
Closes #54
Closes #55
Closes #56
Closes #57

The umbrella #52 stays **open** on purpose — it carries the follow-ups this does
not attempt: the heatmap (a month or two of data first), an inline "finished"
control at the end of the text, and matching a re-imported book to its archive
row by its document id.

## Why the bookmark cannot be the basis

Open a three-novel omnibus, jump to the last novel and read it to the end: the
bookmark sits at 100 %, correctly, but only a third of the book was read. Any
measure built on progress deltas credits the jump and inflates everything
downstream — words, speed, "time left".

So the reader stores **coverage** instead: the item indices actually read, as a
list of intervals. Two numbers fall out of it and both are needed — *coverage*
(unique items, always 0–100 %, exactly 100 % for an ordinary cover-to-cover
read) and *volume* (everything read, repeats included, may exceed 100 %).

**No idle threshold anywhere.** `ReaderModel` already samples the scroll
position through `debounce(300)`, which only ever emits *settled* positions — a
fling across half the book produces no intermediate sample. An item is covered
when it was on screen at a settled sample, so skimming never earns coverage and
there is not one tuning constant to pick.

## What is stored

Three tables, and a deliberate asymmetry between them:

- `ReadingSessionEntity` — one row per sitting: interval, words, `overlayMs`.
- `ReadBookEntity` — one row per book ever read; the durable layer.
- `ReadingCoverageEntity` — intervals and word totals; dies with the book.

**Deleting a book anonymises its sessions (`bookId = NULL`) instead of deleting
them.** The per-book detail stops matching `WHERE bookId = :id` and disappears,
while the day, the duration and the words stay in the lifetime totals — so
removing a book cannot retroactively shorten a streak or shrink the total time.
NULL, rather than a `deleted` flag, is what makes that structural: no query can
reach the detail, instead of every future query having to remember not to.

Days are computed from the session rows at read time, never stored, so a sitting
from 23:50 to 00:30 counts on both days, in the reader's own time zone.

## The speed denominator

One sentence decides two of the tickets: *the denominator of a speed holds
exactly the time in which words could have been earned.*

- **#55** — a footnote's words are credited to the session. Note text is not in
  the item list, so it entered neither the book's total nor coverage — but the
  session ran while the sheet was open, leaving the time counted and the words
  not, which dragged every speed figure down. Volume only, never the book's
  total: otherwise no book could reach 100 % coverage without opening every note.
- **#56** — `overlayMs` records how long the text was covered by something that
  earns no words (the image viewer, the settings sheet, the chapters drawer).
  Every speed divides by `duration − overlayMs`; time in the book, days and
  streaks read the interval whole, because an illustration is part of the book.
  Deliberately **not** a pause: `durationMs = end − start` is what lets days and
  the midnight split be computed from the rows at query time.

Both uncovered the same bug, fixed here: only the scroll flow marked a session
active, so ten minutes in a note or an image, with the list untouched, was cut
off the end of the session by the idle cap.

**#57** applies the same thinking to the other end. "Left to read" divided the
words *coverage had never seen* and called it a forecast — a different question
from what is ahead of the reader. A book whose statistics began mid-way has most
of itself uncovered while having almost nothing left. It now counts words after
the bookmark, and is omitted rather than approximated when that is not yet known.

## UI

- **BookInfo card** — time in this book, coverage, pace here vs usual, time left
  with a projected finish date, sessions, and the `Finished` switch. Every line
  is left out when its figure cannot be trusted yet, rather than printing a
  false one.
- **History** — a card at the top opening a screen with five figures. No charts:
  there is no backfill, so anything needing weeks of history would show nothing
  on day one.
- **Settings → Statistics** — a collection toggle that gates the writes only,
  and a deletion action that erases all three tables in one transaction.

`Finished` is a statement by the reader, not a measurement: it defaults to on
when the end is reached and can be toggled at any time, including on a book this
build has never measured.

## Notes for review

- **Room 17 → 21**, four auto migrations, all exported. The last one makes
  `ReadBookEntity.bookId` unique — one record per live book, stated in the schema
  rather than trusted to the writers. Deleted books are exempt by construction,
  SQLite counting NULLs as distinct. Room recreates the table and adds the index
  last, so a database that somehow held duplicates would roll back intact and
  refuse to open; worth checking before upgrading a database with real data in it.
- The update-then-insert that keeps a book's record single sits behind
  `@Transaction` in the DAO, and the insert aborts rather than replaces: with a
  unique index, `REPLACE` would silently discard the totals accumulated against
  that book.
- A native upsert would have been neater than the pair, but it needs SQLite 3.24
  (API 30) and `minSdk` here is 26.
- The parse cache format is untouched and there is no `VERSION` bump: words are
  counted from the `AnnotatedString`s already in memory.
- **177 unit tests**, covering the pure logic: interval coding, the midnight
  split, the median, the idle cap, per-item word counts, coverage invalidation.
- Device-tested on a tablet: session recording across Back, the home gesture and
  screen-off; slider drags crediting nothing; a cover-to-cover read landing on
  exactly 100 %; deletion keeping the lifetime totals; and each migration running
  on a database with real reading in it.

Known and deliberate: resuming an already-loaded reader credits nothing until
the first scroll. Crediting it would re-credit the whole screen on every
translator lookup, which would fall hardest on someone reading in a foreign
language; undercounting is the safer error.
