### PR TITLE
Name the setup guide, and let it be left

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/presentation/navigator/Navigator.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/navigator/Navigator.kt
@@ -41,6 +41,14 @@ class Navigator @AssistedInject constructor(
         initialValue = initialScreen
     )
 
+    /**
+     * Whether anything is under the current screen — i.e. whether [pop] would
+     * do something. A screen that can be reached both as the app's first one
+     * and from somewhere else asks this to know which of the two it is.
+     */
+    val canPop: Boolean
+        get() = items.value.count() > 1
+
     val lastEvent = savedStateHandle.getStateFlow("stack_event", StackEvent.DEFAULT)
     private fun changeStackEvent(stackEvent: StackEvent) {
         savedStateHandle["stack_event"] = stackEvent

--- a/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/settings/SettingsScreen.kt
@@ -14,7 +14,6 @@ import kotlinx.parcelize.Parcelize
 import ua.acclorite.book_story.presentation.navigator.Screen
 import ua.acclorite.book_story.presentation.start.StartScreen
 import ua.acclorite.book_story.ui.common.components.top_bar.collapsibleTopAppBarScrollBehavior
-import ua.acclorite.book_story.ui.common.helpers.LocalSettings
 import ua.acclorite.book_story.ui.navigator.LocalNavigator
 import ua.acclorite.book_story.ui.settings.SettingsContent
 
@@ -25,7 +24,6 @@ object SettingsScreen : Screen, Parcelable {
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.current
-        val settings = LocalSettings.current
         val (scrollBehavior, listState) = TopAppBarDefaults.collapsibleTopAppBarScrollBehavior()
 
         SettingsContent(
@@ -47,8 +45,12 @@ object SettingsScreen : Screen, Parcelable {
                 navigator.push(BrowseSettingsScreen)
             },
             navigateToStart = {
-                settings.showStartScreen.update(true)
-                navigator.push(StartScreen, saveInBackStack = false)
+                // Kept in the back stack, and [showStartScreen] deliberately not
+                // raised: this is a guide the reader asked to see again, not an
+                // app that has yet to be set up. Marking it unconfigured made
+                // every later launch open the guide until it was walked to its
+                // end, and dropping Settings from the stack left no way back.
+                navigator.push(StartScreen)
             },
             navigateBack = {
                 navigator.pop()

--- a/app/src/main/java/ua/acclorite/book_story/presentation/start/StartScreen.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/start/StartScreen.kt
@@ -81,19 +81,31 @@ object StartScreen : Screen, Parcelable {
             },
             navigateBack = {
                 if ((currentPage.intValue - 1) < 0) {
-                    activity.finish()
+                    // Leaving the first page leaves the guide. That is leaving
+                    // the app only when the guide *is* the app's first screen;
+                    // asked for again from Settings, it has Settings under it.
+                    if (navigator.canPop) navigator.pop() else activity.finish()
                 } else {
                     stackEvent.value = StackEvent.POP
                     currentPage.intValue -= 1
                 }
             },
             navigateToBrowse = {
-                navigator.push(
-                    BrowseScreen,
-                    saveInBackStack = false
-                )
-                BrowseScreen.refreshListChannel.trySend(Unit)
                 settings.showStartScreen.update(false)
+                BrowseScreen.refreshListChannel.trySend(Unit)
+
+                // The scan settings the guide just showed are Browse's, so the
+                // list is refreshed either way; where "Done" lands is not the
+                // same question. A first run has nowhere to go back to and
+                // opens the app proper; a re-run returns to Settings.
+                if (navigator.canPop) {
+                    navigator.pop()
+                } else {
+                    navigator.push(
+                        BrowseScreen,
+                        saveInBackStack = false
+                    )
+                }
             }
         )
     }

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/SettingsLayout.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/SettingsLayout.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.outlined.DisplaySettings
 import androidx.compose.material.icons.outlined.Explore
 import androidx.compose.material.icons.outlined.LocalLibrary
 import androidx.compose.material.icons.outlined.Palette
+import androidx.compose.material.icons.outlined.RestartAlt
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -31,7 +32,8 @@ fun SettingsLayout(
     navigateToAppearanceSettings: () -> Unit,
     navigateToReaderSettings: () -> Unit,
     navigateToLibrarySettings: () -> Unit,
-    navigateToBrowseSettings: () -> Unit
+    navigateToBrowseSettings: () -> Unit,
+    navigateToStart: () -> Unit
 ) {
     LazyColumnWithScrollbar(
         Modifier
@@ -92,6 +94,17 @@ fun SettingsLayout(
                 description = stringResource(id = R.string.browse_settings_desc)
             ) {
                 navigateToBrowseSettings()
+            }
+        }
+
+        item {
+            SettingsLayoutItem(
+                index = 5,
+                icon = Icons.Outlined.RestartAlt,
+                title = stringResource(id = R.string.start_guide_settings),
+                description = stringResource(id = R.string.start_guide_settings_desc)
+            ) {
+                navigateToStart()
             }
         }
     }

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/SettingsScaffold.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/SettingsScaffold.kt
@@ -41,7 +41,6 @@ fun SettingsScaffold(
         topBar = {
             SettingsTopBar(
                 scrollBehavior = scrollBehavior,
-                navigateToStart = navigateToStart,
                 navigateBack = navigateBack
             )
         }
@@ -53,7 +52,8 @@ fun SettingsScaffold(
             navigateToAppearanceSettings = navigateToAppearanceSettings,
             navigateToReaderSettings = navigateToReaderSettings,
             navigateToLibrarySettings = navigateToLibrarySettings,
-            navigateToBrowseSettings = navigateToBrowseSettings
+            navigateToBrowseSettings = navigateToBrowseSettings,
+            navigateToStart = navigateToStart
         )
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/SettingsTopBar.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/SettingsTopBar.kt
@@ -6,8 +6,6 @@
 
 package ua.acclorite.book_story.ui.settings
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.RestartAlt
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
@@ -16,7 +14,6 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import ua.acclorite.book_story.R
-import ua.acclorite.book_story.ui.common.components.common.IconButton
 import ua.acclorite.book_story.ui.common.components.common.StyledText
 import ua.acclorite.book_story.ui.navigator.NavigatorBackIconButton
 
@@ -24,7 +21,6 @@ import ua.acclorite.book_story.ui.navigator.NavigatorBackIconButton
 @Composable
 fun SettingsTopBar(
     scrollBehavior: TopAppBarScrollBehavior,
-    navigateToStart: () -> Unit,
     navigateBack: () -> Unit
 ) {
     LargeTopAppBar(
@@ -35,15 +31,6 @@ fun SettingsTopBar(
             NavigatorBackIconButton(
                 navigateBack = navigateBack
             )
-        },
-        actions = {
-            IconButton(
-                icon = Icons.Outlined.RestartAlt,
-                contentDescription = R.string.reset_start_content_desc,
-                disableOnClick = false
-            ) {
-                navigateToStart()
-            }
         },
         scrollBehavior = scrollBehavior,
         colors = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -286,7 +286,6 @@
     <string name="title_changed">نجح تغيير العنوان.</string>
     <string name="highlighted_reading_level">المستوى</string>
     <string name="filter_content_desc">تصفية</string>
-    <string name="reset_start_content_desc">إعادة تعيين دليل البدء</string>
     <string name="tryzub_badge">Tryzub</string>
     <string name="start_language_preferences">تفضيلات اللغة</string>
     <string name="file_icon_content_desc">الملف</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -334,7 +334,6 @@
     <string name="revert_content_desc">Vrátit</string>
     <string name="delete_history_element_content_desc">Odstranit prvek historie</string>
     <string name="arrow_content_desc">Šipka</string>
-    <string name="reset_start_content_desc">Resetovat průvodce spuštěním</string>
     <string name="delete_color_preset_content_desc">Odstranit předvolbu barvy</string>
     <string name="create_color_preset_content_desc">Vytvořit nové přednastavení barev</string>
     <string name="shuffle_color_preset_content_desc">Míchání barev</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -159,7 +159,6 @@
     <string name="history_content_desc">Leseverlauf</string>
     <string name="browse_content_desc">Bücher hinzufügen</string>
     <string name="arrow_content_desc">Pfeil</string>
-    <string name="reset_start_content_desc">Startanleitung zurücksetzen</string>
     <string name="open_in_web_content_desc">Im Internet öffnen</string>
     <string name="delete_color_preset_content_desc">Farbvoreinstellung löschen</string>
     <string name="create_color_preset_content_desc">Neue Farbvorgabe erstellen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -162,7 +162,6 @@
     <string name="history_content_desc">Historial de lectura</string>
     <string name="revert_content_desc">Revertir</string>
     <string name="checkbox_content_desc">Casilla de verificación</string>
-    <string name="reset_start_content_desc">Restablecer la guía de inicio</string>
     <string name="delete_color_preset_content_desc">Borrar color predefinido</string>
     <string name="create_color_preset_content_desc">Crear un nuevo color predeterminado</string>
     <string name="tryzub_badge">Tryzub</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -158,7 +158,6 @@
     <string name="library_content_desc">Votre librairie</string>
     <string name="browse_content_desc">Ajouter les livres</string>
     <string name="arrow_content_desc">Flèche</string>
-    <string name="reset_start_content_desc">Guide de réinitialisation</string>
     <string name="open_in_web_content_desc">Ouvrir en ligne</string>
     <string name="delete_color_preset_content_desc">Supprimer le préréglage de couleur</string>
     <string name="shuffle_color_preset_content_desc">Mélanger les couleurs</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -234,7 +234,6 @@
     <string name="start_done_desc">Hai completato con successo le impostazioni di base dell\'app. Vuoi imparare a usare l\'app leggendo la schermata di Aiuto?</string>
     <string name="add_files_content_desc">Aggiungi file</string>
     <string name="library_content_desc">La tua libreria</string>
-    <string name="reset_start_content_desc">Ripristina la guida all\'avvio</string>
     <string name="cover_reset">L\'immagine di copertina è stata reimpostata correttamente.</string>
     <string name="credits_ideas">Idea</string>
     <string name="contributors_option">Contributori</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -148,7 +148,6 @@
     <string name="credits_contribution">Wnieśli wkład</string>
     <string name="yesterday">Wczoraj</string>
     <string name="selected_content_desc">Wybrane</string>
-    <string name="reset_start_content_desc">Zresetuj przewodnik startu</string>
     <string name="theme_contrast_high">Wysoki</string>
     <string name="cover_image_changed">Obraz okładki został pomyślnie zmieniony.</string>
     <string name="book_moved">Ta książka została pomyślnie przeniesiona.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -255,7 +255,6 @@
     <string name="color_effects_background">Cor do fundo</string>
     <string name="purple_gray_theme">Ceres</string>
     <string name="book_deleted">Esse livro foi apagado com sucesso.</string>
-    <string name="reset_start_content_desc">Redefinir guia de introdução</string>
     <string name="progress_bar_font_size_option">Tamanho da fonte</string>
     <string name="select_all_files_content_desc">Selecionar todos os arquivos</string>
     <string name="create_color_preset_content_desc">Criar novo padrão de cores</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -53,7 +53,6 @@
     <string name="checkbox_content_desc">தேர்வுப்பெட்டி</string>
     <string name="library_content_desc">உங்கள் நூலகம்</string>
     <string name="delete_history_element_content_desc">வரலாற்று உறுப்பை நீக்கு</string>
-    <string name="reset_start_content_desc">தொடக்க வழிகாட்டியை மீட்டமைக்கவும்</string>
     <string name="reading_speed_reader_settings">வாசிப்பு விரைவு</string>
     <string name="system_reader_settings">மண்டலம்</string>
     <string name="language_option">பயன்பாட்டு மொழி</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -354,7 +354,6 @@
     <string name="history_content_desc">Okuma geçmişi</string>
     <string name="browse_content_desc">Kitap ekle</string>
     <string name="arrow_content_desc">Ok</string>
-    <string name="reset_start_content_desc">Başlangıç rehberini sıfırla</string>
     <string name="open_in_web_content_desc">Web\'de aç</string>
     <string name="delete_color_preset_content_desc">Renk ön ayarını sil</string>
     <string name="create_color_preset_content_desc">Yeni renk ön ayarı oluştur</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -452,7 +452,6 @@
     <string name="history_content_desc">Історія читання</string>
     <string name="browse_content_desc">Додавайте книги</string>
     <string name="arrow_content_desc">Стрілка</string>
-    <string name="reset_start_content_desc">Скинути початковий посібник</string>
     <string name="open_in_web_content_desc">Відкрити в браузері</string>
     <string name="delete_color_preset_content_desc">Видалити пресет кольорів</string>
     <string name="create_color_preset_content_desc">Створити новий пресет кольорів</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -228,7 +228,6 @@
     <string name="history_content_desc">阅读历史</string>
     <string name="browse_content_desc">添加书籍</string>
     <string name="arrow_content_desc">箭头</string>
-    <string name="reset_start_content_desc">重置引导页面</string>
     <string name="delete_books_content_desc">删除所选书籍</string>
     <string name="revert_content_desc">撤销</string>
     <string name="file_icon_content_desc">文件</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,6 +195,8 @@
     <string name="reader_settings_desc">Font, text</string>
     <string name="browse_settings">Browse</string>
     <string name="browse_settings_desc">Scan, display</string>
+    <string name="start_guide_settings">Setup guide</string>
+    <string name="start_guide_settings_desc">Proceed through the initial setup again</string>
     <string name="library_settings">Library</string>
     <string name="library_settings_desc">Categories, display, tabs</string>
 
@@ -599,7 +601,6 @@
     <string name="history_content_desc">Reading history</string>
     <string name="browse_content_desc">Add books</string>
     <string name="arrow_content_desc">Arrow</string>
-    <string name="reset_start_content_desc">Reset start guide</string>
     <string name="open_in_web_content_desc">Open in web</string>
     <string name="delete_color_preset_content_desc">Delete color preset</string>
     <string name="create_color_preset_content_desc">Create new color preset</string>


### PR DESCRIPTION
Closes #97.

The Settings top bar's only action was a bare `RestartAlt` icon that re-runs the first-run guide, and it was one reflex tap away in the corner where other screens keep something harmless. It already had a tooltip — which is the point: a tooltip answers a long press, and the tap that hit this button was short.

**It becomes a row.** Sixth in the Settings list, with the same `SettingsLayoutItem` as the five categories, named *Setup guide* and described as *Proceed through the initial setup again*. The old `reset_start_content_desc` goes with the button, translations included.

**And the door now opens both ways.** The re-run used to raise `showStartScreen` — the flag that says the app has yet to be set up — and push itself over Settings with `saveInBackStack = false`. Back on the guide's first page closed the app, the flag stayed raised until the final **Done**, so every launch until then reopened the guide, and finishing landed in Browse. A re-run now keeps Settings under it and leaves the flag alone; both exits ask `Navigator.canPop` which case they are in, so a first run still finishes the activity or opens Browse, and a re-run returns to Settings.

Worth recording: **the button never reset anything**. Measured before the change on the tablet — the tap wrote one byte (`guide` false → true) and a full pass through the guide left the settings file byte for byte identical. A confirmation dialog was considered and refused for that reason: it would have had to warn about the trap instead of removing it.

### QA on the tablet (TB128FU, debug build)

All four cases, with the settings store read through `run-as` at each step:

| Case | Result |
|---|---|
| First run, Back on page 1 | app closes, `guide` stays true — an unfinished setup still reappears |
| First run, **Done** | lands in Browse, `guide` false |
| Re-run from the row, Back | returns to **Settings**, app alive, `guide` false throughout |
| Re-run from the row, **Done** | returns to **Settings** |

Across the whole run exactly one byte of the settings store moved, and it was the `guide` flag being cleared.

350 unit tests green, `lintDebug` clean.
