### PR TITLE
Ask the provider which sources contain which, instead of comparing invented paths

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/data/service/FileProviderImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/service/FileProviderImpl.kt
@@ -7,7 +7,11 @@
 package ua.acclorite.book_story.data.service
 
 import android.app.Application
+import android.net.Uri
+import android.os.Build
+import android.provider.DocumentsContract
 import androidx.core.net.toUri
+import ua.acclorite.book_story.core.helpers.rethrowIfCancellation
 import ua.acclorite.book_story.core.helpers.runCatchingCancellable
 import ua.acclorite.book_story.core.log.bookTimingNote
 import ua.acclorite.book_story.data.model.file.CachedFile
@@ -21,6 +25,14 @@ class FileProviderImpl @Inject constructor(
     private val application: Application,
     private val ownedBookFiles: OwnedBookFiles
 ) : FileProvider {
+
+    /**
+     * The last nesting decision, against the set of roots it was made for. Browse
+     * re-reads its list on every refresh, and each pair of roots can cost a round
+     * trip to a provider that is not on this device. Adding or removing a grant,
+     * or a source going dark, changes the set and so the key.
+     */
+    private var nestingCache: Pair<Set<SafRoot>, List<SafRoot>>? = null
 
     override fun getFileFromBook(book: Book): Result<CachedFile> = runCatchingCancellable {
         // A book being previewed is reached by the URI another app handed over,
@@ -111,25 +123,60 @@ class FileProviderImpl @Inject constructor(
     }
 
     override fun getStorageFiles(): Result<List<CachedFile>> = runCatchingCancellable {
-        application.contentResolver.persistedUriPermissions.mapNotNull { permission ->
-            val storage = CachedFileCompat.fromUri(
-                application,
-                permission.uri
-            )
-            if (!storage.isDirectory) return@mapNotNull null
+        // A tree that answers nothing is indistinguishable from an empty one: the
+        // query returns a null cursor and `isDirectory` falls back to false.
+        val readable = LinkedHashMap<SafRoot, CachedFile>()
+        val trees = LinkedHashMap<SafRoot, Uri>()
+        application.contentResolver.persistedUriPermissions.forEach { permission ->
+            val storage = CachedFileCompat.fromUri(application, permission.uri)
+            if (!storage.isDirectory) return@forEach
 
-            storage
-        }.let { storages ->
-            storages.filter { storage ->
-                storages.none {
-                    it.path != storage.path && storage.path.startsWith(
-                        it.path,
-                        ignoreCase = true
-                    )
-                }
-            }
+            val root = safRootOf(permission.uri)
+            readable.putIfAbsent(root, storage)
+            trees.putIfAbsent(root, permission.uri)
+        }
+
+        val listed = nestingCache
+            ?.takeIf { (asked, _) -> asked == readable.keys }
+            ?.second
+            ?: rootsToList(readable.keys.toList()) { parent, child ->
+                isChildDocument(trees.getValue(parent), trees.getValue(child))
+            }.also { nestingCache = readable.keys.toSet() to it }
+
+        listed.mapNotNull { readable[it] }
+    }
+
+    /**
+     * Whether the provider considers [childTree] to sit inside [parentTree], or
+     * null when it will not say — unsupported, or gone since the grant was taken.
+     */
+    private fun isChildDocument(parentTree: Uri, childTree: Uri): Boolean? {
+        // Public only since API 29, and `minSdk` is 26. Below it there is no way
+        // to ask at all, so the question goes unanswered and the id structure
+        // decides — the same route a provider that will not answer takes.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return null
+
+        return try {
+            DocumentsContract.isChildDocument(
+                application.contentResolver,
+                documentUriOf(parentTree),
+                documentUriOf(childTree)
+            )
+        } catch (e: Throwable) {
+            e.rethrowIfCancellation()
+            null
         }
     }
+
+    private fun documentUriOf(treeUri: Uri): Uri = DocumentsContract.buildDocumentUriUsingTree(
+        treeUri,
+        DocumentsContract.getTreeDocumentId(treeUri)
+    )
+
+    private fun safRootOf(treeUri: Uri) = SafRoot(
+        authority = treeUri.authority,
+        treeDocumentId = DocumentsContract.getTreeDocumentId(treeUri)
+    )
 }
 
 /**
@@ -162,4 +209,80 @@ internal fun pathSegmentsUnder(rootPath: String, filePath: String): List<String>
     if (segments.any { it.isBlank() }) return null
 
     return segments
+}
+/**
+ * A granted tree, named the way its provider names it rather than by a path.
+ *
+ * A path is the wrong identity for a tree: `DocumentFileCompat.getAbsolutePath`
+ * synthesises one for any provider that is not `com.android.externalstorage`, and
+ * Google Drive answers `/storage` for every folder it hosts — a string that is a
+ * prefix of every real path on the device and identical for two unrelated folders.
+ * The authority and the tree's document id are what the platform actually
+ * promises: unique within a provider, and durable, since long-term permission
+ * grants are issued against them.
+ */
+internal data class SafRoot(val authority: String?, val treeDocumentId: String)
+
+/**
+ * The roots worth listing: duplicates collapsed, and any root that lies inside
+ * another dropped, so a book under two granted trees is offered once.
+ *
+ * [isDescendant] is the provider's own answer and is asked **only** about two
+ * roots of one authority — a folder on Drive cannot be inside a folder on device
+ * storage whatever their strings say, and `DocumentsContract.isChildDocument`
+ * throws when asked across authorities. It may return null where the provider
+ * cannot say, and then [documentIdContains] decides.
+ *
+ * The rule **fails open**: anything unknown keeps both roots. Listing a book
+ * twice is a small harm; the alternative, which is what comparing invented paths
+ * did, is the whole device library disappearing from Browse.
+ */
+internal fun rootsToList(
+    roots: List<SafRoot>,
+    isDescendant: (parent: SafRoot, child: SafRoot) -> Boolean?
+): List<SafRoot> {
+    val unique = roots.distinct()
+    if (unique.size < 2) return unique
+
+    // Each ordered pair is asked at most once: an answer can be a round trip to a
+    // provider that is not on this device.
+    val answers = mutableMapOf<Pair<SafRoot, SafRoot>, Boolean>()
+    fun contains(parent: SafRoot, child: SafRoot): Boolean =
+        answers.getOrPut(parent to child) {
+            if (parent.authority != child.authority) false
+            else isDescendant(parent, child)
+                ?: documentIdContains(parent.treeDocumentId, child.treeDocumentId)
+        }
+
+    return unique.filter { child ->
+        unique.none { parent ->
+            // A pair that claims to contain one another cannot be resolved into a
+            // parent and a child, and dropping both would empty the list — the
+            // very failure this function exists to prevent.
+            parent != child && contains(parent, child) && !contains(child, parent)
+        }
+    }
+}
+
+/**
+ * Whether [childId] names something under [parentId] by the structure of the ids
+ * themselves.
+ *
+ * This is the fallback for a provider that will not answer `isChildDocument`, and
+ * it is safe because it reads the provider's own id rather than a fabricated
+ * path: `externalstorage` composes ids hierarchically (`primary:Download` holds
+ * `primary:Download/books_story`), while an opaque id is never a prefix of
+ * another — every Drive child observed reported the tree's id as no prefix of its
+ * own.
+ *
+ * Compared exactly, not case-insensitively: an id is opaque, and only its issuer
+ * knows whether two spellings mean one document.
+ */
+internal fun documentIdContains(parentId: String, childId: String): Boolean {
+    if (parentId.isEmpty() || childId.length <= parentId.length) return false
+    if (!childId.startsWith(parentId)) return false
+
+    // A boundary, so that `primary:Download` does not claim `primary:DownloadOld`.
+    // A root id ending in ':' is a whole volume, whose children follow immediately.
+    return childId[parentId.length] == '/' || parentId.endsWith(':')
 }

--- a/app/src/test/java/ua/acclorite/book_story/data/service/RootsToListTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/data/service/RootsToListTest.kt
@@ -1,0 +1,206 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Which granted trees Browse lists. The provider answers whether one holds
+ * another; this is everything decided around that answer, and it is where the
+ * mistakes live — the previous rule compared invented paths and made the device
+ * library disappear.
+ */
+class RootsToListTest {
+
+    private val device = SafRoot("com.android.externalstorage.documents", "primary:Download")
+    private val deviceBooks =
+        SafRoot("com.android.externalstorage.documents", "primary:Download/books_story")
+    private val driveBooks = SafRoot("com.google.android.apps.docs.storage", "acc=1;doc=books")
+    private val driveFiction =
+        SafRoot("com.google.android.apps.docs.storage", "acc=1;doc=fiction")
+
+    /** Nobody holds anybody: the provider is sure, and says no. */
+    private val nothingNested: (SafRoot, SafRoot) -> Boolean? = { _, _ -> false }
+
+    /** The provider will not answer at all. */
+    private val silent: (SafRoot, SafRoot) -> Boolean? = { _, _ -> null }
+
+    private fun answering(vararg pairs: Pair<SafRoot, SafRoot>): (SafRoot, SafRoot) -> Boolean? =
+        { parent, child -> pairs.any { it.first == parent && it.second == child } }
+
+    @Test
+    fun `unrelated roots are all listed`() {
+        assertEquals(
+            listOf(device, driveBooks),
+            rootsToList(listOf(device, driveBooks), nothingNested)
+        )
+    }
+
+    @Test
+    fun `a root inside another is dropped`() {
+        assertEquals(
+            listOf(driveBooks),
+            rootsToList(
+                listOf(driveBooks, driveFiction),
+                answering(driveBooks to driveFiction)
+            )
+        )
+    }
+
+    @Test
+    fun `the parent survives whichever order the roots arrive in`() {
+        assertEquals(
+            listOf(driveBooks),
+            rootsToList(
+                listOf(driveFiction, driveBooks),
+                answering(driveBooks to driveFiction)
+            )
+        )
+    }
+
+    /**
+     * The defect this replaces: Drive reports "/storage" for both of its folders
+     * and the real library lives at "/storage/emulated/0/...", so a prefix test
+     * dropped the library. Identity by document id cannot express that mistake —
+     * and the predicate is never even asked across authorities, since
+     * `isChildDocument` throws there.
+     */
+    @Test
+    fun `a root of another authority is never dropped, and never asked about`() {
+        var askedAcrossAuthorities = false
+        val result = rootsToList(listOf(driveBooks, deviceBooks)) { parent, child ->
+            if (parent.authority != child.authority) askedAcrossAuthorities = true
+            true
+        }
+
+        assertEquals(listOf(driveBooks, deviceBooks), result)
+        assertFalse(askedAcrossAuthorities)
+    }
+
+    @Test
+    fun `the same tree granted twice is listed once`() {
+        assertEquals(
+            listOf(driveBooks),
+            rootsToList(listOf(driveBooks, driveBooks), nothingNested)
+        )
+    }
+
+    @Test
+    fun `a chain collapses to its outermost root`() {
+        val deeper =
+            SafRoot("com.android.externalstorage.documents", "primary:Download/books_story/tmp")
+        assertEquals(
+            listOf(device),
+            rootsToList(
+                listOf(device, deviceBooks, deeper),
+                answering(
+                    device to deviceBooks,
+                    device to deeper,
+                    deviceBooks to deeper
+                )
+            )
+        )
+    }
+
+    /**
+     * Fail open. A provider that will not answer must not be able to empty the
+     * list: a book listed twice is a nuisance, a library that vanished is the bug.
+     */
+    @Test
+    fun `an unanswerable pair keeps both roots`() {
+        assertEquals(
+            listOf(driveBooks, driveFiction),
+            rootsToList(listOf(driveBooks, driveFiction), silent)
+        )
+    }
+
+    /** Two roots that each claim to hold the other cannot both be dropped. */
+    @Test
+    fun `mutual containment keeps both roots`() {
+        assertEquals(
+            listOf(driveBooks, driveFiction),
+            rootsToList(
+                listOf(driveBooks, driveFiction),
+                answering(driveBooks to driveFiction, driveFiction to driveBooks)
+            )
+        )
+    }
+
+    /** Silence falls back to the ids, which for this provider are paths. */
+    @Test
+    fun `a silent provider still nests hierarchical ids`() {
+        assertEquals(
+            listOf(device),
+            rootsToList(listOf(device, deviceBooks), silent)
+        )
+    }
+
+    @Test
+    fun `a silent provider does not nest opaque ids`() {
+        assertEquals(
+            listOf(driveBooks, driveFiction),
+            rootsToList(listOf(driveBooks, driveFiction), silent)
+        )
+    }
+
+    @Test
+    fun `each ordered pair is asked at most once`() {
+        val asked = mutableListOf<Pair<SafRoot, SafRoot>>()
+        rootsToList(listOf(driveBooks, driveFiction)) { parent, child ->
+            asked.add(parent to child)
+            false
+        }
+
+        assertEquals(asked.size, asked.distinct().size)
+    }
+
+    @Test
+    fun `one root needs no question at all`() {
+        var asked = false
+        val result = rootsToList(listOf(driveBooks)) { _, _ ->
+            asked = true
+            true
+        }
+
+        assertEquals(listOf(driveBooks), result)
+        assertFalse(asked)
+    }
+
+    @Test
+    fun `no roots is no list`() {
+        assertEquals(emptyList<SafRoot>(), rootsToList(emptyList(), nothingNested))
+    }
+
+    @Test
+    fun `document ids nest only on a segment boundary`() {
+        assertTrue(documentIdContains("primary:Download", "primary:Download/books_story"))
+        assertFalse(documentIdContains("primary:Download", "primary:DownloadOld"))
+        assertFalse(documentIdContains("primary:Download", "primary:Download"))
+        assertFalse(documentIdContains("primary:Download/books_story", "primary:Download"))
+    }
+
+    /** A whole volume holds everything on it, and its children follow the colon. */
+    @Test
+    fun `a volume root holds its top-level entries`() {
+        assertTrue(documentIdContains("primary:", "primary:Download"))
+    }
+
+    @Test
+    fun `an empty parent id holds nothing`() {
+        assertFalse(documentIdContains("", "primary:Download"))
+    }
+
+    /** An id is opaque; only its issuer knows whether two spellings are one thing. */
+    @Test
+    fun `document ids are compared exactly`() {
+        assertFalse(documentIdContains("primary:download", "primary:Download/books"))
+    }
+}


### PR DESCRIPTION
Closes #81. Part of #49.

`getStorageFiles` decided which granted trees Browse lists by comparing
`getAbsolutePath` strings with `startsWith`. Those are synthesised for any
provider that is not `externalstorage`, and Drive answers `/storage` for every
folder it hosts, so the rule failed in both directions at once — the device
library was dropped as "nested" inside a Drive folder, while two Drive folders
that really were parent and child both survived and every book in the child was
listed twice.

A tree is now identified by `authority` + tree document id — unique within a
provider and durable, since the grants are issued against them — and nesting is
asked of `DocumentsContract.isChildDocument`, only ever about two trees of one
authority. Across authorities the question is meaningless and the call throws.

**Fails open.** Where the provider will not answer, the structure of its own ids
decides (`externalstorage` composes them hierarchically; an opaque id is never a
prefix of another). Where that says nothing either, both trees are kept: a book
listed twice is a nuisance, a library that disappeared is the bug. `isChildDocument`
is API 29+ against `minSdk` 26, so below that the ids decide alone.

The rule is a pure function, JVM-tested next to `pathSegmentsUnder` (17 cases),
and memoised against the current set of grants — Browse re-reads its list on
every refresh and each pair can be a network round trip.

## Device QA

Tablet, device folder + Drive `books` + Drive `fiction` (a subfolder of `books`)
all granted:

| | before | after |
|---|---|---|
| device library in Browse | **gone** | listed |
| `nhk-ni-youkoso-ranobe-v1.fb2`, held only by `fiction` | listed **twice** (`/storage/fiction` and `/storage`) | once |
| opening a book stored on Drive | works | works (`cache HIT`, 1081 ms) |

306 tests, lint clean.

## Not here

`FileSystemRepositoryImpl.isValid` decides "already imported" by comparing the
same composed paths and is broken by the same cause. It cannot be fixed honestly
until a book row carries a document id — the identity work still open in #49.
