### PR TITLE
fix: an incoming file and an already-open reader (#63)

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/presentation/main/MainActivity.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/main/MainActivity.kt
@@ -83,7 +83,13 @@ class MainActivity : AppCompatActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         themeTrace("onCreate", this)
-        receiveFile(intent)
+
+        // Only on a fresh launch. The activity keeps the intent that started it,
+        // so every recreation would otherwise open the same file again — and
+        // after the process was killed that re-open fails anyway, since the
+        // grant died with the task, turning a file that opened fine into an
+        // error the user did nothing to cause.
+        if (savedInstanceState == null) receiveFile(intent)
 
         setContent {
             // Initializing Screen Models
@@ -154,15 +160,13 @@ class MainActivity : AppCompatActivity() {
                                     else -> it
                                 }
                             },
-                            backHandlerEnabled = { it != StartScreen }
+                            backHandlerEnabled = { it != StartScreen },
+                            // Over the screens rather than inside one: opening a
+                            // book replaces the reader, and anything living in a
+                            // screen's own content is disposed as that screen
+                            // goes — cancelling the very job doing the replacing.
+                            overlay = { MainFileOpenEffects(mainModel = mainModel) }
                         ) { screen ->
-                            // Inside the navigator's content because that is
-                            // where LocalNavigator exists. During a screen
-                            // transition two of these collect at once, which is
-                            // safe: the model hands the outcome over a channel,
-                            // so exactly one of them receives it.
-                            MainFileOpenEffects(mainModel = mainModel)
-
                             when (screen) {
                                 LibraryScreen, HistoryScreen, BrowseScreen -> {
                                     NavigatorTabs(

--- a/app/src/main/java/ua/acclorite/book_story/presentation/main/MainModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/main/MainModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.launch
 import ua.acclorite.book_story.domain.use_case.book.DiscardPreviewsUseCase
 import ua.acclorite.book_story.domain.use_case.book.OpenBookFromUriUseCase
 import javax.inject.Inject
+import kotlin.coroutines.coroutineContext
 
 /**
  * Books arriving from outside the app: a file tapped in a file manager, handed
@@ -60,11 +61,18 @@ class MainModel @Inject constructor(
      */
     private val sweep: Job = viewModelScope.launch { discardPreviewsUseCase.sweep() }
 
+    private var openJob: Job? = null
+
+    /**
+     * The last file wins. A first parse takes seconds, which is long enough to
+     * tap a second book, and the second tap is the one that says what the user
+     * wants open now — dropping it would be a tap that did nothing.
+     */
     fun onFileReceived(uri: String) {
-        if (_openingFile.value) return
+        openJob?.cancel()
 
         _openingFile.value = true
-        viewModelScope.launch {
+        openJob = viewModelScope.launch {
             sweep.join()
             try {
                 val result = openBookFromUriUseCase(uri)
@@ -75,7 +83,11 @@ class MainModel @Inject constructor(
                     }
                 )
             } finally {
-                _openingFile.value = false
+                // Only the open that is still the current one clears the flag: a
+                // cancelled one runs its finally *after* its replacement has
+                // already raised it, and would take the spinner down over an
+                // open that is still going.
+                if (openJob === coroutineContext[Job]) _openingFile.value = false
             }
         }
     }

--- a/app/src/main/java/ua/acclorite/book_story/presentation/navigator/Navigator.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/navigator/Navigator.kt
@@ -52,7 +52,11 @@ class Navigator @AssistedInject constructor(
         popping: Boolean = false,
         saveInBackStack: Boolean = true
     ) {
-        if (lastItem.value::class == targetScreen::class) return
+        // Read from [items] rather than [lastItem]: the latter is a `map` on a
+        // `stateIn`, so it lags a frame behind. A pop followed by a push in the
+        // same frame — which is how one book replaces another — saw the screen
+        // that had just been popped, and refused to push anything at all.
+        if (items.value.lastOrNull()?.let { it::class == targetScreen::class } == true) return
         if (!saveInBackStack) items.removeLast()
 
         changeStackEvent(

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderEffect.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderEffect.kt
@@ -50,6 +50,9 @@ sealed class ReaderEffect {
 
     data object OnAddedToLibrary : ReaderEffect()
 
+    /** The book being opened is no longer in the database. */
+    data object OnBookGone : ReaderEffect()
+
     /** The file could not be read, so there was nothing to keep. */
     data object OnCannotAddToLibrary : ReaderEffect()
 }

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderModel.kt
@@ -626,6 +626,11 @@ class ReaderModel @Inject constructor(
             val book = timed("  init: book row") { getBookUseCase(bookId) }
 
             if (book == null) {
+                // The commonest way to arrive here is a preview that did not
+                // survive the process: the start-up sweep took its row, and the
+                // navigator restored a screen pointing at it. Leaving silently
+                // looks like the app closing itself for no reason.
+                _effects.emit(ReaderEffect.OnBookGone)
                 _effects.emit(ReaderEffect.OnNavigateBack)
                 return@launch
             }
@@ -926,7 +931,17 @@ class ReaderModel @Inject constructor(
         return prefix[_state.value.book.scrollIndex.coerceIn(0, prefix.lastIndex)]
     }
 
-    fun clearAsync() {
+    /**
+     * Clears up after the reader of [bookId] — and does nothing if the model has
+     * since moved on to another book.
+     *
+     * The check is the point. There is one model for the whole activity, and a
+     * screen being replaced is disposed *after* its replacement has composed:
+     * closing a book to open another one had the outgoing reader cancel the
+     * incoming one's work, and the new book sat at its loading spinner forever.
+     */
+    fun clearAsync(bookId: Int) {
+        if (_state.value.book.id != bookId) return
         viewModelScope.launch { clear() }
     }
 

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderScreen.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderScreen.kt
@@ -413,7 +413,7 @@ data class ReaderScreen(val bookId: Int) : Screen, Parcelable {
 
         DisposableEffect(Unit) {
             onDispose {
-                screenModel.clearAsync()
+                screenModel.clearAsync(bookId = bookId)
                 WindowCompat.getInsetsController(
                     activity.window,
                     activity.window.decorView

--- a/app/src/main/java/ua/acclorite/book_story/ui/main/MainFileOpenEffects.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/main/MainFileOpenEffects.kt
@@ -19,10 +19,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.first
 import ua.acclorite.book_story.R
 import ua.acclorite.book_story.domain.use_case.book.OpenBookFromUriUseCase
 import ua.acclorite.book_story.presentation.main.MainModel
+import ua.acclorite.book_story.presentation.reader.ReaderEvent
+import ua.acclorite.book_story.presentation.reader.ReaderModel
 import ua.acclorite.book_story.presentation.reader.ReaderScreen
 import ua.acclorite.book_story.ui.common.helpers.showToast
 import ua.acclorite.book_story.ui.navigator.LocalNavigator
@@ -38,10 +42,33 @@ fun MainFileOpenEffects(mainModel: MainModel) {
     val context = LocalContext.current
     val opening by mainModel.openingFile.collectAsStateWithLifecycle()
 
+    // The reader that may already be open. Activity-scoped, so this is the same
+    // instance the reader screen uses — which is also why a second reader cannot
+    // simply be pushed on top of the first: there is one model, and two screens
+    // would fight over it.
+    val readerModel = hiltViewModel<ReaderModel>()
+
     LaunchedEffect(Unit) {
         mainModel.fileOpen.collect { state ->
             when (state) {
                 is MainModel.FileOpen.Open -> {
+                    if (navigator.lastItem.value is ReaderScreen) {
+                        // Leave the open book the way closing it does: OnLeave
+                        // is what saves the position, ends the reading session
+                        // and throws away a preview the user did not keep.
+                        // Popping the screen instead would lose all three.
+                        readerModel.onEvent(
+                            ReaderEvent.OnLeave(navigate = { navigator.pop() })
+                        )
+
+                        // And only open the next book once that one is actually
+                        // gone. Pushing from inside the leave — the obvious
+                        // shortcut — starts the new book while the old reader is
+                        // still being torn down, and they share one model: the
+                        // second book stopped at its loading spinner.
+                        navigator.lastItem.first { it !is ReaderScreen }
+                    }
+
                     navigator.push(ReaderScreen(state.bookId))
                 }
 

--- a/app/src/main/java/ua/acclorite/book_story/ui/navigator/Navigator.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/navigator/Navigator.kt
@@ -45,6 +45,14 @@ fun Navigator(
     transitionSpec: AnimatedContentTransitionScope<Screen>.(lastEvent: StackEvent) -> ContentTransform,
     contentKey: (Screen) -> Any? = { it },
     backHandlerEnabled: (Screen) -> Boolean = { true },
+    /**
+     * Drawn over every screen and composed once, outside the animation.
+     *
+     * For work that has to outlive a navigation: anything inside [content] is
+     * disposed the moment its screen is replaced, taking its effects with it, so
+     * a job that navigates cannot live there — it would cancel itself halfway.
+     */
+    overlay: @Composable () -> Unit = {},
     content: @Composable (currentScreen: Screen) -> Unit
 ) {
     val navigator = rememberNavigator(initialScreen = initialScreen)
@@ -67,6 +75,8 @@ fun Navigator(
             contentKey = contentKey,
             content = { content(it) }
         )
+
+        overlay()
     }
 
     BackHandler(enabled = backHandlerEnabled.invoke(currentScreen.value)) {

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderEffects.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderEffects.kt
@@ -221,6 +221,11 @@ fun ReaderEffects(
                     folderPicker.launch(initial)
                 }
 
+                is ReaderEffect.OnBookGone -> {
+                    activity.getString(R.string.book_gone)
+                        .showToast(context = activity, longToast = true)
+                }
+
                 is ReaderEffect.OnAddedToLibrary -> {
                     activity.getString(R.string.add_to_library_added)
                         .showToast(context = activity, longToast = false)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,6 +246,7 @@
     <string name="open_file_unreadable">Could not read that file.</string>
     <string name="add_to_library_content_desc">Add to library</string>
     <string name="preview_bar_title">Preview</string>
+    <string name="book_gone">That book is no longer here. A preview lasts only as long as the app is open — open the file again to read it.</string>
     <string name="add_to_library_added">Added to your library.</string>
     <string name="add_to_library_grant_folder">Choose the folder this book is in, so it can be opened again later.</string>
     <string name="add_to_library_no_path">This file has no location on the device, so it cannot be kept.</string>


### PR DESCRIPTION
Closes #63.

Four defects, all the same question asked in different places: **what should
happen to a file arriving while the app is not sitting on the library?**

## A book tapped while another was open did nothing at all

`Navigator.push` refuses a screen of the class already on top, so the new book
was parsed, a preview row inserted — and then nothing was pushed. The old book
stayed, and the row was left for the next start-up sweep.

It now closes the open book the way closing it does: `OnLeave`, which saves the
position, ends the reading session and discards a preview the user did not keep.
Popping the screen instead would lose all three.

Getting there took three tries, and each one taught something the code did not
say out loud:

- **`push`'s own guard read `lastItem`**, which is a `map` over a `stateIn` and
  so lags a frame. A pop followed by a push in the same frame saw the screen that
  had just been popped, and refused. It reads `items` now — what it always meant.
- **`MainFileOpenEffects` lived inside the navigator's content**, so it was
  disposed along with the screen it sat in, cancelling the very job that was
  waiting for that screen to go. It is an `overlay` now: composed once, outside
  the animation, which `Navigator` grew a slot for. The comment claiming that two
  of them collecting at once was "safe" was wrong — it is safe only for work that
  does not outlive a navigation.
- **`ReaderScreen`'s disposal called `clearAsync`**, which cancels every job the
  model has. A screen being replaced is disposed *after* its replacement has
  composed, so the outgoing reader cancelled the incoming one's parse: the new
  book sat at a loading spinner for good, with no error, because a cancelled
  parse logs nothing. Cleanup now names the book it is cleaning up after and does
  nothing if the model has moved on.

That last one is the single activity-scoped `ReaderModel` showing through, and
the reason two readers cannot simply be stacked.

## The intent was re-handled on every recreation

A process-death restore re-opened the file — and failed, because the grant died
with the task, turning a file that had opened fine into an error the user did
nothing to cause. Only a fresh launch (`savedInstanceState == null`) carries a
file now.

## A second file during a parse was dropped silently

The last one wins: the open in flight is cancelled. Only the open that is still
current clears the loading flag, since a cancelled one runs its `finally` after
its replacement has raised it.

## A restored reader on a swept preview left without a word

It already navigated back — the issue overstated this — but silently, which looks
like the app closing itself for no reason. It says what happened instead.

## Verified

- **200 unit tests**, 0 failures; `assembleRelease` builds, lint-vital clean.
- On the tablet: two books opened in turn from a file manager — the first
  discarded, the second showing its text — with one preview row left behind and
  no trace of the other.
