### PR TITLE
Let a book's identity follow its path, so changing the path changes the book

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/data/repository/BookIdentityRule.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/BookIdentityRule.kt
@@ -1,0 +1,46 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.repository
+
+/** Where a book is, and what the provider holding it calls it. */
+internal data class BookIdentity(
+    val filePath: String,
+    val documentAuthority: String? = null,
+    val documentId: String? = null
+)
+
+/**
+ * The identity to store for a book being updated.
+ *
+ * The identity belongs to the **location**, and every rule here follows from
+ * that one sentence:
+ *
+ * - a path that changed describes somewhere else, so no identity of the old
+ *   place survives it — this is what re-pointing a book by hand does, and what
+ *   keeping a previewed book as a copy of its file does;
+ * - a caller that carries an identity is stating one, and it is written;
+ * - a caller that carries none is not saying the book has none. It is holding a
+ *   copy loaded before the identity was learned, which is what the reader holds
+ *   on the very open that learned it, so what is stored stays.
+ *
+ * Only the first of those was wrong, and it was wrong in the direction where
+ * nothing fails loudly: the path moved, the old id outlived it, and the book
+ * went on opening the file it had always opened.
+ */
+internal fun identityToWrite(incoming: BookIdentity, stored: BookIdentity?): BookIdentity = when {
+    stored == null -> incoming
+    stored.filePath != incoming.filePath -> incoming.copy(
+        documentAuthority = null,
+        documentId = null
+    )
+    incoming.documentId != null -> incoming
+    else -> incoming.copy(
+        documentAuthority = stored.documentAuthority,
+        documentId = stored.documentId
+    )
+}

--- a/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/repository/BookRepositoryImpl.kt
@@ -446,27 +446,29 @@ class BookRepositoryImpl @Inject constructor(
     }
 
     /**
-     * The row to write, with the document identity the resolver learned rather
-     * than the one the caller is holding.
+     * The row to write, with the document identity that belongs to it rather
+     * than the one the caller happens to be holding.
      *
      * Every screen updates a book by writing the whole row back from a [Book] it
-     * loaded earlier — the reader on leaving, the info screen on any edit — and
-     * that copy predates the identity being written, so a plain update would
-     * erase it on the very open that learned it. The identity is not the
-     * caller's to state: it belongs to the location, and it is dropped exactly
-     * when that changes, which is what the path dialog does and what keeping a
-     * book by copying its file does.
+     * loaded earlier, and those copies disagree about the identity: the reader's
+     * predates the open that learned it, the info screen's is current. The rule
+     * cannot be about which of them is talking, so [identityToWrite] states it
+     * about the book instead.
      */
     private suspend fun withStoredIdentity(book: Book): BookEntity {
         val entity = bookMapper.toBookEntity(book)
-        if (book.documentId != null) return entity
+        val stored = database.bookDao.findBookById(book.id)
 
-        val stored = database.bookDao.findBookById(book.id) ?: return entity
-        if (stored.documentId == null || stored.filePath != book.filePath) return entity
+        val identity = identityToWrite(
+            incoming = BookIdentity(book.filePath, book.documentAuthority, book.documentId),
+            stored = stored?.let {
+                BookIdentity(it.filePath, it.documentAuthority, it.documentId)
+            }
+        )
 
         return entity.copy(
-            documentAuthority = stored.documentAuthority,
-            documentId = stored.documentId
+            documentAuthority = identity.documentAuthority,
+            documentId = identity.documentId
         )
     }
 

