### PR TITLE
feat: open a book from a file manager as a preview (#61)

### DIFF
--- a/app/schemas/ua.acclorite.book_story.data.local.room.BookDatabase/22.json
+++ b/app/schemas/ua.acclorite.book_story.data.local.room.BookDatabase/22.json
@@ -1,0 +1,427 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 22,
+    "identityHash": "c919dc17bca690877a0fb75234dd1986",
+    "entities": [
+      {
+        "tableName": "BookEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `description` TEXT, `filePath` TEXT NOT NULL, `scrollIndex` INTEGER NOT NULL, `scrollOffset` INTEGER NOT NULL, `progress` REAL NOT NULL, `image` TEXT, `categories` TEXT NOT NULL DEFAULT '[]', `inLibrary` INTEGER NOT NULL DEFAULT 1, `previewUri` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrollIndex",
+            "columnName": "scrollIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrollOffset",
+            "columnName": "scrollOffset",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "previewUri",
+            "columnName": "previewUri",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "HistoryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER NOT NULL, `time` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ColorPresetEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `backgroundColor` INTEGER NOT NULL, `fontColor` INTEGER NOT NULL, `isSelected` INTEGER NOT NULL, `order` INTEGER NOT NULL, `type` TEXT NOT NULL DEFAULT 'CUSTOM')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "backgroundColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontColor",
+            "columnName": "fontColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSelected",
+            "columnName": "isSelected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'CUSTOM'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "CategoryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `order` INTEGER NOT NULL, `sortOrder` TEXT NOT NULL DEFAULT 'LAST_READ', `sortOrderDescending` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'LAST_READ'"
+          },
+          {
+            "fieldPath": "sortOrderDescending",
+            "columnName": "sortOrderDescending",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ReadingSessionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER, `startTime` INTEGER NOT NULL, `endTime` INTEGER NOT NULL, `wordsRead` INTEGER NOT NULL, `overlayMs` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "endTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordsRead",
+            "columnName": "wordsRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overlayMs",
+            "columnName": "overlayMs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ReadingSessionEntity_bookId",
+            "unique": false,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReadingSessionEntity_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          },
+          {
+            "name": "index_ReadingSessionEntity_startTime",
+            "unique": false,
+            "columnNames": [
+              "startTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ReadingSessionEntity_startTime` ON `${TABLE_NAME}` (`startTime`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ReadBookEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bookId` INTEGER, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `totalTimeMs` INTEGER NOT NULL, `totalWords` INTEGER NOT NULL, `sessions` INTEGER NOT NULL, `firstReadAt` INTEGER NOT NULL, `lastReadAt` INTEGER NOT NULL, `finished` INTEGER NOT NULL, `coveragePercent` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalTimeMs",
+            "columnName": "totalTimeMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalWords",
+            "columnName": "totalWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessions",
+            "columnName": "sessions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstReadAt",
+            "columnName": "firstReadAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadAt",
+            "columnName": "lastReadAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finished",
+            "columnName": "finished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coveragePercent",
+            "columnName": "coveragePercent",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ReadBookEntity_bookId",
+            "unique": true,
+            "columnNames": [
+              "bookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_ReadBookEntity_bookId` ON `${TABLE_NAME}` (`bookId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ReadingCoverageEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` INTEGER NOT NULL, `itemCount` INTEGER NOT NULL, `bookWords` INTEGER NOT NULL, `intervals` TEXT NOT NULL, `coveredWords` INTEGER NOT NULL, `wordsBeforeBookmark` INTEGER, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookWords",
+            "columnName": "bookWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intervals",
+            "columnName": "intervals",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coveredWords",
+            "columnName": "coveredWords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wordsBeforeBookmark",
+            "columnName": "wordsBeforeBookmark",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c919dc17bca690877a0fb75234dd1986')"
+    ]
+  }
+}

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Book's Story — free and open-source Material You eBook reader.
+  Copyright (C) 2026 derand
+  SPDX-License-Identifier: GPL-3.0-only
+
+  The debug build's own name. Three variants can be installed side by side, and
+  since the app now offers itself in "Open with", two of them would otherwise
+  appear there under the same name with no way to tell which is which. Only the
+  debug build is renamed: release-debug is the one actually read on, so it keeps
+  the real name.
+-->
+<resources>
+    <string name="app_name">Book Story DEV</string>
+</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,8 +75,12 @@
                 application/octet-stream is deliberately absent. Several file
                 managers send it for FB2, which has no registered MIME type, but
                 accepting it would offer this app for every unknown binary on the
-                device. Start narrow and widen on evidence. Whatever is declared,
-                the format is decided by the file's content.
+                device. Start narrow and widen on evidence.
+
+                Note that declaring a type here only gets the app offered: what
+                it can actually open is decided by the file's extension, so a
+                book arriving as text/xml under a name ending ".xml" is offered
+                and then refused. See issue #62.
             -->
             <intent-filter tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
@@ -98,8 +102,11 @@
             <!--
                 For file:// the path really is the file's path, so the extension
                 can be matched. Android's matcher has no case folding and its
-                ".*" does not cross a literal dot, hence both cases of every
-                extension and the doubled variants for names containing dots.
+                ".*" does not cross a literal dot, hence a lower-case and an
+                upper-case pattern for every extension, plus a doubled variant
+                for names that contain a dot of their own. Mixed case (".Fb2")
+                is not covered and would need a pattern each; content:// does
+                not go through here at all.
             -->
             <intent-filter tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
@@ -123,10 +130,13 @@
                 <data android:pathPattern=".*\\.TXT" />
                 <data android:pathPattern=".*\\.html" />
                 <data android:pathPattern=".*\\..*\\.html" />
+                <data android:pathPattern=".*\\.HTML" />
                 <data android:pathPattern=".*\\.htm" />
                 <data android:pathPattern=".*\\..*\\.htm" />
+                <data android:pathPattern=".*\\.HTM" />
                 <data android:pathPattern=".*\\.md" />
                 <data android:pathPattern=".*\\..*\\.md" />
+                <data android:pathPattern=".*\\.MD" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,16 +35,98 @@
         tools:ignore="DataExtractionRules"
         tools:targetApi="tiramisu">
 
-        <!-- Main activity -->
+        <!--
+            Main activity. singleTask because of the file filters below.
+
+            A file manager starts the viewer inside *its own* task rather than
+            ours, so every "Open with" produced another whole copy of the app —
+            measured on a tablet: seventeen entries in the recents list, each a
+            DocumentsUI task with a Book's Story activity sitting on top of it,
+            each with its own navigator and its own idea of where the reader is.
+            singleTop cannot help with that; it only reuses an instance already
+            at the top of the same task. singleTask keeps the app to one task and
+            one instance, and routes every later file through onNewIntent.
+
+            documentLaunchMode="never" refuses the other half of it: opening two
+            books must not leave two entries in recents, one per document.
+        -->
         <activity
             android:name=".presentation.main.MainActivity"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|locale|density|uiMode"
+            android:documentLaunchMode="never"
             android:exported="true"
+            android:launchMode="singleTask"
             android:theme="@style/Splash"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <!--
+                Opening a book from a file manager. Two filters, because the two
+                schemes are matched on different things.
+
+                For content:// the path is the provider's document id and almost
+                never ends in the file's extension, so a pathPattern would match
+                nothing; only the MIME type is usable. The types listed are the
+                ones the seven supported extensions actually arrive as.
+
+                application/octet-stream is deliberately absent. Several file
+                managers send it for FB2, which has no registered MIME type, but
+                accepting it would offer this app for every unknown binary on the
+                device. Start narrow and widen on evidence. Whatever is declared,
+                the format is decided by the file's content.
+            -->
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="content" />
+
+                <data android:mimeType="application/epub+zip" />
+                <data android:mimeType="application/pdf" />
+                <data android:mimeType="application/x-fictionbook+xml" />
+                <data android:mimeType="application/xml" />
+                <data android:mimeType="text/xml" />
+                <data android:mimeType="text/plain" />
+                <data android:mimeType="text/html" />
+                <data android:mimeType="text/markdown" />
+            </intent-filter>
+
+            <!--
+                For file:// the path really is the file's path, so the extension
+                can be matched. Android's matcher has no case folding and its
+                ".*" does not cross a literal dot, hence both cases of every
+                extension and the doubled variants for names containing dots.
+            -->
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="file" />
+                <data android:mimeType="*/*" />
+
+                <data android:pathPattern=".*\\.epub" />
+                <data android:pathPattern=".*\\..*\\.epub" />
+                <data android:pathPattern=".*\\.EPUB" />
+                <data android:pathPattern=".*\\.pdf" />
+                <data android:pathPattern=".*\\..*\\.pdf" />
+                <data android:pathPattern=".*\\.PDF" />
+                <data android:pathPattern=".*\\.fb2" />
+                <data android:pathPattern=".*\\..*\\.fb2" />
+                <data android:pathPattern=".*\\.FB2" />
+                <data android:pathPattern=".*\\.txt" />
+                <data android:pathPattern=".*\\..*\\.txt" />
+                <data android:pathPattern=".*\\.TXT" />
+                <data android:pathPattern=".*\\.html" />
+                <data android:pathPattern=".*\\..*\\.html" />
+                <data android:pathPattern=".*\\.htm" />
+                <data android:pathPattern=".*\\..*\\.htm" />
+                <data android:pathPattern=".*\\.md" />
+                <data android:pathPattern=".*\\..*\\.md" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/ua/acclorite/book_story/data/cache/ParseCache.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/cache/ParseCache.kt
@@ -65,6 +65,34 @@ class ParseCache @Inject constructor(application: Application) {
     }
 
     /**
+     * Moves an entry from one source to another, keeping the parsed book.
+     *
+     * The key is a hash of the path, so a book that changes where it lives loses
+     * its entry even though the bytes are identical. That happens on purpose
+     * when a previewed book is kept: the app copies the file into its own
+     * storage, and the copy has a different path. Re-parsing a book that was
+     * just parsed, to produce the very same result, is the only alternative.
+     *
+     * The other two parts of the key have to match already — a copy is byte for
+     * byte, and its modification time is set from the original.
+     */
+    fun rekey(
+        fromPath: String,
+        toPath: String,
+        size: Long,
+        lastModified: Long
+    ): Boolean {
+        val from = entryDir(fromPath, size, lastModified)
+        if (!textFile(from).exists()) return false
+
+        val to = entryDir(toPath, size, lastModified)
+        to.deleteRecursively()
+        return from.renameTo(to).also {
+            if (!it) logE(TAG, "Could not move the cache entry to its new path.")
+        }
+    }
+
+    /**
      * Stores [parsed] (and, if given, its [images] blobs) for this source,
      * overwriting any existing entry, then evicts least-recently-used books so
      * the total stays within [maxBytes] (the entry just written is never

--- a/app/src/main/java/ua/acclorite/book_story/data/cache/ReaderImageFiles.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/cache/ReaderImageFiles.kt
@@ -107,6 +107,15 @@ class ReaderImageFiles @Inject constructor(application: Application) {
     }
 
     /**
+     * Drops one book's files. Unlike closing a book, which keeps them on
+     * purpose, this is for a book that is going away: a preview the user looked
+     * at and did not keep has no next open to save work for.
+     */
+    fun drop(bookId: Int) {
+        File(session, bookId.toString()).deleteRecursively()
+    }
+
+    /**
      * Deletes the leftovers of previous runs. Nothing runs when the process is
      * killed — and swiping the app away from the recents list is an ordinary way
      * to leave a book — so leftovers are the rule rather than an edge case, and

--- a/app/src/main/java/ua/acclorite/book_story/data/local/dto/BookEntity.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/dto/BookEntity.kt
@@ -24,5 +24,29 @@ data class BookEntity(
     val scrollOffset: Int,
     val progress: Float,
     val image: String? = null,
-    @ColumnInfo(defaultValue = "[]") val categories: List<Int>
+    @ColumnInfo(defaultValue = "[]") val categories: List<Int>,
+
+    /**
+     * Whether the book belongs to the library, or is only being previewed.
+     *
+     * A book opened from a file manager is parsed into a real row so the reader,
+     * which is keyed on a row id throughout, works unchanged — but it is not the
+     * user's book yet. It stays out of every list until they say so, and is
+     * deleted if they leave without saying so.
+     *
+     * Defaults to 1: every book that existed before this column was added got
+     * into the database the only way there was, by being imported.
+     */
+    @ColumnInfo(defaultValue = "1") val inLibrary: Boolean = true,
+
+    /**
+     * The URI another app handed the file over on, for a preview only.
+     *
+     * A library book is found by descending a persisted grant to its path; a
+     * preview has no such grant, so the URI is the only way back to its bytes.
+     * It is cleared the moment the book is added, because from then on the book
+     * must be reachable the way every other one is — the grant behind this URI
+     * dies with the task.
+     */
+    val previewUri: String? = null
 )

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDao.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDao.kt
@@ -16,21 +16,35 @@ import ua.acclorite.book_story.data.local.dto.BookEntity
 
 @Dao
 interface BookDao {
+    /** Returns the new row id, which is how a freshly parsed preview is opened. */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertBook(
         book: BookEntity
-    )
+    ): Long
 
+    /**
+     * Every list of books in the app comes from here — the library, the history
+     * and the search — so this is the one place a preview has to be kept out of.
+     */
     @Query(
         """
         SELECT * FROM bookentity
-        WHERE LOWER(title) LIKE '%' || LOWER(:query) || '%'
+        WHERE inLibrary = 1 AND LOWER(title) LIKE '%' || LOWER(:query) || '%'
     """
     )
     suspend fun searchBooks(query: String): List<BookEntity>
 
+    /**
+     * Deliberately **not** filtered by [BookEntity.inLibrary]: this is how the
+     * reader loads the book it was asked for, and a preview is exactly the book
+     * that needs loading.
+     */
     @Query("SELECT * FROM bookentity WHERE id=:id")
     suspend fun findBookById(id: Int): BookEntity?
+
+    /** Previews left behind, which by design means "left behind by a crash". */
+    @Query("SELECT * FROM bookentity WHERE inLibrary = 0")
+    suspend fun findPreviews(): List<BookEntity>
 
     @Delete
     suspend fun deleteBook(book: BookEntity): Int

--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDatabase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDatabase.kt
@@ -34,7 +34,7 @@ import java.io.File
         ReadBookEntity::class,
         ReadingCoverageEntity::class
     ],
