### PR TITLE
Search the library by author, under one rule for both tabs

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDao.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/local/room/BookDao.kt
@@ -25,14 +25,14 @@ interface BookDao {
     /**
      * Every list of books in the app comes from here — the library, the history
      * and the search — so this is the one place a preview has to be kept out of.
+     *
+     * Unfiltered on purpose: a search query is matched in Kotlin, by
+     * [ua.acclorite.book_story.domain.model.library.matchesSearch], because
+     * SQLite's `LOWER()` folds ASCII only and `LIKE` would read a typed `%` or
+     * `_` as a wildcard. This is the same handful of rows either way.
      */
-    @Query(
-        """
-        SELECT * FROM bookentity
-        WHERE inLibrary = 1 AND LOWER(title) LIKE '%' || LOWER(:query) || '%'
-    """
-    )
-    suspend fun searchBooks(query: String): List<BookEntity>
+    @Query("SELECT * FROM bookentity WHERE inLibrary = 1")
+    suspend fun getLibraryBooks(): List<BookEntity>
 
     /**
      * Deliberately **not** filtered by [BookEntity.inLibrary]: this is how the

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
@@ -72,9 +72,9 @@ class BookRepositoryImpl @Inject constructor(
     @Volatile
     private var lastOpenedFile: OpenedBookFile? = null
 
-    override suspend fun searchBooks(query: String): Result<List<Book>> = runCatchingCancellable {
+    override suspend fun getLibraryBooks(): Result<List<Book>> = runCatchingCancellable {
         withContext(Dispatchers.IO) {
-            database.bookDao.searchBooks(query).map { bookMapper.toBook(it) }
+            database.bookDao.getLibraryBooks().map { bookMapper.toBook(it) }
         }
     }
 
@@ -351,7 +351,7 @@ class BookRepositoryImpl @Inject constructor(
             // Matched in Kotlin rather than in SQL: a LIKE over the path would
             // treat '%' and '_' in a file name as wildcards, and the library is
             // the same handful of rows every other screen already reads whole.
-            database.bookDao.searchBooks("")
+            database.bookDao.getLibraryBooks()
                 .map(bookMapper::toBook)
                 .findForFile(filePath = filePath, fileName = fileName)
         }

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/FileSystemRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/FileSystemRepositoryImpl.kt
@@ -40,7 +40,7 @@ class FileSystemRepositoryImpl @Inject constructor(
     override suspend fun searchFiles(query: String): Result<List<File>> {
         return withContext(Dispatchers.IO) {
             fileProvider.getStorageFiles().mapCatchingCancellable { storages ->
-                val existingFiles = database.bookDao.searchBooks("").map { it.filePath }
+                val existingFiles = database.bookDao.getLibraryBooks().map { it.filePath }
 
                 storages.map { storage ->
                     storage.getFilesFromStorage(

--- a/app/src/main/java/ua/acclorite/book_story/domain/model/library/BookQueryMatch.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/model/library/BookQueryMatch.kt
@@ -1,0 +1,54 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.library
+
+/**
+ * What a library or history search query means, in one place, so that the two
+ * lists cannot answer the same query differently.
+ *
+ * Deliberately not SQL. `LOWER()` in SQLite folds ASCII and nothing else, so a
+ * `LIKE` over a lowered title is case-*sensitive* for every non-Latin script;
+ * and `%` or `_` typed into the field would be read as wildcards. The library is
+ * the same handful of rows every other screen already reads whole, so matching
+ * it in Kotlin costs nothing and both problems stop existing.
+ */
+fun bookSearchTokens(query: String): List<String> =
+    query.lowercase().split(' ', '\t', '\n').filter { it.isNotBlank() }
+
+/**
+ * True when every token appears somewhere in the book's title or author.
+ *
+ * Per token rather than as one substring, so that either order of a name
+ * matches, and so that a query can name a word of the title and a word of the
+ * author at once. An empty [tokens] matches everything — that is the plain
+ * unfiltered list.
+ *
+ * The author is searched because the library is already organised by it (see
+ * [ua.acclorite.book_story.presentation.library.model.LibrarySortOrder]), and an
+ * unknown one contributes nothing: its placeholder is a label, not the name of
+ * anybody's book.
+ *
+ * The description is deliberately **not** searched. It is a different kind of
+ * match — publisher's copy rather than the name of the thing being looked for —
+ * in a list that has no ranking to keep the two apart; it exists for some
+ * formats only (never for TXT or HTML); and it summarises plots, which is the
+ * one thing a reader should not be shown by accident.
+ */
+fun Book.matchesSearch(tokens: List<String>): Boolean {
+    if (tokens.isEmpty()) return true
+
+    val haystack = buildString {
+        append(title)
+        author.getAsString()?.let {
+            append(' ')
+            append(it)
+        }
+    }.lowercase()
+
+    return tokens.all { haystack.contains(it) }
+}

--- a/app/src/main/java/ua/acclorite/book_story/domain/repository/BookRepository.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/repository/BookRepository.kt
@@ -13,9 +13,8 @@ import ua.acclorite.book_story.domain.model.reader.BookImage
 import ua.acclorite.book_story.domain.model.reader.ParsedText
 
 interface BookRepository {
-    suspend fun searchBooks(
-        query: String
-    ): Result<List<Book>>
+    /** Every book in the library; previews are not books yet and are left out. */
+    suspend fun getLibraryBooks(): Result<List<Book>>
 
     suspend fun getBook(
         bookId: Int

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/SearchBooksUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/book/SearchBooksUseCase.kt
@@ -9,6 +9,8 @@ package ua.acclorite.book_story.domain.use_case.book
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.domain.model.library.Book
+import ua.acclorite.book_story.domain.model.library.bookSearchTokens
+import ua.acclorite.book_story.domain.model.library.matchesSearch
 import ua.acclorite.book_story.domain.repository.BookRepository
 import ua.acclorite.book_story.domain.repository.HistoryRepository
 import javax.inject.Inject
@@ -23,8 +25,10 @@ class SearchBooksUseCase @Inject constructor(
     suspend operator fun invoke(query: String): List<Book> {
         logI(TAG, "Searching for books with query: \"$query\".")
 
-        return bookRepository.searchBooks(query).fold(
-            onSuccess = { books ->
+        val tokens = bookSearchTokens(query)
+        return bookRepository.getLibraryBooks().fold(
+            onSuccess = { allBooks ->
+                val books = allBooks.filter { book -> book.matchesSearch(tokens) }
                 logI(TAG, "Successfully found [${books.size}] books.")
                 books.map { book ->
                     val history = historyRepository.getHistoryForBook(book.id).getOrNull()

--- a/app/src/main/java/ua/acclorite/book_story/domain/use_case/history/GetHistoryUseCase.kt
+++ b/app/src/main/java/ua/acclorite/book_story/domain/use_case/history/GetHistoryUseCase.kt
@@ -10,6 +10,8 @@ import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.domain.model.history.History
+import ua.acclorite.book_story.domain.model.library.bookSearchTokens
+import ua.acclorite.book_story.domain.model.library.matchesSearch
 import ua.acclorite.book_story.domain.repository.HistoryRepository
 import ua.acclorite.book_story.presentation.history.model.GroupedHistory
 import java.time.Instant
@@ -48,10 +50,10 @@ class GetHistoryUseCase @Inject constructor(
             return maxElementsById.filterNotNull()
         }
 
-        val query = query.lowercase().trim()
+        val tokens = bookSearchTokens(query)
         return runCatchingCancellable {
             historyRepository.getHistory().getOrThrow()
-                .filter { history -> history.book.title.lowercase().trim().contains(query) }
+                .filter { history -> history.book.matchesSearch(tokens) }
                 .sortedByDescending { history -> history.time }
                 .groupBy { history -> getDayLabel(history.time) }
                 .map { (day, history) -> GroupedHistory(day, filterMaxElementsById(history)) }

--- a/app/src/main/java/ua/acclorite/book_story/ui/library/LibraryListItem.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/library/LibraryListItem.kt
@@ -9,6 +9,7 @@ package ua.acclorite.book_story.ui.library
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -103,14 +104,29 @@ fun LibraryListItem(
 
         Spacer(modifier = Modifier.width(16.dp))
 
-        StyledText(
-            text = book.data.title,
-            modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.bodyMedium.copy(
-                color = fontColor
-            ),
-            maxLines = 2
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            StyledText(
+                text = book.data.title,
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = fontColor
+                ),
+                maxLines = 2
+            )
+
+            // Shown because the search matches it: without it an author query
+            // would return titles with no visible reason for being there. Only
+            // when the book carries one — the placeholder for an unknown author
+            // says nothing and would sit under every book that has no metadata.
+            book.data.author.getAsString()?.let { author ->
+                StyledText(
+                    text = author,
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        color = fontColor.copy(alpha = 0.7f)
+                    ),
+                    maxLines = 1
+                )
+            }
+        }
 
         Spacer(modifier = Modifier.width(8.dp))
 

--- a/app/src/test/java/ua/acclorite/book_story/domain/model/library/BookQueryMatchTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/model/library/BookQueryMatchTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.domain.model.library
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.core.ui.UIText
+
+/**
+ * What a search query means for a book. One rule for the library and the
+ * history, because two rules is how the same query came to give two answers.
+ */
+class BookQueryMatchTest {
+
+    private fun book(
+        title: String,
+        author: String? = null,
+        description: String? = null
+    ) = Book.default.copy(
+        title = title,
+        author = author?.let { UIText.StringValue(it) }
+            ?: UIText.StringResource(R.string.unknown_author),
+        description = description
+    )
+
+    private fun matches(query: String, book: Book) = book.matchesSearch(bookSearchTokens(query))
+
+    private val solaris = book(
+        title = "Соляріс",
+        author = "Станіслав Лем",
+        description = "Планета, вкрита мислячим океаном."
+    )
+
+    @Test
+    fun `matches the title`() {
+        assertTrue(matches("соляр", solaris))
+    }
+
+    @Test
+    fun `matches the author`() {
+        assertTrue(matches("лем", solaris))
+    }
+
+    /**
+     * The reason the filter left SQL: `LOWER()` in SQLite folds ASCII and
+     * nothing else, so this exact query used to return nothing.
+     */
+    @Test
+    fun `case is ignored beyond ASCII`() {
+        assertTrue(matches("соляріс", book(title = "Соляріс")))
+        assertTrue(matches("СОЛЯРІС", book(title = "соляріс")))
+        assertTrue(matches("solaris", book(title = "SOLARIS")))
+    }
+
+    /** The other half of leaving SQL: these are characters, not wildcards. */
+    @Test
+    fun `LIKE wildcards are literal`() {
+        assertFalse(matches("%", solaris))
+        assertFalse(matches("_", solaris))
+        assertTrue(matches("%", book(title = "100% Rust")))
+        assertTrue(matches("_", book(title = "snake_case")))
+    }
+
+    @Test
+    fun `every token has to appear`() {
+        assertTrue(matches("лем соляріс", solaris))
+        assertFalse(matches("лем небула", solaris))
+    }
+
+    @Test
+    fun `token order does not matter`() {
+        val byLastNameFirst = book(title = "Соляріс", author = "Лем Станіслав")
+
+        assertTrue(matches("станіслав лем", byLastNameFirst))
+        assertTrue(matches("лем станіслав", solaris))
+    }
+
+    @Test
+    fun `a token may come from the title and another from the author`() {
+        assertTrue(matches("соляріс станіслав", solaris))
+    }
+
+    @Test
+    fun `extra whitespace is not a token`() {
+        assertEquals(listOf("лем"), bookSearchTokens("   лем\t\n"))
+        assertTrue(matches("  лем   соляріс  ", solaris))
+    }
+
+    @Test
+    fun `an empty query matches everything`() {
+        assertTrue(matches("", solaris))
+        assertTrue(matches("   ", solaris))
+    }
+
+    /** Deliberate: a blurb hit is a different kind of answer. See the rule. */
+    @Test
+    fun `the description is not searched`() {
+        assertFalse(matches("океаном", solaris))
+    }
+
+    /**
+     * An unknown author is a placeholder label, not the name of anybody's book,
+     * so it is not searchable text — and it must not swallow a query either.
+     */
+    @Test
+    fun `an unknown author matches nothing`() {
+        val anonymous = book(title = "Соляріс")
+
+        assertFalse(matches("unknown", anonymous))
+        assertFalse(matches("лем", anonymous))
+        assertTrue(matches("соляріс", anonymous))
+    }
+}

--- a/app/src/test/java/ua/acclorite/book_story/domain/use_case/book/FakeBookRepository.kt
+++ b/app/src/test/java/ua/acclorite/book_story/domain/use_case/book/FakeBookRepository.kt
@@ -36,7 +36,7 @@ class FakeBookRepository(
     var storedFor: Book? = null
         private set
 
-    override suspend fun searchBooks(query: String): Result<List<Book>> = Result.success(books)
+    override suspend fun getLibraryBooks(): Result<List<Book>> = Result.success(books)
 
     override suspend fun findPreviews(): Result<List<Book>> = Result.success(previews)
 


### PR DESCRIPTION
Closes #69.

The library searched the title in SQL and the history searched the title in
Kotlin, so the same query could get two answers — and the SQL one was wrong
twice over.

## The two defects

**`LOWER()` in SQLite folds ASCII and nothing else**, which made the library
search case-*sensitive* for every non-Latin title:

```sql
sqlite> select 'Війна і мир' LIKE '%війна%';  -- 0
sqlite> select 'War and Peace' LIKE '%war%';  -- 1
```

The history tab answered the same query correctly, because Kotlin's
`lowercase()` knows Unicode. Nobody had noticed, because you tend to type the
case you can see.

**`%` and `_` typed into the field were LIKE wildcards** — `_` matched every
book. `findBookForFile` already avoids `LIKE` for exactly this reason, and its
comment is the whole argument for this change: *"a LIKE over the path would
treat '%' and '_' in a file name as wildcards, and the library is the same
handful of rows every other screen already reads whole."*

## What changed

The filter moves out of SQL, which is also what makes searching a second field
cheap. `BookDao.searchBooks(query)` becomes `getLibraryBooks()`, a plain
`WHERE inLibrary = 1`; the two callers that already passed `""` to mean "all"
stop pretending to search.

One rule — `bookSearchTokens` + `Book.matchesSearch` in `domain/model/library`,
beside `findForFile` — now serves both the library and the history. It splits
the query on whitespace and requires every token somewhere in **title +
author**: per token so that either order of a name matches, and so that a query
can name one word of the title and one of the author.

The author is searched because the library already sorts by it
(`LibrarySortOrder.AUTHOR`). An unknown author matches nothing: its placeholder
is a label, not the name of anybody's book.

The **description is deliberately not searched**. It is a different kind of
match — publisher's copy rather than the name of the thing being looked for —
in a list that has no ranking to keep the two apart; it exists for FB2, EPUB and
PDF but never for TXT or HTML, so the search would silently cover part of the
library; and it summarises plots. If it is ever wanted it belongs behind a
deliberate switch, not in the default.

The list layout gains an author line, so an author match arrives with a visible
reason for being there. The grid has no room for one and keeps to the title.

## Tests

11 new JVM tests (`BookQueryMatchTest`, written in Cyrillic so the case rule is
actually exercised), **237 in the suite**, lint clean.

## Device QA

Tablet, debug build. The library there is 10 books by one author plus two with
other authors.

| query | result | what it shows |
|---|---|---|
| `android` | 10 | the author is searched — no title contains that word |
| `Android lenovo` | 1 | tokens across both fields, mixed case |
| `_` / `_%` | 0 | wildcards are literal characters now |
| history `android` | the same 10 | both tabs answer alike |

Non-ASCII case cannot be typed over adb (`input text` is ASCII-only, and this
Android has no `cmd clipboard`), so that half was verified by hand afterwards —
a lower-case Cyrillic query now finds a capitalised title.

## Known limits, not addressed here

- The grid layout still shows no author, so an author match is silent there.
- FB2 keeps only the first `<author>`, so an anthology's other authors are
  unsearchable regardless of this change.