--- a/app/src/test/java/ua/acclorite/book_story/data/repository/BookIdentityRuleTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/data/repository/BookIdentityRuleTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Which document identity a book keeps when its row is written.
+ *
+ * Every screen writes the whole row back from a copy it loaded earlier, and
+ * those copies disagree about the identity, so the rule has to be about the
+ * book rather than about who is talking. Both ways of getting it wrong are
+ * silent: erase the identity and the book resolves the slow way forever, keep a
+ * stale one and it opens a file the user has moved away from.
+ */
+class BookIdentityRuleTest {
+
+    private val drive = "com.google.android.apps.docs.storage"
+    private val path = "/storage/emulated/0/Books/solaris.fb2"
+
+    private val identified = BookIdentity(path, drive, "acc=1;doc=A")
+    private val unidentified = BookIdentity(path)
+
+    @Test
+    fun `a caller holding no identity does not erase the stored one`() {
+        // The reader, leaving a book on the very open that learned its identity.
+        val result = identityToWrite(incoming = unidentified, stored = identified)
+
+        assertEquals(drive, result.documentAuthority)
+        assertEquals("acc=1;doc=A", result.documentId)
+    }
+
+    @Test
+    fun `a caller holding an identity states it`() {
+        val result = identityToWrite(
+            incoming = BookIdentity(path, drive, "acc=1;doc=NEW"),
+            stored = identified
+        )
+
+        assertEquals("acc=1;doc=NEW", result.documentId)
+    }
+
+    /**
+     * The defect this fixes. Book info holds a copy loaded after the identity
+     * was written, so it carries one — and a rule about the caller kept it,
+     * leaving the row with a new path and an id describing the old place. The
+     * book went on opening the file it had always opened.
+     */
+    @Test
+    fun `a path that changed drops the identity, whatever the caller carries`() {
+        val moved = identified.copy(filePath = "/storage/emulated/0/Download/solaris.fb2")
+        val result = identityToWrite(incoming = moved, stored = identified)
+
+        assertNull(result.documentAuthority)
+        assertNull(result.documentId)
+    }
+
+    @Test
+    fun `a path that changed drops the identity when the caller carries none`() {
+        // Keeping a previewed book by copying its file: the copy is the location
+        // now, and the id belonged to the provider it came from.
+        val stored = BookIdentity("/storage/emulated/0/Download/solaris.fb2", drive, "acc=1;doc=A")
+        val result = identityToWrite(
+            incoming = BookIdentity("/data/user/0/…/owned_books/7/solaris.fb2"),
+            stored = stored
+        )
+
+        assertNull(result.documentAuthority)
+        assertNull(result.documentId)
+    }
+
+    @Test
+    fun `the path is what is written, in every case`() {
+        val moved = identified.copy(filePath = "/elsewhere/solaris.fb2")
+
+        assertEquals("/elsewhere/solaris.fb2", identityToWrite(moved, identified).filePath)
+        assertEquals(path, identityToWrite(unidentified, identified).filePath)
+    }
+
+    @Test
+    fun `a book with no row yet keeps what it came with`() {
+        assertEquals(identified, identityToWrite(incoming = identified, stored = null))
+        assertNull(identityToWrite(incoming = unidentified, stored = null).documentId)
+    }
+
+    @Test
+    fun `neither side having an identity leaves none`() {
+        assertNull(identityToWrite(incoming = unidentified, stored = unidentified).documentId)
+    }
+
+    /** An authority without an id is not an identity, and does not travel alone. */
+    @Test
+    fun `the authority follows the id it belongs to`() {
+        val result = identityToWrite(incoming = unidentified, stored = identified)
+
+        assertEquals(result.documentAuthority != null, result.documentId != null)
+    }
+}


### PR DESCRIPTION
Closes #85. Regression from #83 / PR #84.

Editing a book's path did nothing. The row took the new path and kept the old
document id, and the id is tried before the path, so the book went on opening
the file it had always opened.

#83 stated the rule as *the identity belongs to the location, so it is dropped
when the location changes* and then implemented it as a condition on the
**caller**:

```kotlin
if (book.documentId != null) return entity
```

That holds for the reader, which updates a book it loaded before the identity
was written and so carries none. Book info loads the book after, carries one,
and walked straight past it.

The condition is about the location now. The identity survives an ordinary
update, is written when a caller has one of its own to state, and is dropped
whenever the path moves — by the path dialog, and by keeping a previewed book as
a copy of its file, which is the other place a path changes.

`identityToWrite` is a pure function in a file of its own, 8 cases on the JVM.
It has been got wrong once already, in the direction where nothing fails loudly;
that is the argument for testing the rule rather than the three callers that
happen to exercise it.

## Device QA

Against the Drive-hosted book, on the tablet:

| | before | after |
|---|---|---|
| append `.test` to the path | id kept — the old file still opens | `documentAuthority`/`documentId` → NULL |
| remove the suffix again | — | resolved, and the open learned the same `acc=1;doc=encoded=cNCUD6…` back |

318 tests, lint clean.

Part of #49.