-    version = 21,
+    version = 22,
     autoMigrations = [
         AutoMigration(1, 2),
         AutoMigration(2, 3),
@@ -56,6 +56,7 @@ import java.io.File
         AutoMigration(18, 19), // ReadingSessionEntity.overlayMs (default 0)
         AutoMigration(19, 20), // ReadingCoverageEntity.wordsBeforeBookmark (nullable)
         AutoMigration(20, 21), // ReadBookEntity.bookId is unique (one record per book)
+        AutoMigration(21, 22), // BookEntity.inLibrary (default 1: every existing book)
     ],
     exportSchema = true
 )

--- a/app/src/main/java/ua/acclorite/book_story/data/mapper/book/BookMapperImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/mapper/book/BookMapperImpl.kt
@@ -25,7 +25,9 @@ class BookMapperImpl @Inject constructor() : BookMapper {
             author = book.author.getAsString() ?: "",
             description = book.description,
             image = book.coverImage?.toString(),
-            categories = book.categories
+            categories = book.categories,
+            inLibrary = book.inLibrary,
+            previewUri = book.previewUri
         )
     }
 
@@ -44,7 +46,9 @@ class BookMapperImpl @Inject constructor() : BookMapper {
             filePath = bookEntity.filePath,
             lastOpened = null,
             coverImage = bookEntity.image?.toUri(),
-            categories = bookEntity.categories
+            categories = bookEntity.categories,
+            inLibrary = bookEntity.inLibrary,
+            previewUri = bookEntity.previewUri
         )
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/model/file/CachedFile.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/model/file/CachedFile.kt
@@ -53,6 +53,18 @@ class CachedFile(
         getFileQueryParams()
     }
     val path: String by lazy { builder?.path ?: getFilePath() }
+
+    /**
+     * What identifies this file to the parse cache.
+     *
+     * Normally the path. A provider that exposes no location leaves it empty,
+     * and an empty path is not an identity: two such books whose size and
+     * modification time also went unreported would share one cache entry, and
+     * the second would open showing the first one's text. The URI is unique per
+     * document, which is exactly what is needed until the book is kept and
+     * gains a real path of its own.
+     */
+    val cacheKeyPath: String get() = path.ifBlank { uri.toString() }
     val rawFile: File? by lazy { storeInCache() }
 
     val name: String get() = builder?.name ?: queryParams.name

