### PR TITLE
Declare an interest in documents providers, so a granted source stays reachable

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,20 @@
         tools:node="remove"
         tools:ignore="ScopedStorage" />
 
+    <!-- Package visibility (API 30+) hides other apps from this one, and a
+         persisted URI grant is no exemption: after a reboot every query against
+         a third-party documents provider — a cloud client, an SMB client —
+         answers "Unknown authority" with a null cursor, so a folder the user
+         granted long ago simply returns nothing. This declares the one interest
+         the app has. It is not a permission: it prompts for nothing, appears in
+         no permission list, and grants no network access — a cloud-hosted book
+         is fetched by the provider's own process, not by this one. -->
+    <queries>
+        <intent>
+            <action android:name="android.content.action.DOCUMENTS_PROVIDER" />
+        </intent>
+    </queries>
+
     <application
         android:name=".Application"
         android:allowBackup="false"


### PR DESCRIPTION
Closes #79.

One manifest block. Package visibility (API 30+) hides other packages from this
app, and a persisted URI grant is no exemption — so after a reboot a folder
granted on Google Drive, or any other third-party documents provider, answers
`Unknown authority` with a null cursor. A null cursor reads as an empty folder,
so Browse shows nothing and opening a book stored there fails with *"File is
empty, missing, or inaccessible… change the path"*.

```xml
<queries>
    <intent>
        <action android:name="android.content.action.DOCUMENTS_PROVIDER" />
    </intent>
</queries>
```

`<queries>` is not a permission — no prompt, no permission list, no network. The
app still declares zero permissions; a cloud-hosted book's bytes are fetched by
the provider's own process. `<package>` / `<provider android:authorities>` need
the name in advance, which SAF does not give; `QUERY_ALL_PACKAGES` is a
permission and far broader. Device storage is unaffected.

## Verified

Tablet with two Drive folders granted, one boot, same build otherwise:

| build | Drive answers |
|---|---|
| with `<queries>` | yes — 23 / 27 children, bytes read, `isChildDocument` works |
| removed, reinstalled | no — 11 x `Unknown authority` / `CURSOR IS NULL` |

The control is what rules out the reinstall being the cure.

289 tests, lint clean.

Split out of #49, which keeps the rest.
