### PR TITLE
feat: read the second-to-last extension too, so Drive's .fb2.xml is a book (#62)

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/core/data/ExtensionsData.kt
+++ b/app/src/main/java/ua/acclorite/book_story/core/data/ExtensionsData.kt
@@ -25,4 +25,36 @@ object ExtensionsData {
         ".jpeg",
         ".gif"
     )
+
+    /**
+     * Which of [fileExtensions] this file name names, or null if it names none.
+     *
+     * The last extension, and failing that the **second-to-last** — because
+     * Google Drive saves an FB2 as `book.fb2.xml`, and that is how books arrive
+     * on a device. Nothing is read: this is a question about the name.
+     *
+     * The position is the whole of the care here. Only the second-to-last
+     * counts, never a known extension found anywhere in the name, or
+     *
+     *     як конвертувати .fb2 в .epub.html.xml
+     *
+     * — an HTML page about converting books — would be handed to the FB2 parser.
+     * Its second-to-last is `.html`, which is what it is. By the same rule
+     * `book.fb2.xml.bak` is not a book: two unknown extensions is a file that
+     * has stopped saying what it holds.
+     *
+     * A consequence taken deliberately: `book.epub.bak` opens as EPUB, and shows
+     * up in Browse for the same reason.
+     */
+    fun formatOf(fileName: String): String? {
+        val parts = fileName.split('.')
+        if (parts.size < 2) return null
+
+        fun extensionAt(index: Int) = ".${parts[index]}".lowercase().trim()
+
+        extensionAt(parts.lastIndex).let { if (it in fileExtensions) return it }
+        if (parts.size < 3) return null
+
+        return extensionAt(parts.lastIndex - 1).takeIf { it in fileExtensions }
+    }
 }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/cover/CoverParserImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/cover/CoverParserImpl.kt
@@ -6,6 +6,7 @@
 
 package ua.acclorite.book_story.data.parser.cover
 
+import ua.acclorite.book_story.core.data.ExtensionsData
 import ua.acclorite.book_story.core.CoverImage
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.data.model.file.CachedFile
@@ -27,7 +28,7 @@ class CoverParserImpl @Inject constructor(
             return null
         }
 