--- a/app/src/main/java/ua/acclorite/book_story/data/model/file/CachedFile.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/model/file/CachedFile.kt
@@ -29,7 +29,17 @@ import java.util.UUID
 class CachedFile(
     private val context: Context,
     val uri: Uri,
-    private val builder: CachedFileBuilder? = null
+    private val builder: CachedFileBuilder? = null,
+    /**
+     * The file itself, when the app owns it rather than reaching it through a
+     * provider — a book copied into the app's own storage because the app that
+     * handed it over exposed no location for it.
+     *
+     * Everything a provider would be asked for is read straight off the file
+     * instead, and [rawFile] hands it over as it is: there is nothing to copy,
+     * the copy is what this is.
+     */
+    private val localFile: File? = null
 ) {
     @Immutable
     private data class QueryParams(
@@ -51,6 +61,8 @@ class CachedFile(
     val isDirectory: Boolean get() = builder?.isDirectory ?: queryParams.isDirectory
 
     fun canAccess(): Boolean {
+        localFile?.let { return it.exists() && it.canRead() }
+
         return try {
             context.contentResolver.query(uri, null, null, null, null)?.let {
                 it.close()
@@ -63,6 +75,15 @@ class CachedFile(
     }
 
     fun openInputStream(): InputStream? {
+        localFile?.let {
+            return try {
+                it.inputStream()
+            } catch (e: Exception) {
+                e.printStackTrace()
+                null
+            }
+        }
+
         return try {
             context.contentResolver.openInputStream(uri)
                 ?: throw Exception("Failed to open InputStream for URI: $uri")
@@ -176,7 +197,7 @@ class CachedFile(
      *
      * @return null if the file is directory or failed
      */
-    private fun storeInCache(): File? = timed(
+    private fun storeInCache(): File? = localFile ?: timed(
         "    copy book",
         describe = { file -> "${(file?.length() ?: 0) / 1024} KB" }
     ) {
@@ -200,96 +221,74 @@ class CachedFile(
     }
 
     private fun getFileQueryParams(): QueryParams {
-        val nameColumn = DocumentsContract.Document.COLUMN_DISPLAY_NAME
-        val sizeColumn = DocumentsContract.Document.COLUMN_SIZE
-        val lastModifiedColumn = DocumentsContract.Document.COLUMN_LAST_MODIFIED
-        val isDirectoryColumn = DocumentsContract.Document.COLUMN_MIME_TYPE
-
-        val projection = mutableListOf<String>().apply {
-            if (builder?.name == null) add(nameColumn)
-            if (builder?.size == null) add(sizeColumn)
-            if (builder?.lastModified == null) add(lastModifiedColumn)
-            if (builder?.isDirectory == null) add(isDirectoryColumn)
-        }
-
-        if (projection.isEmpty() && builder != null) {
+        localFile?.let {
             return QueryParams(
-                name = builder.name!!,
-                size = builder.size!!,
-                lastModified = builder.lastModified!!,
-                isDirectory = builder.isDirectory!!
+                name = it.name,
+                size = it.length(),
+                lastModified = it.lastModified(),
+                isDirectory = it.isDirectory
             )
         }
 
+        val nameColumn = DocumentsContract.Document.COLUMN_DISPLAY_NAME
+        val sizeColumn = DocumentsContract.Document.COLUMN_SIZE
+        val lastModifiedColumn = DocumentsContract.Document.COLUMN_LAST_MODIFIED
+        val mimeTypeColumn = DocumentsContract.Document.COLUMN_MIME_TYPE
+
+        if (
+            builder?.name != null &&
+            builder.size != null &&
+            builder.lastModified != null &&
+            builder.isDirectory != null
+        ) {
+            return QueryParams(
+                name = builder.name,
+                size = builder.size,
+                lastModified = builder.lastModified,
+                isDirectory = builder.isDirectory
+            )
+        }
+
+        // A null projection, and every column read by name and tolerated when
+        // absent, rather than asking for the four DocumentsContract columns.
+        // Those names belong to a documents provider, and a URI arriving from
+        // another app need not come from one: MediaStore — what a chat app or a
+        // mail client shares — rejects the query outright with "Invalid column
+        // last_modified", so a book that opens everywhere else would not open
+        // when it arrived that way.
         context.contentResolver.query(
             uri,
-            projection.toTypedArray(),
-            null, null, null
+            null, null, null, null
         )?.use { cursor ->
             try {
                 if (cursor.moveToFirst()) {
-                    val queryResult = mutableMapOf<String, Any?>()
+                    fun stringOf(column: String): String? = cursor
+                        .getColumnIndex(column)
+                        .takeIf { it >= 0 && !cursor.isNull(it) }
+                        ?.let { cursor.getString(it) }
 
-                    projection.forEach { column ->
-                        when (column) {
-                            nameColumn -> {
-                                if (builder?.name == null) {
-                                    queryResult[column] = cursor.getString(
-                                        cursor.getColumnIndexOrThrow(column)
-                                    )
-                                }
-                            }
+                    fun longOf(column: String): Long? = cursor
+                        .getColumnIndex(column)
+                        .takeIf { it >= 0 && !cursor.isNull(it) }
+                        ?.let { cursor.getLong(it) }
 
-                            sizeColumn -> {
-                                if (builder?.size == null) {
-                                    queryResult[column] = cursor.getLong(
-                                        cursor.getColumnIndexOrThrow(column)
-                                    )
-                                }
-                            }
+                    val name = builder?.name ?: stringOf(nameColumn)
+                    val mimeType = stringOf(mimeTypeColumn)
 
-                            lastModifiedColumn -> {
-                                if (builder?.lastModified == null) {
-                                    queryResult[column] = cursor.getLong(
-                                        cursor.getColumnIndexOrThrow(column)
-                                    )
-                                }
+                    if (name != null) {
+                        return QueryParams(
+                            name = name,
+                            size = builder?.size ?: longOf(sizeColumn) ?: 0,
+                            lastModified = builder?.lastModified
+                                ?: longOf(lastModifiedColumn)
+                                ?: longOf(MEDIA_STORE_DATE_MODIFIED)?.times(1000)
+                                ?: 0,
+                            isDirectory = when (mimeType) {
+                                null -> builder?.isDirectory ?: false
+                                else -> mimeType == DocumentsContract.Document.MIME_TYPE_DIR
                             }
-
-                            isDirectoryColumn -> {
-                                if (builder?.isDirectory == null) {
-                                    queryResult[column] = cursor.getString(
-                                        cursor.getColumnIndexOrThrow(column)
-                                    )
-                                }
-                            }
-                        }
+                        )
                     }
-
-                    val nameQuery = queryResult.getOrElse(nameColumn) {
-                        builder?.name
-                    } as String
-
-                    val sizeQuery = queryResult.getOrElse(sizeColumn) {
-                        builder?.size
-                    } as Long
-
-                    val lastModifiedQuery = queryResult.getOrElse(lastModifiedColumn) {
-                        builder?.lastModified
-                    } as Long
-
-                    val isDirectoryQuery = when (queryResult[isDirectoryColumn]) {
-                        DocumentsContract.Document.MIME_TYPE_DIR -> true
-                        null -> builder?.isDirectory!!
-                        else -> false
-                    }
-
-                    return QueryParams(
-                        name = nameQuery,
-                        size = sizeQuery,
-                        lastModified = lastModifiedQuery,
-                        isDirectory = isDirectoryQuery
-                    )
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -305,6 +304,8 @@ class CachedFile(
     }
 
     private fun getFilePath(): String {
+        localFile?.let { return it.absolutePath }
+
         val tempFile = DocumentFileCompat.fromUri(context, uri)
         return tempFile?.getAbsolutePath(context)?.trimEnd('/') ?: ""
     }
@@ -319,6 +320,9 @@ class CachedFile(
          * and the image loader's own store.
          */
         private const val COPIES_DIR_NAME = "raw_copies"
+
+        /** MediaStore's own spelling of the modification time, in seconds. */
+        private const val MEDIA_STORE_DATE_MODIFIED = "date_modified"
 
         private fun copiesDir(context: Context): File =
             File(context.cacheDir, COPIES_DIR_NAME)

--- a/app/src/main/java/ua/acclorite/book_story/data/model/file/CachedFileCompat.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/model/file/CachedFileCompat.kt
@@ -30,6 +30,18 @@ object CachedFileCompat {
         )
     }
 
+    /**
+     * A book the app owns, held as a plain file. No provider is involved, so
+     * none of the URI machinery is: see [CachedFile]'s `localFile`.
+     */
+    fun fromFile(context: Context, file: java.io.File): CachedFile {
+        return CachedFile(
+            context = context,
+            uri = Uri.fromFile(file),
+            localFile = file
+        )
+    }
+
     fun build(
         name: String? = null,
         path: String? = null,

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
@@ -109,7 +109,7 @@ class BookRepositoryImpl @Inject constructor(
                     // is a lazy property that may be a ContentResolver round-trip
                     // against the document URI; `size` and `lastModified` share
                     // one query, so whichever is asked for first pays for both.
-                    val path = timed("  open: key path") { cachedFile.path }
+                    val path = timed("  open: key path") { cachedFile.cacheKeyPath }
                     val size = timed("  open: key size") { cachedFile.size }
                     val lastModified = timed("  open: key modified") {
                         cachedFile.lastModified
@@ -285,7 +285,7 @@ class BookRepositoryImpl @Inject constructor(
     override suspend fun storeBookFile(book: Book): Result<String> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             val source = fileProvider.getFileFromBook(book).getOrThrow()
-            val sourcePath = source.path
+            val sourcePath = source.cacheKeyPath
             val size = source.size
             val lastModified = source.lastModified
 

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
@@ -20,6 +20,7 @@ import ua.acclorite.book_story.data.cache.ReaderImageFiles
 import ua.acclorite.book_story.data.local.room.BookDatabase
 import ua.acclorite.book_story.data.model.file.CachedFile
 import ua.acclorite.book_story.data.settings.SettingsManager
+import ua.acclorite.book_story.data.storage.OwnedBookFiles
 import ua.acclorite.book_story.data.mapper.book.BookMapper
 import ua.acclorite.book_story.data.mapper.file.FileMapper
 import ua.acclorite.book_story.data.parser.cover.CoverParser
@@ -27,6 +28,7 @@ import ua.acclorite.book_story.data.parser.image.BookImageLoader
 import ua.acclorite.book_story.data.parser.text.TextParser
 import ua.acclorite.book_story.domain.model.file.File
 import ua.acclorite.book_story.domain.model.library.Book
+import ua.acclorite.book_story.domain.model.library.findForFile
 import ua.acclorite.book_story.domain.model.reader.BookImage
 import ua.acclorite.book_story.domain.model.reader.ParsedText
 import ua.acclorite.book_story.domain.model.reader.ReaderText
@@ -46,6 +48,7 @@ class BookRepositoryImpl @Inject constructor(
     private val fileProvider: FileProvider,
     private val parseCache: ParseCache,
     private val readerImageFiles: ReaderImageFiles,
+    private val ownedBookFiles: OwnedBookFiles,
     private val bookImageLoader: BookImageLoader,
     private val settings: SettingsManager
 ) : BookRepository {
@@ -273,6 +276,28 @@ class BookRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun dropBookImages(bookId: Int): Result<Unit> = runCatchingCancellable {
+        withContext(Dispatchers.IO) {
+            readerImageFiles.drop(bookId)
+        }
+    }
+
+    override suspend fun storeBookFile(book: Book): Result<String> = runCatchingCancellable {
+        withContext(Dispatchers.IO) {
+            val source = fileProvider.getFileFromBook(book).getOrThrow()
+            val stored = ownedBookFiles.store(source, book.id)
+                ?: throw IllegalStateException("Could not store ${source.name}.")
+
+            stored.absolutePath
+        }
+    }
+
+    override suspend fun deleteBookFile(bookId: Int): Result<Unit> = runCatchingCancellable {
+        withContext(Dispatchers.IO) {
+            ownedBookFiles.delete(bookId)
+        }
+    }
+
     /** What the timing log says about a parsed book: how much text, how many images. */
     private fun ParsedText.describeForTiming(): String {
         val images = text.filterIsInstance<ReaderText.Image>()
@@ -297,9 +322,29 @@ class BookRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun addBook(book: Book): Result<Unit> = runCatchingCancellable {
+    override suspend fun addBook(book: Book): Result<Int> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
-            database.bookDao.insertBook(bookMapper.toBookEntity(book))
+            database.bookDao.insertBook(bookMapper.toBookEntity(book)).toInt()
+        }
+    }
+
+    override suspend fun findLibraryBookForFile(
+        filePath: String,
+        fileName: String
+    ): Result<Book?> = runCatchingCancellable {
+        withContext(Dispatchers.IO) {
+            // Matched in Kotlin rather than in SQL: a LIKE over the path would
+            // treat '%' and '_' in a file name as wildcards, and the library is
+            // the same handful of rows every other screen already reads whole.
+            database.bookDao.searchBooks("")
+                .map(bookMapper::toBook)
+                .findForFile(filePath = filePath, fileName = fileName)
+        }
+    }
+
+    override suspend fun findPreviews(): Result<List<Book>> = runCatchingCancellable {
+        withContext(Dispatchers.IO) {
+            database.bookDao.findPreviews().map(bookMapper::toBook)
         }
     }
 

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
@@ -285,8 +285,23 @@ class BookRepositoryImpl @Inject constructor(
     override suspend fun storeBookFile(book: Book): Result<String> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
             val source = fileProvider.getFileFromBook(book).getOrThrow()
+            val sourcePath = source.path
+            val size = source.size
+            val lastModified = source.lastModified
+
             val stored = ownedBookFiles.store(source, book.id)
                 ?: throw IllegalStateException("Could not store ${source.name}.")
+
+            // The preview parsed this book a moment ago and cached the result
+            // under the path it had then. Moving the entry is what keeps the
+            // second open instant; without it the book is parsed again to
+            // produce exactly the same text.
+            parseCache.rekey(
+                fromPath = sourcePath,
+                toPath = stored.absolutePath,
+                size = size,
+                lastModified = lastModified
+            )
 
             stored.absolutePath
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/FileSystemRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/FileSystemRepositoryImpl.kt
@@ -6,6 +6,8 @@
 
 package ua.acclorite.book_story.data.repository
 
+import android.app.Application
+import androidx.core.net.toUri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import ua.acclorite.book_story.core.CoverImage
@@ -15,6 +17,7 @@ import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.data.local.room.BookDatabase
 import ua.acclorite.book_story.data.mapper.file.FileMapper
 import ua.acclorite.book_story.data.model.file.CachedFile
+import ua.acclorite.book_story.data.model.file.CachedFileCompat
 import ua.acclorite.book_story.data.parser.cover.CoverParser
 import ua.acclorite.book_story.data.parser.file.FileParser
 import ua.acclorite.book_story.domain.model.file.File
@@ -26,6 +29,7 @@ import javax.inject.Singleton
 
 @Singleton
 class FileSystemRepositoryImpl @Inject constructor(
+    private val application: Application,
     private val database: BookDatabase,
     private val fileMapper: FileMapper,
     private val fileParser: FileParser,
@@ -91,4 +95,18 @@ class FileSystemRepositoryImpl @Inject constructor(
                 return@withContext book to coverImage
             }
         }
+
+    override suspend fun getFileFromUri(uri: String): Result<File> = runCatchingCancellable {
+        withContext(Dispatchers.IO) {
+            val cachedFile = CachedFileCompat.fromUri(application, uri.toUri())
+            if (!cachedFile.canAccess()) {
+                throw IllegalStateException("No read access to $uri.")
+            }
+
+            // `path` is deliberately not required: a provider that exposes no
+            // real location still gives a readable book, it just gives one that
+            // cannot be kept.
+            fileMapper.toFile(cachedFile)
+        }
+    }
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/service/FileProviderImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/service/FileProviderImpl.kt
@@ -7,19 +7,42 @@
 package ua.acclorite.book_story.data.service
 
 import android.app.Application
+import androidx.core.net.toUri
 import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.core.log.bookTimingNote
 import ua.acclorite.book_story.data.model.file.CachedFile
 import ua.acclorite.book_story.data.model.file.CachedFileCompat
+import ua.acclorite.book_story.data.storage.OwnedBookFiles
 import ua.acclorite.book_story.domain.model.library.Book
 import ua.acclorite.book_story.domain.service.FileProvider
 import javax.inject.Inject
 
 class FileProviderImpl @Inject constructor(
-    private val application: Application
+    private val application: Application,
+    private val ownedBookFiles: OwnedBookFiles
 ) : FileProvider {
 
     override fun getFileFromBook(book: Book): Result<CachedFile> = runCatchingCancellable {
+        // A book being previewed is reached by the URI another app handed over,
+        // not by descending a granted tree: there is no grant, and that is the
+        // whole reason it is a preview. The URI is good for as long as the task
+        // holding the intent, which is exactly as long as the preview itself —
+        // a killed process takes both, and the start-up sweep clears the row.
+        book.previewUri?.let { uri ->
+            val file = CachedFileCompat.fromUri(application, uri.toUri())
+            if (file.canAccess()) return@runCatchingCancellable file
+            throw IllegalStateException("The preview's grant on $uri is gone.")
+        }
+
+        // A book the app holds a copy of, because the app that handed it over
+        // exposed no location to remember. Nothing is granted and nothing is
+        // descended: the path is a real path, in our own directory.
+        if (ownedBookFiles.owns(book.filePath)) {
+            val file = CachedFileCompat.fromFile(application, java.io.File(book.filePath))
+            if (file.canAccess()) return@runCatchingCancellable file
+            throw NoSuchElementException("The stored copy of ${book.title} is gone.")
+        }
+
         val storages = application.contentResolver.persistedUriPermissions
             .map { permission -> CachedFileCompat.fromUri(application, permission.uri) }
             .filter { it.isDirectory }

--- a/app/src/main/java/ua/acclorite/book_story/data/storage/OwnedBookFiles.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/storage/OwnedBookFiles.kt
@@ -82,6 +82,12 @@ class OwnedBookFiles @Inject constructor(
             return null
         }
 
+        // The parse cache is keyed on path, size and modification time. Two of
+        // the three already match — a copy is byte for byte — so carrying the
+        // third across lets the entry the preview just wrote be moved to the
+        // copy instead of the book being parsed a second time.
+        destination.setLastModified(source.lastModified)
+
         logI(TAG, "Stored ${destination.length()} bytes for [$bookId].")
         return destination
     }

--- a/app/src/main/java/ua/acclorite/book_story/data/storage/OwnedBookFiles.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/storage/OwnedBookFiles.kt
@@ -1,0 +1,93 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.storage
+
+import android.app.Application
+import ua.acclorite.book_story.core.log.logI
+import ua.acclorite.book_story.data.model.file.CachedFile
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "OwnedBookFiles"
+
+/**
+ * The directory books the app owns live in, one directory per book.
+ *
+ * Deliberately not `books`: `DatabaseHelper.AUTO_MIGRATION_7_8.removeBooksDir`
+ * deletes `filesDir/books`, and `AppModule` calls it every time the database is
+ * built rather than only when that migration runs. A store named `books` was
+ * therefore emptied on every app start — the book was added, survived being
+ * closed, and was gone by the next launch.
+ */
+private const val DIR_NAME = "owned_books"
+
+/**
+ * Books the app keeps a copy of, because there is nowhere else to keep them.
+ *
+ * A library book is normally a path inside a folder the user granted, and the
+ * app stores no copy of it: the book stays where the user put it. That fails for
+ * a file handed over by another app that exposes no location — the Downloads
+ * provider composes its document ids out of MediaStore row numbers, so there is
+ * no path to remember and no folder to ask for. Downloading a book is the
+ * commonest way to get one, so "cannot be kept" is not an acceptable answer.
+ *
+ * Deliberately in `filesDir` rather than the cache. The cache is the system's to
+ * empty whenever it wants storage back, and it holds three things of ours that
+ * are meant to be disposable — the parse cache, the reader's image files and
+ * `CachedFile`'s raw copies. A book that vanished from the library because the
+ * device got low on space would be a different kind of bug entirely.
+ *
+ * A directory per book, named by its id, so a book takes its file with it when
+ * it is deleted and nothing else has to be consulted to find it. The file keeps
+ * its own name inside: the parsers decide the format from the extension.
+ */
+@Singleton
+class OwnedBookFiles @Inject constructor(
+    private val application: Application
+) {
+
+    private val root: File
+        get() = File(application.filesDir, DIR_NAME)
+
+    /** Whether [path] names a file this store owns. */
+    fun owns(path: String): Boolean =
+        path.isNotBlank() && path.startsWith(root.absolutePath + File.separator)
+
+    /**
+     * Copies [source] in and returns the file, or null if it could not be read.
+     * A book already stored under [bookId] is replaced.
+     */
+    fun store(source: CachedFile, bookId: Int): File? {
+        val directory = File(root, bookId.toString())
+        directory.deleteRecursively()
+        if (!directory.mkdirs()) {
+            logI(TAG, "Could not make a directory for [$bookId].")
+            return null
+        }
+
+        val destination = File(directory, source.name)
+        try {
+            source.openInputStream()?.use { input ->
+                destination.outputStream().buffered().use(input::copyTo)
+            } ?: throw IllegalStateException("Could not open ${source.name}.")
+        } catch (e: Exception) {
+            logI(TAG, "Could not store [$bookId]: ${e.message}")
+            directory.deleteRecursively()
+            return null
+        }
+
+        logI(TAG, "Stored ${destination.length()} bytes for [$bookId].")
+        return destination
+    }
+
+    /** Drops the book's file, if it has one. */
+    fun delete(bookId: Int) {
+        File(root, bookId.toString()).deleteRecursively()
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/library/Book.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/library/Book.kt
@@ -29,7 +29,17 @@ data class Book(
     val progress: Float,
 
     val lastOpened: Long?,
-    val categories: List<Int>
+    val categories: List<Int>,
+
+    /**
+     * False while the book is only being previewed from a file manager. The
+     * reader treats such a book as a book in every way but two: it records no
+     * statistics for it, and it offers to add it.
+     */
+    val inLibrary: Boolean = true,
+
+    /** How a preview reaches its file; see the entity of the same name. */
+    val previewUri: String? = null
 ) : Parcelable {
     companion object {
         val default = Book(

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/library/BookFileMatch.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/library/BookFileMatch.kt
@@ -1,0 +1,31 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.library
+
+/**
+ * The book among these holding the given file, if any.
+ *
+ * By path first, because that is what identifies a book everywhere else in the
+ * app. By file name second, because a file arriving from another app does not
+ * always come with a path — a document URI yields one only when the providing
+ * app exposes real storage — and because the same file reached through two
+ * providers can carry two different paths.
+ *
+ * Size would be the better second key and is not available: a book row does not
+ * store one. The name match is therefore deliberately loose, and it errs the
+ * safe way: matching wrongly opens the user's own book instead of a preview,
+ * while failing to match costs a parse and an extra row.
+ */
+fun List<Book>.findForFile(filePath: String, fileName: String): Book? {
+    if (filePath.isNotBlank()) {
+        firstOrNull { it.filePath == filePath }?.let { return it }
+    }
+
+    if (fileName.isBlank()) return null
+    return firstOrNull { it.filePath.substringAfterLast('/') == fileName }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/repository/BookRepository.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/repository/BookRepository.kt
@@ -50,13 +50,48 @@ interface BookRepository {
      */
     suspend fun keepOnlyBookImages(bookId: Int): Result<Unit>
 
+    /** Drops one book's image files, for a book that is being deleted. */
+    suspend fun dropBookImages(bookId: Int): Result<Unit>
+
+    /**
+     * Copies [book]'s file into the app's own storage and returns where it
+     * landed — for a book whose provider exposes no location, so there is
+     * nothing to remember and no folder to ask the user for.
+     */
+    suspend fun storeBookFile(book: Book): Result<String>
+
+    /** Drops the app's own copy of a book's file, if it has one. */
+    suspend fun deleteBookFile(bookId: Int): Result<Unit>
+
     suspend fun getFileFromBook(
         bookId: Int
     ): Result<File>
 
+    /** Returns the id of the inserted row, which is how a preview is opened. */
     suspend fun addBook(
         book: Book
-    ): Result<Unit>
+    ): Result<Int>
+
+    /**
+     * The library book holding this file, if the user already has it — a file
+     * arriving from a file manager should reach that book rather than become a
+     * second copy of it.
+     *
+     * By path first. Failing that by file name, because a document URI does not
+     * always yield a path, and because the same book reached through two
+     * providers can carry two different ones. Size would be the better second
+     * key and is not available: a book row does not store it.
+     */
+    suspend fun findLibraryBookForFile(
+        filePath: String,
+        fileName: String
+    ): Result<Book?>
+
+    /**
+     * Books left mid-preview. By design a preview never outlives the process
+     * that created it, so anything this returns was left by a crash.
+     */
+    suspend fun findPreviews(): Result<List<Book>>
 
     suspend fun updateBook(
         book: Book

--- a/app/src/main/java/ua/acclorite/book_story/domain/repository/FileSystemRepository.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/repository/FileSystemRepository.kt
@@ -18,4 +18,13 @@ interface FileSystemRepository {
     suspend fun getBookFromFile(
         file: File
     ): Result<Pair<Book, CoverImage?>>
+
+    /**
+     * The file behind a URI handed over by another app. Its [File.path] is empty
+     * when the providing app exposes no real path — which is not a failure, only
+     * a file that cannot be matched against the library or added to it.
+     */
+    suspend fun getFileFromUri(
+        uri: String
+    ): Result<File>
 }

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/AddBookUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/AddBookUseCase.kt
@@ -23,7 +23,8 @@ class AddBookUseCase @Inject constructor(
     private val coverImageHandler: CoverImageHandler
 ) {
 
-    suspend operator fun invoke(book: Book, coverImage: CoverImage?) {
+    /** The id of the inserted row, or null if it could not be inserted. */
+    suspend operator fun invoke(book: Book, coverImage: CoverImage?): Int? {
         logI(TAG, "Inserting [${book.title}].")
 
         val coverImageUri = coverImage?.let { coverImage ->
@@ -39,12 +40,14 @@ class AddBookUseCase @Inject constructor(
             )
         }
 
-        bookRepository.addBook(book = book.copy(coverImage = coverImageUri)).fold(
-            onSuccess = {
+        return bookRepository.addBook(book = book.copy(coverImage = coverImageUri)).fold(
+            onSuccess = { id ->
                 logI(TAG, "Successfully inserted [${book.title}].")
+                id
             },
             onFailure = {
                 logE(TAG, "Could not insert [${book.title}] with error: ${it.message}")
+                null
             }
         )
     }

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/AddPreviewToLibraryUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/AddPreviewToLibraryUseCase.kt
@@ -1,0 +1,108 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.book
+
+import ua.acclorite.book_story.core.log.logI
+import ua.acclorite.book_story.core.log.logW
+import ua.acclorite.book_story.domain.model.library.Book
+import ua.acclorite.book_story.domain.repository.BookRepository
+import ua.acclorite.book_story.domain.service.FileProvider
+import javax.inject.Inject
+
+private const val TAG = "AddPreviewToLibrary"
+
+/**
+ * Promotes a previewed book into the library.
+ *
+ * This is the one place in the preview feature where storage permissions come
+ * into it at all. A library book is a path resolved through a persisted grant on
+ * the folder above it, so a book can only be kept if such a grant exists — and
+ * the grant the file manager handed over is not one, it dies with the task.
+ */
+class AddPreviewToLibraryUseCase @Inject constructor(
+    private val bookRepository: BookRepository,
+    private val fileProvider: FileProvider
+) {
+
+    sealed interface Result {
+        /** The book is in the library and will open like any other. */
+        data object Added : Result
+
+        /**
+         * Nothing reaches the file yet. [folder] is where the picker should
+         * start, or null when even that is unknown.
+         */
+        data class NeedsGrant(val folder: String?) : Result
+
+        /** The file could not be read, so there was nothing to keep. */
+        data object Failed : Result
+    }
+
+    suspend operator fun invoke(book: Book): Result {
+        // No location to remember, so there is no folder to ask for and nothing
+        // to find the book by later: the Downloads provider builds its document
+        // ids out of MediaStore row numbers, and downloading a book is the
+        // commonest way to get one. Keeping such a book means keeping the file.
+        if (book.filePath.isBlank()) {
+            logI(TAG, "[${book.title}] has no location; storing a copy of it.")
+            return store(book)
+        }
+
+        // Exactly the question the reader will ask on every future open: does any
+        // persisted grant reach this path? Asking it here means the book is never
+        // added in a state where it could not be opened again.
+        //
+        // Asked without the preview's own URI, which would answer yes and mean
+        // nothing — that URI is good only while the task that received it lives,
+        // and this is the decision to keep the book past it.
+        if (fileProvider.getFileFromBook(book.copy(previewUri = null)).isFailure) {
+            val folder = book.filePath.substringBeforeLast('/', missingDelimiterValue = "")
+            logI(TAG, "[${book.title}] is not reachable yet; asking for [$folder].")
+            return Result.NeedsGrant(folder.ifBlank { null })
+        }
+
+        // The URI goes with the promotion: keeping it would leave the book
+        // reachable by a route that stops working the moment the app is killed,
+        // hiding a broken path until the next restart.
+        bookRepository.updateBook(book.copy(inLibrary = true, previewUri = null)).onFailure {
+            logW(TAG, "Could not add [${book.title}]: ${it.message}")
+            return Result.NeedsGrant(null)
+        }
+
+        logI(TAG, "Added [${book.title}] to the library.")
+        return Result.Added
+    }
+
+    /**
+     * Keeps the book by keeping its file: the copy becomes the book's location,
+     * and from then on it is an ordinary library book that happens to live in
+     * the app's own directory.
+     *
+     * The original file rather than the parsed one. A parsed book cannot be
+     * parsed again — the cache format carries a version, and raising it would
+     * leave a book with no source unreadable for good — and the parse cache
+     * keeps repeat opens fast on the copy exactly as it does on any other book.
+     */
+    private suspend fun store(book: Book): Result {
+        val path = bookRepository.storeBookFile(book).getOrElse {
+            logW(TAG, "Could not store [${book.title}]: ${it.message}")
+            return Result.Failed
+        }
+
+        bookRepository.updateBook(
+            book.copy(inLibrary = true, previewUri = null, filePath = path)
+        ).onFailure {
+            logW(TAG, "Could not add [${book.title}]: ${it.message}")
+            bookRepository.deleteBookFile(book.id)
+            return Result.Failed
+        }
+
+        logI(TAG, "Added [${book.title}] to the library, holding its file.")
+        return Result.Added
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/AddPreviewToLibraryUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/AddPreviewToLibraryUseCase.kt
@@ -30,8 +30,13 @@ class AddPreviewToLibraryUseCase @Inject constructor(
 ) {
 
     sealed interface Result {
-        /** The book is in the library and will open like any other. */
-        data object Added : Result
+        /**
+         * The book is in the library and will open like any other. Carries the
+         * row as written, because promoting changes more than a flag — the
+         * caller's copy is stale the moment this returns, and the reader writes
+         * its whole book row back on every settled scroll.
+         */
+        data class Added(val book: Book) : Result
 
         /**
          * Nothing reaches the file yet. [folder] is where the picker should
@@ -69,13 +74,14 @@ class AddPreviewToLibraryUseCase @Inject constructor(
         // The URI goes with the promotion: keeping it would leave the book
         // reachable by a route that stops working the moment the app is killed,
         // hiding a broken path until the next restart.
-        bookRepository.updateBook(book.copy(inLibrary = true, previewUri = null)).onFailure {
+        val promoted = book.copy(inLibrary = true, previewUri = null)
+        bookRepository.updateBook(promoted).onFailure {
             logW(TAG, "Could not add [${book.title}]: ${it.message}")
-            return Result.NeedsGrant(null)
+            return Result.Failed
         }
 
         logI(TAG, "Added [${book.title}] to the library.")
-        return Result.Added
+        return Result.Added(promoted)
     }
 
     /**
@@ -94,15 +100,14 @@ class AddPreviewToLibraryUseCase @Inject constructor(
             return Result.Failed
         }
 
-        bookRepository.updateBook(
-            book.copy(inLibrary = true, previewUri = null, filePath = path)
-        ).onFailure {
+        val promoted = book.copy(inLibrary = true, previewUri = null, filePath = path)
+        bookRepository.updateBook(promoted).onFailure {
             logW(TAG, "Could not add [${book.title}]: ${it.message}")
             bookRepository.deleteBookFile(book.id)
             return Result.Failed
         }
 
         logI(TAG, "Added [${book.title}] to the library, holding its file.")
-        return Result.Added
+        return Result.Added(promoted)
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/DeleteBookUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/DeleteBookUseCase.kt
@@ -54,6 +54,13 @@ class DeleteBookUseCase @Inject constructor(
             logW(TAG, "Could not unlink record of [${book.title}]: ${it.message}")
         }
 
+        // The app's own copy of the file, for a book that was kept by keeping
+        // it. Nothing else refers to it, so it would otherwise sit in filesDir
+        // for the life of the install.
+        bookRepository.deleteBookFile(bookId = book.id).onFailure {
+            logW(TAG, "Could not delete the stored file of [${book.title}]: ${it.message}")
+        }
+
         // Deleting book
         bookRepository.deleteBook(book).fold(
             onSuccess = {

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/DiscardPreviewsUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/DiscardPreviewsUseCase.kt
@@ -1,0 +1,53 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.book
+
+import ua.acclorite.book_story.core.log.logI
+import ua.acclorite.book_story.core.log.logW
+import ua.acclorite.book_story.domain.model.library.Book
+import ua.acclorite.book_story.domain.repository.BookRepository
+import javax.inject.Inject
+
+private const val TAG = "DiscardPreviews"
+
+/**
+ * Throws away books that were only ever previewed.
+ *
+ * A preview is not meant to outlive the look the user took at it, so this runs
+ * on two occasions: when they leave one without adding it, and at app start,
+ * which is where the previews of a killed process are collected — nothing runs
+ * on the way out of one.
+ */
+class DiscardPreviewsUseCase @Inject constructor(
+    private val bookRepository: BookRepository,
+    private val deleteBookUseCase: DeleteBookUseCase
+) {
+
+    /** Discards [book] if, and only if, it is still a preview. */
+    suspend fun discard(book: Book) {
+        if (book.inLibrary) return
+
+        logI(TAG, "Discarding preview [${book.title}].")
+        deleteBookUseCase(book)
+        bookRepository.dropBookImages(book.id).onFailure {
+            logW(TAG, "Could not drop images of [${book.title}]: ${it.message}")
+        }
+    }
+
+    /** Discards every preview there is. By design there never should be one. */
+    suspend fun sweep() {
+        val previews = bookRepository.findPreviews().getOrElse {
+            logW(TAG, "Could not look for previews: ${it.message}")
+            return
+        }
+
+        if (previews.isEmpty()) return
+        logI(TAG, "Sweeping ${previews.size} preview(s) left by a killed process.")
+        previews.forEach { discard(it) }
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/OpenBookFromUriUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/OpenBookFromUriUseCase.kt
@@ -1,0 +1,90 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.book
+
+import ua.acclorite.book_story.core.log.logE
+import ua.acclorite.book_story.core.log.logI
+import ua.acclorite.book_story.domain.model.library.findForFile
+import ua.acclorite.book_story.domain.repository.BookRepository
+import ua.acclorite.book_story.domain.repository.FileSystemRepository
+import ua.acclorite.book_story.domain.use_case.file_system.GetBookFromFileUseCase
+import javax.inject.Inject
+
+private const val TAG = "OpenBookFromUri"
+
+/**
+ * Turns a file handed over by another app into a book the reader can open.
+ *
+ * The book the user already has takes precedence: opening a file that is
+ * already in the library reaches that book, with its reading position and its
+ * statistics, rather than a second copy of it.
+ *
+ * Anything else becomes a **preview** — a real row that is not in the library.
+ * It is a row because the reader is keyed on a book id from end to end, and it
+ * is out of the library because the user has done nothing but look at the file
+ * yet. Adding it is theirs to decide; see [AddPreviewToLibraryUseCase].
+ */
+class OpenBookFromUriUseCase @Inject constructor(
+    private val fileSystemRepository: FileSystemRepository,
+    private val bookRepository: BookRepository,
+    private val getBookFromFileUseCase: GetBookFromFileUseCase,
+    private val addBookUseCase: AddBookUseCase
+) {
+
+    sealed interface Result {
+        /** Open this book: either the user's own, or a fresh preview. */
+        data class Open(val bookId: Int) : Result
+
+        /** The file could be read but is not a book this app can open. */
+        data object Unsupported : Result
+
+        /** The file could not be read at all — a revoked grant, or it is gone. */
+        data object Unreadable : Result
+    }
+
+    suspend operator fun invoke(uri: String): Result {
+        logI(TAG, "Opening [$uri].")
+
+        val file = fileSystemRepository.getFileFromUri(uri).getOrElse {
+            logE(TAG, "Could not read the file: ${it.message}")
+            return Result.Unreadable
+        }
+
+        bookRepository.findLibraryBookForFile(
+            filePath = file.path,
+            fileName = file.name
+        ).getOrNull()?.let { existing ->
+            logI(TAG, "Already in the library as [${existing.id}].")
+            return Result.Open(existing.id)
+        }
+
+        // The same file arriving twice must reach the same preview, not parse a
+        // second one. It happens for ordinary reasons — the process is restored
+        // holding the intent that started it, or the user taps the file again —
+        // and a duplicate would cost a full parse and leave a stray row behind.
+        bookRepository.findPreviews().getOrNull()
+            ?.findForFile(filePath = file.path, fileName = file.name)
+            ?.let { existing ->
+                logI(TAG, "Already being previewed as [${existing.id}].")
+                return Result.Open(existing.id)
+            }
+
+        val parsed = getBookFromFileUseCase(file) ?: return Result.Unsupported
+
+        // Every field of the parsed book is kept, including the path, which is
+        // what makes adding it later a matter of a grant rather than a re-import.
+        val id = addBookUseCase(
+            parsed.first.copy(inLibrary = false, previewUri = uri),
+            parsed.second
+        )
+            ?: return Result.Unsupported
+
+        logI(TAG, "Previewing [${parsed.first.title}] as [$id].")
+        return Result.Open(id)
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/presentation/main/MainActivity.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/main/MainActivity.kt
@@ -9,6 +9,7 @@
 package ua.acclorite.book_story.presentation.main
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.content.res.Configuration
 import android.database.CursorWindow
 import android.os.Bundle
@@ -42,6 +43,7 @@ import ua.acclorite.book_story.ui.common.components.navigation_bar.NavigationBar
 import ua.acclorite.book_story.ui.common.components.navigation_rail.NavigationRail
 import ua.acclorite.book_story.ui.common.helpers.ProvideSettings
 import ua.acclorite.book_story.ui.main.MainActivityKeyboardManager
+import ua.acclorite.book_story.ui.main.MainFileOpenEffects
 import ua.acclorite.book_story.ui.navigator.Navigator
 import ua.acclorite.book_story.ui.navigator.NavigatorTabs
 import ua.acclorite.book_story.ui.settings.SettingsEffects
@@ -58,6 +60,7 @@ class MainActivity : AppCompatActivity() {
     @Inject
     lateinit var settings: SettingsManager
     private val settingsModel: SettingsModel by viewModels()
+    private val mainModel: MainModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen().setKeepOnScreenCondition {
@@ -80,6 +83,7 @@ class MainActivity : AppCompatActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         themeTrace("onCreate", this)
+        receiveFile(intent)
 
         setContent {
             // Initializing Screen Models
@@ -152,6 +156,13 @@ class MainActivity : AppCompatActivity() {
                             },
                             backHandlerEnabled = { it != StartScreen }
                         ) { screen ->
+                            // Inside the navigator's content because that is
+                            // where LocalNavigator exists. During a screen
+                            // transition two of these collect at once, which is
+                            // safe: the model hands the outcome over a channel,
+                            // so exactly one of them receives it.
+                            MainFileOpenEffects(mainModel = mainModel)
+
                             when (screen) {
                                 LibraryScreen, HistoryScreen, BrowseScreen -> {
                                     NavigatorTabs(
@@ -186,6 +197,28 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    /**
+     * A book tapped in a file manager. The activity is `singleTask`-less and
+     * ordinary, so the same file can arrive either as the intent that started
+     * the activity or, when it is already running, through [onNewIntent].
+     *
+     * The read permission carried by the intent is transient — it lasts as long
+     * as the task holding it and cannot be persisted, because a file manager
+     * does not offer it as persistable. That is what makes this a preview rather
+     * than an import.
+     */
+    private fun receiveFile(intent: Intent?) {
+        if (intent?.action != Intent.ACTION_VIEW) return
+        val uri = intent.data ?: return
+        mainModel.onFileReceived(uri.toString())
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        receiveFile(intent)
     }
 
     // The three moments a lost uiMode change could have been noticed, and was

--- a/app/src/main/java/ua/acclorite/book_story/presentation/main/MainActivity.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/main/MainActivity.kt
@@ -200,9 +200,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     /**
-     * A book tapped in a file manager. The activity is `singleTask`-less and
-     * ordinary, so the same file can arrive either as the intent that started
-     * the activity or, when it is already running, through [onNewIntent].
+     * A book tapped in a file manager. The activity is `singleTask`, so a file
+     * arriving while the app runs reaches the one instance through
+     * [onNewIntent]; the first one arrives as the intent that started it.
      *
      * The read permission carried by the intent is transient — it lasts as long
      * as the task holding it and cannot be persisted, because a file manager

--- a/app/src/main/java/ua/acclorite/book_story/presentation/main/MainModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/main/MainModel.kt
@@ -1,0 +1,82 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.presentation.main
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import ua.acclorite.book_story.domain.use_case.book.DiscardPreviewsUseCase
+import ua.acclorite.book_story.domain.use_case.book.OpenBookFromUriUseCase
+import javax.inject.Inject
+
+/**
+ * Books arriving from outside the app: a file tapped in a file manager, handed
+ * over as `ACTION_VIEW`.
+ *
+ * Held by the activity rather than a screen because the file arrives before any
+ * screen does, and because the answer must survive the file being parsed, which
+ * on a book this app has never seen is seconds rather than milliseconds.
+ */
+@HiltViewModel
+class MainModel @Inject constructor(
+    private val openBookFromUriUseCase: OpenBookFromUriUseCase,
+    private val discardPreviewsUseCase: DiscardPreviewsUseCase
+) : ViewModel() {
+
+    sealed interface FileOpen {
+        data class Open(val bookId: Int) : FileOpen
+        data class Failed(val reason: OpenBookFromUriUseCase.Result) : FileOpen
+    }
+
+    /**
+     * A channel rather than a state: the outcome must be acted on exactly once,
+     * and it must survive arriving before anything is listening. The activity's
+     * intent is read in `onCreate`, before the first composition, and during a
+     * screen transition two compositions collect at the same moment — a replayed
+     * state would open the book twice.
+     */
+    private val _fileOpen = Channel<FileOpen>(Channel.BUFFERED)
+    val fileOpen = _fileOpen.receiveAsFlow()
+
+    private val _openingFile = MutableStateFlow(false)
+    val openingFile = _openingFile.asStateFlow()
+
+    /**
+     * App start is the only reliable place to collect previews left by a killed
+     * process, since nothing runs on the way out of one. Held as a job because a
+     * file arriving in the same breath must not have its fresh preview swept by
+     * a pass that started before it existed.
+     */
+    private val sweep: Job = viewModelScope.launch { discardPreviewsUseCase.sweep() }
+
+    fun onFileReceived(uri: String) {
+        if (_openingFile.value) return
+
+        _openingFile.value = true
+        viewModelScope.launch {
+            sweep.join()
+            try {
+                val result = openBookFromUriUseCase(uri)
+                _fileOpen.send(
+                    when (result) {
+                        is OpenBookFromUriUseCase.Result.Open -> FileOpen.Open(result.bookId)
+                        else -> FileOpen.Failed(result)
+                    }
+                )
+            } finally {
+                _openingFile.value = false
+            }
+        }
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderEffect.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderEffect.kt
@@ -38,4 +38,18 @@ sealed class ReaderEffect {
     data class OnNavigateToBookInfo(
         val changePath: Boolean
     ) : ReaderEffect()
+
+    /**
+     * Nothing persisted reaches the previewed book's file, so it cannot be kept
+     * until the user grants the folder holding it. [initialFolder] is where the
+     * picker should open, when a path was recoverable.
+     */
+    data class OnRequestFolderGrant(
+        val initialFolder: String?
+    ) : ReaderEffect()
+
+    data object OnAddedToLibrary : ReaderEffect()
+
+    /** The file could not be read, so there was nothing to keep. */
+    data object OnCannotAddToLibrary : ReaderEffect()
 }

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderEvent.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderEvent.kt
@@ -102,4 +102,15 @@ sealed class ReaderEvent {
     data class OnNavigateToBookInfo(
         val changePath: Boolean
     ) : ReaderEvent()
+
+    /** Keep the book being previewed; see `AddPreviewToLibraryUseCase`. */
+    data object OnAddToLibrary : ReaderEvent()
+
+    /**
+     * A folder the user has just granted, in answer to
+     * [ReaderEffect.OnRequestFolderGrant]. Adding is retried with it.
+     */
+    data class OnGrantFolder(
+        val uri: String
+    ) : ReaderEvent()
 }

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
@@ -42,12 +42,15 @@ import ua.acclorite.book_story.domain.model.statistics.ReadingCoverage
 import ua.acclorite.book_story.domain.model.statistics.SessionWords
 import ua.acclorite.book_story.domain.model.statistics.wordCount
 import ua.acclorite.book_story.domain.model.statistics.wordPrefixSums
+import ua.acclorite.book_story.domain.use_case.book.AddPreviewToLibraryUseCase
+import ua.acclorite.book_story.domain.use_case.book.DiscardPreviewsUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetBookUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetChapterProgressUseCase
 import ua.acclorite.book_story.domain.use_case.book.GetTextUseCase
 import ua.acclorite.book_story.domain.use_case.book.KeepOnlyBookImagesUseCase
 import ua.acclorite.book_story.domain.use_case.book.LoadBookImagesUseCase
 import ua.acclorite.book_story.domain.use_case.book.UpdateBookUseCase
+import ua.acclorite.book_story.domain.use_case.permission.GrantPersistableUriPermissionUseCase
 import ua.acclorite.book_story.domain.use_case.history.GetHistoryForBookUseCase
 import ua.acclorite.book_story.domain.use_case.statistics.GetBookCoverageUseCase
 import ua.acclorite.book_story.domain.use_case.statistics.RecordReadingSessionUseCase
@@ -72,7 +75,10 @@ class ReaderModel @Inject constructor(
     private val recordReadingSessionUseCase: RecordReadingSessionUseCase,
     private val getBookCoverageUseCase: GetBookCoverageUseCase,
     private val saveBookCoverageUseCase: SaveBookCoverageUseCase,
-    private val updateReadBookUseCase: UpdateReadBookUseCase
+    private val updateReadBookUseCase: UpdateReadBookUseCase,
+    private val addPreviewToLibraryUseCase: AddPreviewToLibraryUseCase,
+    private val discardPreviewsUseCase: DiscardPreviewsUseCase,
+    private val grantPersistableUriPermissionUseCase: GrantPersistableUriPermissionUseCase
 ) : ViewModel() {
 
     private val mutex = Mutex()
@@ -467,6 +473,12 @@ class ReaderModel @Inject constructor(
                         HistoryScreen.refreshListChannel.trySend(0)
                     }
 
+                    // Leaving a book that was only being previewed is the user
+                    // declining it. Nothing about it is kept — the row, the
+                    // cover and the image files all go, and the statistics never
+                    // held anything to begin with.
+                    discardPreviewsUseCase.discard(_state.value.book)
+
                     _effects.emit(
                         ReaderEffect.OnSystemBarsVisibility(
                             show = true
@@ -474,6 +486,15 @@ class ReaderModel @Inject constructor(
                     )
                     _effects.emit(ReaderEffect.OnResetBrightness)
                     event.navigate()
+                }
+
+                is ReaderEvent.OnAddToLibrary -> {
+                    addToLibrary()
+                }
+
+                is ReaderEvent.OnGrantFolder -> {
+                    grantPersistableUriPermissionUseCase(event.uri)
+                    addToLibrary()
                 }
 
                 is ReaderEvent.OnOpenTranslator -> {
@@ -644,9 +665,54 @@ class ReaderModel @Inject constructor(
         viewModelScope.launch { endSession() }
     }
 
+    /**
+     * Keeps the book being previewed, and starts measuring it.
+     *
+     * Statistics begin here rather than at the open: the minutes spent deciding
+     * whether the book was worth reading are not credited retroactively, which
+     * is the same statement as not recording them in the first place. Coverage
+     * has to be loaded now for the same reason — the pass at open time declined
+     * to, so without this the session would bank time and no words.
+     */
+    private suspend fun addToLibrary() {
+        val book = _state.value.book
+        if (book.inLibrary) return
+
+        when (val result = addPreviewToLibraryUseCase(book)) {
+            is AddPreviewToLibraryUseCase.Result.Added -> {
+                _state.update { it.copy(book = it.book.copy(inLibrary = true)) }
+
+                startSession()
+                coverageJob = viewModelScope.launch(Dispatchers.Default) {
+                    loadCoverage(_state.value.text)
+                }
+
+                LibraryScreen.refreshListChannel.trySend(0)
+                HistoryScreen.refreshListChannel.trySend(0)
+                _effects.emit(ReaderEffect.OnAddedToLibrary)
+            }
+
+            is AddPreviewToLibraryUseCase.Result.NeedsGrant -> {
+                _effects.emit(ReaderEffect.OnRequestFolderGrant(result.folder))
+            }
+
+            is AddPreviewToLibraryUseCase.Result.Failed -> {
+                _effects.emit(ReaderEffect.OnCannotAddToLibrary)
+            }
+        }
+    }
+
     private fun startSession() {
         if (sessionStartTime != null) return
         if (_state.value.text.isEmpty()) return
+
+        // A book being previewed from a file manager records nothing. Skimming a
+        // book to decide whether to read it is not reading it, and a speed
+        // measured over that skim would be a lie about the only thing a speed is
+        // good for. Leaving the session unstarted is the whole guard: notes,
+        // coverage and the end of a session are all already conditioned on one
+        // being open.
+        if (!_state.value.book.inLibrary) return
 
         val now = System.currentTimeMillis()
         sessionStartTime = now
@@ -767,6 +833,10 @@ class ReaderModel @Inject constructor(
     }
 
     private suspend fun loadCoverage(text: List<ReaderText>) {
+        // The one statistics step that does not hang off an open session, so it
+        // needs the preview guard of its own; see [startSession].
+        if (!_state.value.book.inLibrary) return
+
         val prefix = text.wordPrefixSums()
         val bookWords = prefix.last()
         val stored = getBookCoverageUseCase(

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
@@ -680,7 +680,20 @@ class ReaderModel @Inject constructor(
 
         when (val result = addPreviewToLibraryUseCase(book)) {
             is AddPreviewToLibraryUseCase.Result.Added -> {
-                _state.update { it.copy(book = it.book.copy(inLibrary = true)) }
+                // Everything the promotion changed, and nothing else: progress
+                // may have moved while the copy was being made, and [updateProgress]
+                // writes this row whole on every settled scroll — a stale path or
+                // preview URI here would be written straight back over the row
+                // that was just promoted, leaving the book unopenable.
+                _state.update {
+                    it.copy(
+                        book = it.book.copy(
+                            inLibrary = true,
+                            previewUri = null,
+                            filePath = result.book.filePath
+                        )
+                    )
+                }
 
                 startSession()
                 coverageJob = viewModelScope.launch(Dispatchers.Default) {

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderScreen.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderScreen.kt
@@ -424,7 +424,8 @@ data class ReaderScreen(val bookId: Int) : Screen, Parcelable {
         ReaderEffects(
             effects = screenModel.effects,
             book = state.value.book,
-            fullscreen = settings.fullscreen.value
+            fullscreen = settings.fullscreen.value,
+            grantFolder = screenModel::onEvent
         )
 
         ProvideBookImages(screenModel.imageStore) {
@@ -508,6 +509,7 @@ data class ReaderScreen(val bookId: Int) : Screen, Parcelable {
                 showSettingsBottomSheet = screenModel::onEvent,
                 dismissBottomSheet = screenModel::onEvent,
                 showChaptersDrawer = screenModel::onEvent,
+                addToLibrary = screenModel::onEvent,
                 dismissDrawer = screenModel::onEvent,
                 navigateBack = screenModel::onEvent,
                 navigateToBookInfo = screenModel::onEvent

--- a/app/src/main/java/ua/acclorite/book_story/ui/main/MainFileOpenEffects.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/main/MainFileOpenEffects.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import ua.acclorite.book_story.R
@@ -61,6 +62,9 @@ fun MainFileOpenEffects(mainModel: MainModel) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                // Swallows taps as well as covering: a first parse takes
+                // seconds, and the library underneath is still live otherwise.
+                .pointerInput(Unit) { awaitPointerEventScope { while (true) awaitPointerEvent() } }
                 .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f)),
             contentAlignment = Alignment.Center
         ) {

--- a/app/src/main/java/ua/acclorite/book_story/ui/main/MainFileOpenEffects.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/main/MainFileOpenEffects.kt
@@ -1,0 +1,70 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.main
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.domain.use_case.book.OpenBookFromUriUseCase
+import ua.acclorite.book_story.presentation.main.MainModel
+import ua.acclorite.book_story.presentation.reader.ReaderScreen
+import ua.acclorite.book_story.ui.common.helpers.showToast
+import ua.acclorite.book_story.ui.navigator.LocalNavigator
+
+/**
+ * Opens the book behind a file handed over by another app, once it has been
+ * read. The wait is shown: a first parse of a book this app has never seen is
+ * seconds long, and a tap that appears to do nothing invites a second tap.
+ */
+@Composable
+fun MainFileOpenEffects(mainModel: MainModel) {
+    val navigator = LocalNavigator.current
+    val context = LocalContext.current
+    val opening by mainModel.openingFile.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        mainModel.fileOpen.collect { state ->
+            when (state) {
+                is MainModel.FileOpen.Open -> {
+                    navigator.push(ReaderScreen(state.bookId))
+                }
+
+                is MainModel.FileOpen.Failed -> {
+                    val message = when (state.reason) {
+                        is OpenBookFromUriUseCase.Result.Unsupported ->
+                            R.string.open_file_unsupported
+
+                        else -> R.string.open_file_unreadable
+                    }
+                    context.getString(message).showToast(context, longToast = true)
+                }
+            }
+        }
+    }
+
+    if (opening) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f)),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderContent.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderContent.kt
@@ -116,6 +116,7 @@ fun ReaderContent(
     showSettingsBottomSheet: (ReaderEvent.OnShowSettingsBottomSheet) -> Unit,
     dismissBottomSheet: (ReaderEvent.OnDismissBottomSheet) -> Unit,
     showChaptersDrawer: (ReaderEvent.OnShowChaptersDrawer) -> Unit,
+    addToLibrary: (ReaderEvent.OnAddToLibrary) -> Unit,
     dismissDrawer: (ReaderEvent.OnDismissDrawer) -> Unit,
     navigateToBookInfo: (ReaderEvent.OnNavigateToBookInfo) -> Unit,
     navigateBack: (ReaderEvent.OnNavigateBack) -> Unit
@@ -200,6 +201,7 @@ fun ReaderContent(
             openDictionary = openDictionary,
             showSettingsBottomSheet = showSettingsBottomSheet,
             showChaptersDrawer = showChaptersDrawer,
+            addToLibrary = addToLibrary,
             navigateBack = navigateBack,
             navigateToBookInfo = navigateToBookInfo
         )

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderEffects.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderEffects.kt
@@ -8,6 +8,9 @@ package ua.acclorite.book_story.ui.reader
 
 import android.app.SearchManager
 import android.content.Intent
+import android.provider.DocumentsContract
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.core.net.toUri
@@ -19,20 +22,32 @@ import ua.acclorite.book_story.R
 import ua.acclorite.book_story.domain.model.library.Book
 import ua.acclorite.book_story.presentation.book_info.BookInfoScreen
 import ua.acclorite.book_story.presentation.reader.ReaderEffect
+import ua.acclorite.book_story.presentation.reader.ReaderEvent
 import ua.acclorite.book_story.ui.common.helpers.LocalActivity
 import ua.acclorite.book_story.ui.common.helpers.launchActivity
 import ua.acclorite.book_story.ui.common.helpers.setBrightness
 import ua.acclorite.book_story.ui.common.helpers.showToast
 import ua.acclorite.book_story.ui.navigator.LocalNavigator
 
+private const val EXTERNAL_STORAGE_AUTHORITY = "com.android.externalstorage.documents"
+private const val PRIMARY_STORAGE = "/storage/emulated/0"
+
 @Composable
 fun ReaderEffects(
     effects: SharedFlow<ReaderEffect>,
     book: Book,
-    fullscreen: Boolean
+    fullscreen: Boolean,
+    grantFolder: (ReaderEvent.OnGrantFolder) -> Unit
 ) {
     val navigator = LocalNavigator.current
     val activity = LocalActivity.current
+
+    val folderPicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        grantFolder(ReaderEvent.OnGrantFolder(uri = uri.toString()))
+    }
 
     LaunchedEffect(effects, book, fullscreen) {
         effects.collect { effect ->
@@ -182,6 +197,38 @@ fun ReaderEffects(
                         popping = true,
                         saveInBackStack = false
                     )
+                }
+
+                is ReaderEffect.OnRequestFolderGrant -> {
+                    // The book's own folder as the picker's starting point, so
+                    // the user confirms rather than navigates. Only external
+                    // storage composes a document id this way; any other
+                    // provider ignores the hint and opens where it likes, which
+                    // is why nothing depends on it.
+                    val initial = effect.initialFolder
+                        ?.substringAfter(PRIMARY_STORAGE, missingDelimiterValue = "")
+                        ?.trim('/')
+                        ?.takeIf { it.isNotBlank() }
+                        ?.let { relative ->
+                            DocumentsContract.buildDocumentUri(
+                                EXTERNAL_STORAGE_AUTHORITY,
+                                "primary:$relative"
+                            )
+                        }
+
+                    activity.getString(R.string.add_to_library_grant_folder)
+                        .showToast(context = activity, longToast = true)
+                    folderPicker.launch(initial)
+                }
+
+                is ReaderEffect.OnAddedToLibrary -> {
+                    activity.getString(R.string.add_to_library_added)
+                        .showToast(context = activity, longToast = false)
+                }
+
+                is ReaderEffect.OnCannotAddToLibrary -> {
+                    activity.getString(R.string.add_to_library_no_path)
+                        .showToast(context = activity, longToast = true)
                 }
             }
         }

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderPreviewBar.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderPreviewBar.kt
@@ -1,0 +1,81 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.reader
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.presentation.reader.ReaderEvent
+import ua.acclorite.book_story.ui.common.components.common.StyledText
+import ua.acclorite.book_story.ui.theme.readerBarsColor
+
+/**
+ * Shown for as long as the book is only being previewed, and never once it is
+ * kept.
+ *
+ * Deliberately not part of the reader's menu, which is the natural place for it
+ * and the wrong one: the menu hides on the first tap into the text, so the one
+ * decision this whole screen exists for would be two taps away and out of sight
+ * for a reader who never opens the menu. It costs a strip of the page, and it
+ * costs it only while the question is open.
+ */
+@Composable
+fun ReaderPreviewBar(
+    addToLibrary: (ReaderEvent.OnAddToLibrary) -> Unit,
+    onHeightChanged: (Dp) -> Unit
+) {
+    val density = LocalDensity.current
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            // The reader's list has to end above this bar rather than behind it:
+            // the bar is here for the whole preview, so text scrolled under it
+            // would simply never be readable. Measured rather than assumed —
+            // the button grows with the font scale.
+            .onSizeChanged { onHeightChanged(with(density) { it.height.toDp() }) }
+            .background(MaterialTheme.colorScheme.readerBarsColor)
+            .navigationBarsPadding()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        StyledText(
+            text = stringResource(id = R.string.preview_bar_title),
+            style = LocalTextStyle.current.copy(
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            ),
+            maxLines = 1
+        )
+
+        Button(onClick = { addToLibrary(ReaderEvent.OnAddToLibrary) }) {
+            StyledText(
+                text = stringResource(id = R.string.add_to_library_content_desc),
+                style = LocalTextStyle.current.copy(
+                    color = MaterialTheme.colorScheme.onPrimary
+                ),
+                maxLines = 1
+            )
+        }
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderScaffold.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderScaffold.kt
@@ -114,6 +114,7 @@ fun ReaderScaffold(
     openDictionary: (ReaderEvent.OnOpenDictionary) -> Unit,
     showSettingsBottomSheet: (ReaderEvent.OnShowSettingsBottomSheet) -> Unit,
     showChaptersDrawer: (ReaderEvent.OnShowChaptersDrawer) -> Unit,
+    addToLibrary: (ReaderEvent.OnAddToLibrary) -> Unit,
     navigateToBookInfo: (ReaderEvent.OnNavigateToBookInfo) -> Unit,
     navigateBack: (ReaderEvent.OnNavigateBack) -> Unit
 ) {
@@ -144,6 +145,7 @@ fun ReaderScaffold(
                     switchColorPreset = switchColorPreset,
                     showSettingsBottomSheet = showSettingsBottomSheet,
                     showChaptersDrawer = showChaptersDrawer,
+                    addToLibrary = addToLibrary,
                     navigateBack = navigateBack,
                     navigateToBookInfo = navigateToBookInfo
                 )

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderScaffold.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderScaffold.kt
@@ -9,15 +9,23 @@ package ua.acclorite.book_story.ui.reader
 import android.annotation.SuppressLint
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -25,6 +33,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.TextUnit
 import ua.acclorite.book_story.domain.model.library.Book
 import ua.acclorite.book_story.domain.model.reader.ReaderText
@@ -118,6 +127,11 @@ fun ReaderScaffold(
     navigateToBookInfo: (ReaderEvent.OnNavigateToBookInfo) -> Unit,
     navigateBack: (ReaderEvent.OnNavigateBack) -> Unit
 ) {
+    // How much of the page the preview bar is taking, so the text can end above
+    // it. Zero for a book in the library, which has no such bar.
+    var previewBarHeight by remember { mutableStateOf(0.dp) }
+    val layoutDirection = LocalLayoutDirection.current
+
     Scaffold(
         Modifier
             .fillMaxSize()
@@ -145,38 +159,55 @@ fun ReaderScaffold(
                     switchColorPreset = switchColorPreset,
                     showSettingsBottomSheet = showSettingsBottomSheet,
                     showChaptersDrawer = showChaptersDrawer,
-                    addToLibrary = addToLibrary,
                     navigateBack = navigateBack,
                     navigateToBookInfo = navigateToBookInfo
                 )
             }
         },
         bottomBar = {
-            AnimatedVisibility(
-                modifier = Modifier.fillMaxWidth(),
-                visible = showMenu && !coveredByBottomSheet,
-                enter = slideInVertically { it },
-                exit = slideOutVertically { it }
-            ) {
-                ReaderBottomBar(
-                    book = book,
-                    progress = progress,
-                    text = text,
-                    listState = listState,
-                    lockMenu = lockMenu,
-                    checkpoints = checkpoints,
-                    bottomBarPadding = bottomBarPadding,
-                    restoreCheckpoint = restoreCheckpoint,
-                    scroll = scroll,
-                    changeProgress = changeProgress
-                )
+            // A Column, because the slot holds two bars for a previewed book and
+            // Scaffold measures its bottom bar as one: the preview bar sits below
+            // the menu's rather than replacing it, so a previewed book is read
+            // like any other and the progress slider stays where it always is.
+            Column {
+                AnimatedVisibility(
+                    modifier = Modifier.fillMaxWidth(),
+                    visible = showMenu && !coveredByBottomSheet,
+                    enter = slideInVertically { it },
+                    exit = slideOutVertically { it }
+                ) {
+                    ReaderBottomBar(
+                        book = book,
+                        progress = progress,
+                        text = text,
+                        listState = listState,
+                        lockMenu = lockMenu,
+                        checkpoints = checkpoints,
+                        bottomBarPadding = bottomBarPadding,
+                        restoreCheckpoint = restoreCheckpoint,
+                        scroll = scroll,
+                        changeProgress = changeProgress
+                    )
+                }
+
+                if (!book.inLibrary && !coveredByBottomSheet) {
+                    ReaderPreviewBar(
+                        addToLibrary = addToLibrary,
+                        onHeightChanged = { previewBarHeight = it }
+                    )
+                }
             }
         }
     ) {
         ReaderLayout(
             text = text,
             listState = listState,
-            contentPadding = contentPadding,
+            contentPadding = if (book.inLibrary) contentPadding else PaddingValues(
+                top = contentPadding.calculateTopPadding(),
+                start = contentPadding.calculateStartPadding(layoutDirection),
+                end = contentPadding.calculateEndPadding(layoutDirection),
+                bottom = contentPadding.calculateBottomPadding() + previewBarHeight
+            ),
             verticalPadding = verticalPadding,
             horizontalGesture = horizontalGesture,
             horizontalGestureScroll = horizontalGestureScroll,

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderTopBar.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderTopBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.LibraryAdd
 import androidx.compose.material.icons.rounded.Menu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -52,6 +53,7 @@ fun ReaderTopBar(
     switchColorPreset: (SettingsEvent.OnSwitchColorPreset) -> Unit,
     showSettingsBottomSheet: (ReaderEvent.OnShowSettingsBottomSheet) -> Unit,
     showChaptersDrawer: (ReaderEvent.OnShowChaptersDrawer) -> Unit,
+    addToLibrary: (ReaderEvent.OnAddToLibrary) -> Unit,
     navigateToBookInfo: (ReaderEvent.OnNavigateToBookInfo) -> Unit,
     navigateBack: (ReaderEvent.OnNavigateBack) -> Unit
 ) {
@@ -92,7 +94,10 @@ fun ReaderTopBar(
                     modifier = Modifier
                         .padding(end = 8.dp)
                         .noRippleClickable(
-                            enabled = !lockMenu,
+                            // A previewed book has no book info worth showing:
+                            // it is not in the library, and that screen is built
+                            // around books that are.
+                            enabled = !lockMenu && book.inLibrary,
                             onClick = {
                                 leave(
                                     ReaderEvent.OnLeave(
@@ -127,6 +132,20 @@ fun ReaderTopBar(
                 )
             },
             actions = {
+                // Only while the book is a preview: it is the one thing the user
+                // came here to decide, so it sits in the bar rather than behind
+                // the settings sheet.
+                if (!book.inLibrary) {
+                    IconButton(
+                        icon = Icons.Outlined.LibraryAdd,
+                        contentDescription = R.string.add_to_library_content_desc,
+                        disableOnClick = false,
+                        enabled = !lockMenu
+                    ) {
+                        addToLibrary(ReaderEvent.OnAddToLibrary)
+                    }
+                }
+
                 if (currentChapter != null) {
                     IconButton(
                         icon = Icons.Rounded.Menu,

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderTopBar.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderTopBar.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.outlined.LibraryAdd
 import androidx.compose.material.icons.rounded.Menu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -53,7 +52,6 @@ fun ReaderTopBar(
     switchColorPreset: (SettingsEvent.OnSwitchColorPreset) -> Unit,
     showSettingsBottomSheet: (ReaderEvent.OnShowSettingsBottomSheet) -> Unit,
     showChaptersDrawer: (ReaderEvent.OnShowChaptersDrawer) -> Unit,
-    addToLibrary: (ReaderEvent.OnAddToLibrary) -> Unit,
     navigateToBookInfo: (ReaderEvent.OnNavigateToBookInfo) -> Unit,
     navigateBack: (ReaderEvent.OnNavigateBack) -> Unit
 ) {
@@ -132,20 +130,6 @@ fun ReaderTopBar(
                 )
             },
             actions = {
-                // Only while the book is a preview: it is the one thing the user
-                // came here to decide, so it sits in the bar rather than behind
-                // the settings sheet.
-                if (!book.inLibrary) {
-                    IconButton(
-                        icon = Icons.Outlined.LibraryAdd,
-                        contentDescription = R.string.add_to_library_content_desc,
-                        disableOnClick = false,
-                        enabled = !lockMenu
-                    ) {
-                        addToLibrary(ReaderEvent.OnAddToLibrary)
-                    }
-                }
-
                 if (currentChapter != null) {
                     IconButton(
                         icon = Icons.Rounded.Menu,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,6 +241,14 @@
     <string name="clear_parse_cache_dialog">Clear parse cache?</string>
     <string name="clear_parse_cache_dialog_desc">This removes all cached parsed books. They will be re-parsed the next time you open them.</string>
 
+    <!-- Opening a book from a file manager -->
+    <string name="open_file_unsupported">That file is not a book this app can open.</string>
+    <string name="open_file_unreadable">Could not read that file.</string>
+    <string name="add_to_library_content_desc">Add to library</string>
+    <string name="add_to_library_added">Added to your library.</string>
+    <string name="add_to_library_grant_folder">Choose the folder this book is in, so it can be opened again later.</string>
+    <string name="add_to_library_no_path">This file has no location on the device, so it cannot be kept.</string>
+
     <!-- Reader -->
     <string name="font_family_option">Font family</string>
     <string name="font_thickness_option">Font thickness</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,6 +245,7 @@
     <string name="open_file_unsupported">That file is not a book this app can open.</string>
     <string name="open_file_unreadable">Could not read that file.</string>
     <string name="add_to_library_content_desc">Add to library</string>
+    <string name="preview_bar_title">Preview</string>
     <string name="add_to_library_added">Added to your library.</string>
     <string name="add_to_library_grant_folder">Choose the folder this book is in, so it can be opened again later.</string>
     <string name="add_to_library_no_path">This file has no location on the device, so it cannot be kept.</string>

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/library/BookFileMatchTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/library/BookFileMatchTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.library
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Which book a file arriving from another app belongs to. Getting this wrong is
+ * silent both ways: too loose and a tap opens someone else's book, too strict
+ * and the library quietly fills with duplicates of books already in it.
+ */
+class BookFileMatchTest {
+
+    private fun book(id: Int, filePath: String) = Book.default.copy(
+        id = id,
+        filePath = filePath
+    )
+
+    private val library = listOf(
+        book(1, "/storage/emulated/0/Books/Solaris.fb2"),
+        book(2, "/storage/emulated/0/Download/Solaris.fb2"),
+        book(3, "/storage/emulated/0/Books/Nebula.epub")
+    )
+
+    @Test
+    fun `path wins over name`() {
+        val match = library.findForFile(
+            filePath = "/storage/emulated/0/Download/Solaris.fb2",
+            fileName = "Solaris.fb2"
+        )
+
+        // Both rows carry that name; only one carries that path.
+        assertEquals(2, match?.id)
+    }
+
+    @Test
+    fun `falls back to the file name when there is no path`() {
+        val match = library.findForFile(filePath = "", fileName = "Nebula.epub")
+        assertEquals(3, match?.id)
+    }
+
+    @Test
+    fun `falls back to the file name when the path is unknown to the library`() {
+        // The same file reached through another provider reports another path.
+        val match = library.findForFile(
+            filePath = "/mnt/media_rw/ABCD-1234/Nebula.epub",
+            fileName = "Nebula.epub"
+        )
+
+        assertEquals(3, match?.id)
+    }
+
+    @Test
+    fun `a file the library does not have matches nothing`() {
+        val match = library.findForFile(
+            filePath = "/storage/emulated/0/Books/Eden.fb2",
+            fileName = "Eden.fb2"
+        )
+
+        assertNull(match)
+    }
+
+    @Test
+    fun `nothing to match on matches nothing`() {
+        assertNull(library.findForFile(filePath = "", fileName = ""))
+    }
+
+    @Test
+    fun `a name is matched whole, not as a suffix`() {
+        // "Solaris.fb2" must not be found by "olaris.fb2", which a LIKE '%…'
+        // over the path would do.
+        assertNull(library.findForFile(filePath = "", fileName = "olaris.fb2"))
+    }
+
+    @Test
+    fun `an empty library matches nothing`() {
+        val match = emptyList<Book>().findForFile(
+            filePath = "/storage/emulated/0/Books/Solaris.fb2",
+            fileName = "Solaris.fb2"
+        )
+
+        assertNull(match)
+    }
+}

--- a/app/src/test/java/ua/acclorite/book_story/domain/use_case/book/AddPreviewToLibraryUseCaseTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/use_case/book/AddPreviewToLibraryUseCaseTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.book
+
+import android.net.Uri
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import ua.acclorite.book_story.data.model.file.CachedFile
+import ua.acclorite.book_story.domain.model.library.Book
+import ua.acclorite.book_story.domain.service.FileProvider
+
+/**
+ * Keeping a previewed book. The point of the use case is that a book is never
+ * added in a state where it could not be opened again: the grant that reaches
+ * its file has to exist *before* the row is promoted, because the grant the file
+ * manager handed over dies with the task.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AddPreviewToLibraryUseCaseTest {
+
+    private val preview = Book.default.copy(
+        id = 7,
+        filePath = "/storage/emulated/0/Download/Solaris.fb2",
+        inLibrary = false,
+        previewUri = "content://provider/document/7"
+    )
+
+    private class FakeFileProvider(private val reachable: Boolean) : FileProvider {
+        override fun getFileFromBook(book: Book): Result<CachedFile> =
+            if (reachable) {
+                Result.success(
+                    CachedFile(
+                        context = RuntimeEnvironment.getApplication(),
+                        uri = Uri.parse("content://test/book")
+                    )
+                )
+            } else {
+                Result.failure(NoSuchElementException("No grant reaches it."))
+            }
+
+        override fun getStorageFiles(): Result<List<CachedFile>> = Result.success(emptyList())
+    }
+
+    @Test
+    fun `a reachable book is added`() = runBlocking {
+        val repository = FakeBookRepository()
+        val useCase = AddPreviewToLibraryUseCase(repository, FakeFileProvider(reachable = true))
+
+        val result = useCase(preview)
+
+        assertEquals(AddPreviewToLibraryUseCase.Result.Added, result)
+        assertEquals(true, repository.updated?.inLibrary)
+        assertEquals(7, repository.updated?.id)
+    }
+
+    @Test
+    fun `an unreachable book asks for its folder and is not added`() = runBlocking {
+        val repository = FakeBookRepository()
+        val useCase = AddPreviewToLibraryUseCase(repository, FakeFileProvider(reachable = false))
+
+        val result = useCase(preview)
+
+        assertEquals(
+            AddPreviewToLibraryUseCase.Result.NeedsGrant("/storage/emulated/0/Download"),
+            result
+        )
+        // Nothing was written: a row promoted here could never be opened again.
+        assertNull(repository.updated)
+    }
+
+    @Test
+    fun `a book with no path is kept by keeping its file`() = runBlocking {
+        val repository = FakeBookRepository(storedPath = "/data/books/7/Solaris.fb2")
+        val useCase = AddPreviewToLibraryUseCase(repository, FakeFileProvider(reachable = true))
+
+        val result = useCase(preview.copy(filePath = ""))
+
+        assertEquals(AddPreviewToLibraryUseCase.Result.Added, result)
+        // The copy becomes the book's location, and the transient URI goes.
+        assertEquals("/data/books/7/Solaris.fb2", repository.updated?.filePath)
+        assertEquals(true, repository.updated?.inLibrary)
+        assertNull(repository.updated?.previewUri)
+        // No grant was asked for: nothing about the copy needs one.
+        assertEquals(7, repository.storedFor?.id)
+    }
+
+    @Test
+    fun `a book whose file cannot be stored is not added`() = runBlocking {
+        val repository = FakeBookRepository(storedPath = null)
+        val useCase = AddPreviewToLibraryUseCase(repository, FakeFileProvider(reachable = true))
+
+        val result = useCase(preview.copy(filePath = ""))
+
+        assertEquals(AddPreviewToLibraryUseCase.Result.Failed, result)
+        assertNull(repository.updated)
+    }
+
+    @Test
+    fun `a file at the storage root still names a folder`() = runBlocking {
+        val repository = FakeBookRepository()
+        val useCase = AddPreviewToLibraryUseCase(repository, FakeFileProvider(reachable = false))
+
+        val result = useCase(preview.copy(filePath = "/Solaris.fb2"))
+
+        assertTrue(result is AddPreviewToLibraryUseCase.Result.NeedsGrant)
+        // No folder above it that can be named, so the picker opens wherever it
+        // likes rather than being sent to "".
+        assertNull((result as AddPreviewToLibraryUseCase.Result.NeedsGrant).folder)
+    }
+}

--- a/app/src/test/java/ua/acclorite/book_story/domain/use_case/book/AddPreviewToLibraryUseCaseTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/use_case/book/AddPreviewToLibraryUseCaseTest.kt
@@ -59,9 +59,14 @@ class AddPreviewToLibraryUseCaseTest {
 
         val result = useCase(preview)
 
-        assertEquals(AddPreviewToLibraryUseCase.Result.Added, result)
+        assertTrue(result is AddPreviewToLibraryUseCase.Result.Added)
         assertEquals(true, repository.updated?.inLibrary)
         assertEquals(7, repository.updated?.id)
+        // What was written comes back, so the reader can adopt it: it writes the
+        // whole book row on every settled scroll, and a stale copy would undo
+        // the promotion at the next one.
+        assertEquals(repository.updated, (result as AddPreviewToLibraryUseCase.Result.Added).book)
+        assertNull(result.book.previewUri)
     }
 
     @Test
@@ -86,7 +91,8 @@ class AddPreviewToLibraryUseCaseTest {
 
         val result = useCase(preview.copy(filePath = ""))
 
-        assertEquals(AddPreviewToLibraryUseCase.Result.Added, result)
+        assertTrue(result is AddPreviewToLibraryUseCase.Result.Added)
+        assertEquals(repository.updated, (result as AddPreviewToLibraryUseCase.Result.Added).book)
         // The copy becomes the book's location, and the transient URI goes.
         assertEquals("/data/books/7/Solaris.fb2", repository.updated?.filePath)
         assertEquals(true, repository.updated?.inLibrary)

--- a/app/src/test/java/ua/acclorite/book_story/domain/use_case/book/FakeBookRepository.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/use_case/book/FakeBookRepository.kt
@@ -1,0 +1,91 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.use_case.book
+
+import ua.acclorite.book_story.core.CoverImage
+import ua.acclorite.book_story.domain.model.file.File
+import ua.acclorite.book_story.domain.model.library.Book
+import ua.acclorite.book_story.domain.model.reader.BookImage
+import ua.acclorite.book_story.domain.model.reader.ParsedText
+import ua.acclorite.book_story.domain.repository.BookRepository
+
+/**
+ * A book repository that records what was written to it. Only the handful of
+ * calls the preview use cases make are answered; anything else fails loudly
+ * rather than returning a plausible empty value, so a test that starts reaching
+ * further says so instead of quietly passing.
+ */
+class FakeBookRepository(
+    private val books: List<Book> = emptyList(),
+    private val previews: List<Book> = emptyList(),
+    private val storedPath: String? = null
+) : BookRepository {
+
+    var updated: Book? = null
+        private set
+
+    var deleted: Book? = null
+        private set
+
+    /** The book whose file was copied into the app's own storage, if any. */
+    var storedFor: Book? = null
+        private set
+
+    override suspend fun searchBooks(query: String): Result<List<Book>> = Result.success(books)
+
+    override suspend fun findPreviews(): Result<List<Book>> = Result.success(previews)
+
+    override suspend fun updateBook(book: Book): Result<Unit> {
+        updated = book
+        return Result.success(Unit)
+    }
+
+    override suspend fun deleteBook(book: Book): Result<Unit> {
+        deleted = book
+        return Result.success(Unit)
+    }
+
+    override suspend fun dropBookImages(bookId: Int): Result<Unit> = Result.success(Unit)
+
+    override suspend fun storeBookFile(book: Book): Result<String> {
+        storedFor = book
+        return storedPath?.let { Result.success(it) }
+            ?: Result.failure(IllegalStateException("Could not store it."))
+    }
+
+    override suspend fun deleteBookFile(bookId: Int): Result<Unit> = Result.success(Unit)
+
+    private fun unused(name: String): Nothing =
+        throw UnsupportedOperationException("$name is not part of this fake.")
+
+    override suspend fun getBook(bookId: Int): Result<Book> = unused("getBook")
+
+    override suspend fun getText(bookId: Int): Result<ParsedText> = unused("getText")
+
+    override suspend fun loadBookImages(
+        bookId: Int,
+        srcs: Set<String>,
+        parsed: Map<String, ByteArray>,
+        onImage: (src: String, image: BookImage.Ready) -> Unit
+    ): Result<Unit> = unused("loadBookImages")
+
+    override suspend fun keepOnlyBookImages(bookId: Int): Result<Unit> =
+        unused("keepOnlyBookImages")
+
+    override suspend fun getFileFromBook(bookId: Int): Result<File> = unused("getFileFromBook")
+
+    override suspend fun addBook(book: Book): Result<Int> = unused("addBook")
+
+    override suspend fun findLibraryBookForFile(
+        filePath: String,
+        fileName: String
+    ): Result<Book?> = unused("findLibraryBookForFile")
+
+    override suspend fun getDefaultCover(book: Book): Result<CoverImage?> =
+        unused("getDefaultCover")
+}


### PR DESCRIPTION
Closes #61.

Tapping a `.fb2` or `.epub` in a file manager never offered this app: the
manifest declared one intent filter, `MAIN`/`LAUNCHER`, so the only way a book
reached the library was by granting a folder and browsing it.

Receiving the file and importing it would have been the wrong shape. A library
book is a **path**, resolved at open time by descending from a persisted SAF tree
grant; a file manager hands over a **document URI** carrying a transient one,
which is precisely what that model cannot store. Importing on arrival would force
either a copy of the file or a folder-grant dialog, at the moment the user has
done nothing but express curiosity.

So the file opens as a **preview**: look at the book, flip through it, and add it
to the library only if it is worth reading.

## A preview is a real row that is not in the library

`BookEntity.inLibrary` (Room 21 → 22, `DEFAULT 1`, so every existing book stays
where it is). A row, because `ReaderModel.init` takes a book id and everything
under it — progress, images, coverage, sessions — is keyed on that id; a reader
without a row is not the cheap path but a second implementation of the reader's
whole downstream. Keeping it out of the library costs **one `WHERE` clause**, in
the only query that lists books. `findBookById` stays unfiltered: it is how the
reader loads the very book being previewed.

It also carries `previewUri`, because the reader resolves a book through the same
SAF descent and a preview has nothing to descend. That URI is cleared the moment
the book is added.

## Nothing is recorded while a book is a preview

No session, no coverage, no words, and `finished` is never set. **Skimming a book
to decide whether to read it is not reading it**, and a speed measured over that
skim would be a lie about the only thing a speed is good for. Leaving the session
unstarted is almost the whole guard, since notes, coverage credit and the end of
a session are already conditioned on one being open.

Statistics begin when the book is added, which is the same statement read
backwards: the minutes spent deciding are not credited retroactively.

## Adding has two shapes

- **The file has a location.** It is promoted only once something persisted
  reaches it — the same question the reader will ask on every future open, so a
  book is never added in a state where it could not be opened again. Failing
  that, the folder picker opens at the book's own directory.
- **It has none.** The app keeps the file. The Downloads provider builds its
  document ids out of MediaStore row numbers, so there is nothing to remember and
  no folder to ask for — and downloading a book is the commonest way to get one.
  The **original** file rather than the parsed one: a parsed book cannot be parsed
  again once the cache format's version moves.

Copies live in `filesDir`, not the cache the system may empty whenever it wants
storage back, one directory per book so a book takes its file with it when it is
deleted. Named `owned_books` rather than `books` — upstream's
`AUTO_MIGRATION_7_8.removeBooksDir` deletes `filesDir/books`, and `AppModule`
calls it *every time the database is built* rather than only when that migration
runs. A store named `books` was emptied on every app start; device testing found
it and no unit test could have.

## The filters

For `content://` only the MIME type is matchable — the path is the provider's
document id and almost never ends in the file's extension. `application/octet-stream`
is deliberately absent: several file managers send it for FB2, which has no
registered MIME type, but accepting it would offer this app for every unknown
binary on the device. Start narrow, widen on evidence. `file://` keeps
`pathPattern` filters, where the path really is the path.

`singleTask`, because a file manager starts the viewer inside *its own* task:
every "Open with" left another whole copy of the app behind — seventeen entries
deep in the recents list on the tablet, each with its own navigator.

## Two things found by using it, not by reading it

**The preview's parse cache was thrown away.** Adding a book made the next open
slow as if nothing had been cached; everything had been, but the entry is keyed
on a hash of path/size/modification time, and keeping the book changes the path.
The copy now inherits the original's modification time and the entry is renamed —
a rename against a second parse of a book parsed seconds ago.

**"Add to library" was invisible.** It sat in the reader's top bar, behind a menu
that hides on the first tap into the text: the one decision the whole preview
exists for was two taps away and out of sight. It is a bar along the bottom now,
for as long as the book is a preview. The reader's list ends above it — its
content padding comes from the system insets and knew nothing about a bar the app
added, so the bar measures itself and reports its height up.

## Reviewed, and what the review found

Six findings fixed in `76a4231f`, the worst of them silent: `addToLibrary`
updated one field of the reader's state and left `previewUri`/`filePath` stale,
while `updateProgress` writes that whole row on every settled scroll — so the
first scroll after adding wrote the stale pair back and a book that had just been
kept became unopenable. The first device pass missed it by leaving without
scrolling.

Four further findings are **#63**, deliberately not fixed here: they are one
question — what an incoming file should do to an already-open reader, and to a
back stack restored after the process died — and it wants a decision rather than
a patch. The most visible of them: tapping a file while a book is open does
nothing, because `Navigator.push` refuses a screen of the class already on top.

Filed along the way: **#62**, deciding a book's format from its contents. Google
Drive saves FB2 as `.fb2.xml`, and `text/xml` is in the filter above — so the app
offers itself for exactly those files and then refuses them on the extension.

## Verified

- **189 unit tests**, 0 failures; `assembleRelease` builds, lint-vital clean.
- **Room 21 → 22 on the live database** (release-debug, R8): 12 books and 20
  sessions intact, `inLibrary = 1` and `previewUri = NULL` across the board.
- **The feature under R8**: preview, "already in the library", add-with-copy,
  reopen after a restart with no grant anywhere, delete taking the copy with it.
- **The parse cache after adding**: `cache HIT`, `getText: 2 ms`, `find file: 0 ms`.
- **The task fix**: two opens from a file manager added no recents entries, where
  before each one did.
