### PR TITLE
feat: copy the database to somewhere adb can read it (#58)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,10 +54,16 @@ android {
         // sees it, under the "ThemeTrace" tag. Same variants as BOOK_TIMING, and
         // for a stronger reason: the bug it chases takes hours of ordinary
         // reading to appear, and release-debug is what that reading happens on.
+        // DB_EXPORT puts a "Copy database" row in General settings. The reading
+        // app is release-debug, which is not debuggable on purpose, so `run-as`
+        // cannot reach its database and no question about real reading data can
+        // be answered without it. Off in release: nothing ships a one-tap "put
+        // my reading history where another process can read it" button.
         getByName("debug") {
             applicationIdSuffix = ".debug"
             buildConfigField("boolean", "BOOK_TIMING", "true")
             buildConfigField("boolean", "THEME_TRACE", "true")
+            buildConfigField("boolean", "DB_EXPORT", "true")
         }
 
         getByName("release") {
@@ -65,6 +71,7 @@ android {
             isShrinkResources = false
             buildConfigField("boolean", "BOOK_TIMING", "false")
             buildConfigField("boolean", "THEME_TRACE", "false")
+            buildConfigField("boolean", "DB_EXPORT", "false")
 
             proguardFiles("proguard-rules.pro")
         }
@@ -75,6 +82,7 @@ android {
             signingConfig = signingConfigs.getByName("debug")
             buildConfigField("boolean", "BOOK_TIMING", "true")
             buildConfigField("boolean", "THEME_TRACE", "true")
+            buildConfigField("boolean", "DB_EXPORT", "true")
         }
     }
 

--- a/app/src/main/java/ua/acclorite/book_story/data/debug/DatabaseCopier.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/debug/DatabaseCopier.kt
@@ -1,0 +1,72 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.debug
+
+import android.app.Application
+import ua.acclorite.book_story.core.log.logI
+import ua.acclorite.book_story.data.local.room.BookDatabase
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "DatabaseCopier"
+
+/** Where the copy lands. `adb shell` can read it; `run-as` is not needed. */
+private const val DIRECTORY = "debug"
+
+/**
+ * Copies the database somewhere it can actually be read.
+ *
+ * The app that does the reading is `release-debug`, which is deliberately not
+ * `debuggable` — that flag would cost every `BookTiming` measurement its
+ * comparability — so `run-as` cannot reach its files. This puts a copy under
+ * the app's own external files directory instead, which adb reads directly.
+ */
+@Singleton
+class DatabaseCopier @Inject constructor(
+    private val application: Application,
+    private val database: BookDatabase
+) {
+
+    /**
+     * Checkpoints the write-ahead log and copies the database out, returning
+     * where it landed.
+     *
+     * **The checkpoint is the whole point of the ordering.** SQLite keeps
+     * recent writes in `-wal`, and the main file on its own can be a 4 KB
+     * header holding nothing — a copy taken without checkpointing would be
+     * missing exactly the sessions worth asking about. `TRUNCATE` folds the
+     * log back in and empties it; the `-wal`/`-shm` files are copied anyway if
+     * anything is still there, so a copy is complete or it is nothing.
+     */
+    fun copy(): File {
+        database.openHelper.writableDatabase.let { db ->
+            db.query("PRAGMA wal_checkpoint(TRUNCATE)").use { cursor ->
+                // The result says whether it blocked; reading it is what runs it.
+                if (cursor.moveToFirst()) {
+                    logI(TAG, "Checkpointed: ${cursor.getInt(0)} busy.")
+                }
+            }
+        }
+
+        val source = File(database.openHelper.writableDatabase.path!!)
+        val destination = File(application.getExternalFilesDir(null), DIRECTORY).apply {
+            mkdirs()
+        }
+
+        val copied = File(destination, source.name)
+        source.copyTo(copied, overwrite = true)
+
+        for (suffix in listOf("-wal", "-shm")) {
+            val extra = File(source.path + suffix)
+            if (extra.exists()) extra.copyTo(File(destination, extra.name), overwrite = true)
+        }
+
+        logI(TAG, "Copied ${copied.length()} bytes to ${copied.path}.")
+        return copied
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/debug/CopyDatabaseUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/debug/CopyDatabaseUseCase.kt
@@ -1,0 +1,41 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.debug
+
+import ua.acclorite.book_story.BuildConfig
+import ua.acclorite.book_story.core.log.logW
+import ua.acclorite.book_story.core.helpers.runCatchingCancellable
+import ua.acclorite.book_story.data.debug.DatabaseCopier
+import javax.inject.Inject
+
+private const val TAG = "CopyDatabase"
+
+class CopyDatabaseUseCase @Inject constructor(
+    private val databaseCopier: DatabaseCopier
+) {
+
+    /**
+     * Where the copy landed, or the failure. A copy that quietly did nothing
+     * would be worse than no button at all — the next question would be
+     * answered from a stale file.
+     *
+     * The build-config guard is repeated here rather than left to the settings
+     * row that calls it, so the flag is the one place this feature exists or
+     * does not.
+     */
+    suspend operator fun invoke(): Result<String> {
+        if (!BuildConfig.DB_EXPORT) {
+            return Result.failure(IllegalStateException("Database export is off in this build."))
+        }
+
+        return runCatchingCancellable {
+            databaseCopier.copy().path
+        }.onFailure {
+            logW(TAG, "Could not copy the database: ${it.message}")
+        }
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsEvent.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsEvent.kt
@@ -87,4 +87,6 @@ sealed class SettingsEvent {
     data object OnClearParseCache : SettingsEvent()
 
     data object OnRefreshParseCacheSize : SettingsEvent()
+
+    data object OnCopyDatabase : SettingsEvent()
 }

--- a/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsModel.kt
@@ -34,6 +34,7 @@ import ua.acclorite.book_story.domain.use_case.color_preset.GetColorPresetsUseCa
 import ua.acclorite.book_story.domain.use_case.color_preset.ReorderColorPresetsUseCase
 import ua.acclorite.book_story.domain.use_case.color_preset.SelectColorPresetUseCase
 import ua.acclorite.book_story.domain.use_case.color_preset.UpdateColorPresetUseCase
+import ua.acclorite.book_story.domain.use_case.debug.CopyDatabaseUseCase
 import ua.acclorite.book_story.domain.use_case.permission.GrantPersistableUriPermissionUseCase
 import ua.acclorite.book_story.domain.use_case.permission.ReleasePersistableUriPermissionUseCase
 import ua.acclorite.book_story.domain.use_case.settings.UpdateLanguageUseCase
@@ -57,7 +58,8 @@ class SettingsModel @Inject constructor(
     private val updateCategoriesOrderUseCase: UpdateCategoriesOrderUseCase,
     private val deleteCategoryUseCase: DeleteCategoryUseCase,
     private val getParseCacheSizeUseCase: GetParseCacheSizeUseCase,
-    private val clearParseCacheUseCase: ClearParseCacheUseCase
+    private val clearParseCacheUseCase: ClearParseCacheUseCase,
+    private val copyDatabaseUseCase: CopyDatabaseUseCase
 ) : ViewModel() {
 
     private val mutex = Mutex()
@@ -488,6 +490,16 @@ class SettingsModel @Inject constructor(
                     val size = withContext(Dispatchers.IO) { getParseCacheSizeUseCase() }
                     _state.update {
                         it.copy(parseCacheSizeBytes = size)
+                    }
+                }
+
+                is SettingsEvent.OnCopyDatabase -> {
+                    val result = withContext(Dispatchers.IO) { copyDatabaseUseCase() }
+                    _state.update {
+                        it.copy(
+                            databaseCopyPath = result.getOrNull(),
+                            databaseCopyError = result.exceptionOrNull()?.message
+                        )
                     }
                 }
             }

--- a/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsState.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsState.kt
@@ -20,5 +20,13 @@ data class SettingsState(
 
     val categories: List<Category> = emptyList(),
 
-    val parseCacheSizeBytes: Long = 0L
+    val parseCacheSizeBytes: Long = 0L,
+
+    /**
+     * Where the last "Copy database" landed, or why it did not. Both null until
+     * the row is tapped; a copy that reported nothing would leave the next
+     * question to be answered from a stale file.
+     */
+    val databaseCopyPath: String? = null,
+    val databaseCopyError: String? = null
 )

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/general/GeneralSettingsCategory.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/general/GeneralSettingsCategory.kt
@@ -19,11 +19,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
+import ua.acclorite.book_story.BuildConfig
 import ua.acclorite.book_story.R
 import ua.acclorite.book_story.ui.settings.components.SettingsSubcategory
 import ua.acclorite.book_story.ui.settings.general.components.AppLanguageOption
 import ua.acclorite.book_story.ui.settings.general.components.CacheImagesOption
 import ua.acclorite.book_story.ui.settings.general.components.ClearParseCacheOption
+import ua.acclorite.book_story.ui.settings.general.components.CopyDatabaseOption
 import ua.acclorite.book_story.ui.settings.general.components.DoublePressExitOption
 import ua.acclorite.book_story.ui.settings.general.components.ParseCacheSizeOption
 
@@ -60,6 +62,22 @@ fun LazyListScope.GeneralSettingsCategory(
 
         item {
             ClearParseCacheOption()
+        }
+    }
+
+    // Debugging tools, absent from a release build entirely: the reading app is
+    // release-debug and is not debuggable, so without this its database cannot
+    // be read at all.
+    if (BuildConfig.DB_EXPORT) {
+        SettingsSubcategory(
+            titleColor = titleColor,
+            title = { stringResource(id = R.string.debug_option) },
+            showTitle = true,
+            showDivider = false
+        ) {
+            item {
+                CopyDatabaseOption()
+            }
         }
     }
 

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/general/components/CopyDatabaseOption.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/general/components/CopyDatabaseOption.kt
@@ -1,0 +1,67 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.settings.general.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.presentation.settings.SettingsEvent
+import ua.acclorite.book_story.presentation.settings.SettingsModel
+import ua.acclorite.book_story.ui.common.components.common.StyledText
+
+/**
+ * Copies the database somewhere adb can read it. Present only in the builds
+ * whose `DB_EXPORT` flag is on; the reading app is `release-debug`, which is
+ * not debuggable, so this is the only way to its data.
+ *
+ * No confirmation dialog, unlike the destructive rows next to it: this one
+ * writes a copy and touches nothing.
+ */
+@Composable
+fun CopyDatabaseOption() {
+    val settingsModel = hiltViewModel<SettingsModel>()
+    val state = settingsModel.state.collectAsStateWithLifecycle()
+
+    val description = state.value.let { current ->
+        when {
+            current.databaseCopyError != null -> current.databaseCopyError
+            current.databaseCopyPath != null -> current.databaseCopyPath
+            else -> stringResource(id = R.string.copy_database_option_desc)
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { settingsModel.onEvent(SettingsEvent.OnCopyDatabase) }
+            .padding(horizontal = 18.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.Center
+    ) {
+        StyledText(
+            text = stringResource(id = R.string.copy_database_option),
+            style = MaterialTheme.typography.titleMedium.copy(
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        )
+        StyledText(
+            text = description,
+            style = MaterialTheme.typography.bodySmall.copy(
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,6 +193,9 @@
     <string name="cache_images_option_desc">Also store image data in the cache so books with images open instantly too. Uses more space.</string>
     <string name="clear_parse_cache_option">Clear cache</string>
     <string name="clear_parse_cache_option_desc">Currently using %1$s</string>
+    <string name="debug_option">Debug</string>
+    <string name="copy_database_option">Copy database</string>
+    <string name="copy_database_option_desc">Copies it where adb can read it, without run-as</string>
     <string name="clear_parse_cache_dialog">Clear parse cache?</string>
     <string name="clear_parse_cache_dialog_desc">This removes all cached parsed books. They will be re-parsed the next time you open them.</string>
 


### PR DESCRIPTION
Closes #58.

The app that does the real reading is `release-debug`, which is deliberately not
debuggable — that flag costs every `BookTiming` measurement its comparability —
so `run-as` cannot reach its database. Every question about real reading data
has had to be answered from the `debug` build instead, which holds test books
and adb-driven sessions: it can show that a mechanism works, never that the
numbers from real reading are right.

A **Copy database** row in General settings copies the database under the app's
own external files directory, where adb reads it without `run-as`. The whole
database rather than chosen columns, so questions nobody has asked yet are still
answerable from the copy.

- It checkpoints the write-ahead log first, and that ordering is the point:
  SQLite keeps recent writes in `-wal`, and the main file alone can be a 4 KB
  header holding nothing — exactly the sessions worth asking about would be the
  ones missing. `TRUNCATE` folds the log back in; `-wal` and `-shm` are copied
  too if anything remains, so a copy is whole or it is nothing.
- Gated on `DB_EXPORT`, a third build-config field in the
  `BOOK_TIMING`/`THEME_TRACE` pattern: on in `debug` and `release-debug`, off in
  `release`. No release build ships a one-tap "put my reading history where
  another process can read it" button — the code is unreachable there and R8
  strips it.
- The row reports where the copy landed, or why it failed, in its own subtitle.
  A copy that silently did nothing would be worse than no button, because the
  next question would be answered from a stale file.

## Why it lands now

The branch was cut from `develop` on its own so the reading-statistics PR would
not carry a debugging tool. That reason expired when #59 merged. Keeping it out
of `develop` any longer buys nothing — release is unaffected by construction —
while costing a merge conflict in the same four files every time a feature adds
a settings row; this merge already had to resolve four of them.

It stays trivially removable: `git revert -m 1` of the merge, or flipping the
flag.

## Not done here

A dedicated "Developer settings" screen was considered and deferred. With one
row it would be a top-level entry holding a single item; the gated **Debug**
subsection at the bottom of General says the same thing for now. Worth
revisiting once there is a second or third such tool.

## Verified

- `:app:testDebugUnitTest` — **177 tests, 0 failures**.
- `:app:assembleRelease` builds with `DB_EXPORT = false`, lint-vital clean.
- Device-tested on 2026-08-09: it produced the first real-data check of the
  reading statistics on the tablet.