-        val fileFormat = ".${cachedFile.name.substringAfterLast(".")}".lowercase().trim()
+        val fileFormat = ExtensionsData.formatOf(cachedFile.name)
         return when (fileFormat) {
             ".pdf" -> {
                 pdfCoverParser.parse(cachedFile)

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/file/FileParserImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/file/FileParserImpl.kt
@@ -6,6 +6,7 @@
 
 package ua.acclorite.book_story.data.parser.file
 
+import ua.acclorite.book_story.core.data.ExtensionsData
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.data.model.file.CachedFile
 import ua.acclorite.book_story.domain.model.library.Book
@@ -27,7 +28,7 @@ class FileParserImpl @Inject constructor(
             return null
         }
 
-        val fileFormat = ".${cachedFile.name.substringAfterLast(".")}".lowercase().trim()
+        val fileFormat = ExtensionsData.formatOf(cachedFile.name)
         return when (fileFormat) {
             ".pdf" -> {
                 pdfFileParser.parse(cachedFile)

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/image/BookImageLoader.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/image/BookImageLoader.kt
@@ -8,6 +8,7 @@
 package ua.acclorite.book_story.data.parser.image
 
 import android.util.Base64
+import ua.acclorite.book_story.core.data.ExtensionsData
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.data.model.file.CachedFile
 import java.io.ByteArrayOutputStream
@@ -53,7 +54,7 @@ class BookImageLoader @Inject constructor() {
         onImage: (src: String, bytes: ByteArray) -> Unit
     ) {
         if (srcs.isEmpty()) return
-        val format = ".${cachedFile.name.substringAfterLast(".")}".lowercase().trim()
+        val format = ExtensionsData.formatOf(cachedFile.name)
         when (format) {
             ".fb2" -> loadFromFb2(cachedFile, srcs, onImage)
             ".epub" -> loadFromEpub(cachedFile, srcs, onImage)

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/TextParserImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/TextParserImpl.kt
@@ -8,6 +8,7 @@ package ua.acclorite.book_story.data.parser.text
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import ua.acclorite.book_story.core.data.ExtensionsData
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.data.model.file.CachedFile
 import ua.acclorite.book_story.domain.model.reader.ParsedText
@@ -32,7 +33,7 @@ class TextParserImpl @Inject constructor(
             return ParsedText.EMPTY
         }
 
-        val fileFormat = ".${cachedFile.name.substringAfterLast(".")}".lowercase().trim()
+        val fileFormat = ExtensionsData.formatOf(cachedFile.name)
         return withContext(Dispatchers.IO) {
             when (fileFormat) {
                 ".pdf" -> {

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/FileSystemRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/FileSystemRepositoryImpl.kt
@@ -56,14 +56,10 @@ class FileSystemRepositoryImpl @Inject constructor(
         query: String,
         existingFiles: List<String>
     ): Boolean {
-        if (
-            ExtensionsData.fileExtensions.none {
-                name.endsWith(
-                    it,
-                    ignoreCase = true
-                )
-            }
-        ) return false
+        // The same question the parsers ask, so the listing cannot offer a file
+        // that then refuses to open — and so a book named the way Drive names
+        // one is visible here too.
+        if (ExtensionsData.formatOf(name) == null) return false
         if (query.isNotBlank() && !name.contains(query.trim(), ignoreCase = true)) return false
         if (existingFiles.any { it.equals(path, ignoreCase = true) }) return false
         return true

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/file_system/GetFilesUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/file_system/GetFilesUseCase.kt
@@ -6,6 +6,7 @@
 
 package ua.acclorite.book_story.domain.use_case.file_system
 
+import ua.acclorite.book_story.core.data.ExtensionsData
 import ua.acclorite.book_story.core.helpers.compareByWithOrder
 import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.core.log.logE
@@ -43,10 +44,11 @@ class GetFilesUseCase @Inject constructor(
                     when (settings.browseSortOrder.lastValue) {
                         BrowseSortOrder.NAME -> file.name.trim()
 
-                        BrowseSortOrder.FILE_FORMAT -> file.path
-                            .substringAfterLast(".")
-                            .lowercase()
-                            .trimEnd()
+                        // The format the file will actually be read as, so a
+                        // book named `*.fb2.xml` sorts with the other FB2s
+                        // rather than under "xml".
+                        BrowseSortOrder.FILE_FORMAT ->
+                            ExtensionsData.formatOf(file.name).orEmpty()
 
                         BrowseSortOrder.FILE_SIZE -> file.size
 

--- a/app/src/test/java/ua/acclorite/book_story/core/data/ExtensionsDataTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/core/data/ExtensionsDataTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.core.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Which file names are books.
+ *
+ * The rule reaches past one unknown extension and no further, and it looks at
+ * one position rather than searching the name. Both halves matter: too short a
+ * reach and Drive's `.fb2.xml` is not a book; too loose a search and a web page
+ * about books is handed to the FB2 parser.
+ */
+class ExtensionsDataTest {
+
+    @Test
+    fun `a plain extension is the format`() {
+        assertEquals(".fb2", ExtensionsData.formatOf("Solaris.fb2"))
+        assertEquals(".epub", ExtensionsData.formatOf("Solaris.epub"))
+        assertEquals(".md", ExtensionsData.formatOf("notes.md"))
+    }
+
+    @Test
+    fun `case does not matter`() {
+        assertEquals(".fb2", ExtensionsData.formatOf("Solaris.FB2"))
+        assertEquals(".epub", ExtensionsData.formatOf("Solaris.EpUb"))
+    }
+
+    @Test
+    fun `the second-to-last extension is read past an unknown one`() {
+        // What Google Drive does to an FB2, and the reason this exists.
+        assertEquals(".fb2", ExtensionsData.formatOf("Solaris.fb2.xml"))
+    }
+
+    @Test
+    fun `only the second-to-last counts, not any extension in the name`() {
+        // An HTML page about converting books. A rule that searched the name
+        // would find ".fb2" and hand a web page to the FB2 parser.
+        assertEquals(
+            ".html",
+            ExtensionsData.formatOf("як конвертувати .fb2 в .epub.html.xml")
+        )
+    }
+
+    @Test
+    fun `two unknown extensions is not a book`() {
+        assertNull(ExtensionsData.formatOf("Solaris.fb2.xml.bak"))
+    }
+
+    @Test
+    fun `an unknown extension over an unknown one is not a book`() {
+        assertNull(ExtensionsData.formatOf("archive.tar.gz"))
+    }
+
+    @Test
+    fun `a known extension under an unknown one is taken deliberately`() {
+        // A backup of a book is still a book, and the user tapped it.
+        assertEquals(".epub", ExtensionsData.formatOf("Solaris.epub.bak"))
+    }
+
+    @Test
+    fun `a name with no extension is not a book`() {
+        assertNull(ExtensionsData.formatOf("Solaris"))
+        assertNull(ExtensionsData.formatOf(""))
+    }
+
+    @Test
+    fun `a trailing dot is not an extension`() {
+        assertNull(ExtensionsData.formatOf("Solaris."))
+    }
+
+    @Test
+    fun `dots inside the title do not confuse it`() {
+        assertEquals(".fb2", ExtensionsData.formatOf("Solaris. Эдем. Непобедимый.fb2"))
+        assertEquals(".fb2", ExtensionsData.formatOf("Solaris. Эдем. Непобедимый.fb2.xml"))
+    }
+
+    @Test
+    fun `a file that is only an extension still names its format`() {
+        assertEquals(".fb2", ExtensionsData.formatOf(".fb2"))
+    }
+}


### PR DESCRIPTION
Closes #62.

A book's format was the last dot in its name and nothing else, so a book whose
name ends in anything unfamiliar did not exist: invisible in Browse, and "Wrong
file format, could not find supported extension" when opened from a file manager.

**Google Drive saves an FB2 as `book.fb2.xml`.** That is how books arrive on this
device — a folder of them was sitting there, every one refused — and the intent
filter added in #61 made it worse in the most confusing way available, since
`text/xml` is in it: the app offered itself for exactly those files and then
declined them.

## The name is enough

No file is read. The last extension when it is one of the seven, and failing that
the **second-to-last**.

The position is the whole of the care here:

```
як конвертувати .fb2 в .epub.html.xml
                            ↑     ↑
                   second-to-last last
```

An HTML page about converting books. Only the second-to-last counts — never a
known extension found anywhere in the name — or this would be handed to the FB2
parser. Its second-to-last is `.html`, which is what it is. By the same rule
`book.fb2.xml.bak` is **not** a book: two unknown extensions is a file that has
stopped saying what it holds. Both are tests.

Taken deliberately: `book.epub.bak` now opens as EPUB, and shows up in Browse for
the same reason. The user tapped that file.

## One resolver, for what were five copies

The three parsers, the image loader, the Browse listing and the sort by file
format each carried the rule. Browse mattered most: it filtered on `endsWith`
against the same seven strings, so without it a file that opens from a file
manager would stay invisible in the library it belongs to — and a listing that
disagrees with the parser offers files it cannot open. Sorting by format now
sorts a `*.fb2.xml` with the other FB2s rather than under "xml".

## Deciding by content is deliberately not here

A `PK` header, `%PDF-`, a `<FictionBook` root — nothing on the device needs it
yet, and it cannot be done on the Browse scan: that walks the whole tree, and a
read per file is a ContentResolver round trip, over a network for a cloud
provider. Worth doing when a file appears that its name cannot answer for.

`.fb2.zip` stays out for a different reason: it needs unzipping, not recognising.

## Verified

- **200 unit tests** (11 new), 0 failures; `assembleRelease` builds, lint-vital
  clean.
- On the tablet: a `*.fb2.xml` opens from a file manager and renders as FB2,
  where the same file previously reached "Wrong file format".
