### PR TITLE
Let the segmented button survive a narrow screen, and use it for the last four rows

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/ui/common/components/settings/ChipsWithTitle.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/common/components/settings/ChipsWithTitle.kt
@@ -39,25 +39,44 @@ fun <T> ChipsWithTitle(
         SettingsSubcategoryTitle(title = title, padding = 0.dp)
         Spacer(modifier = Modifier.height(8.dp))
 
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-            content = {
-                chips.forEach { item ->
-                    FilterChip(
-                        modifier = Modifier.height(36.dp),
-                        selected = item.selected,
-                        label = {
-                            StyledText(
-                                text = item.title,
-                                style = item.textStyle(),
-                                maxLines = 1
-                            )
-                        },
-                        onClick = { onClick(item.item) },
-                    )
-                }
-            }
-        )
+        ChipsFlow(chips = chips, onClick = onClick)
     }
+}
+
+/**
+ * The chips themselves, without the title, so that
+ * [SegmentedButtonWithTitle] can fall back to them when its own row does not fit
+ * the screen. Wrapping is the whole point of this shape: a chip that does not
+ * fit moves to the next line, where the segmented row would push it off the
+ * edge instead.
+ */
+@Composable
+internal fun <T> ChipsFlow(
+    modifier: Modifier = Modifier,
+    chips: List<ListItem<T>>,
+    enabled: Boolean = true,
+    onClick: (T) -> Unit
+) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        content = {
+            chips.forEach { item ->
+                FilterChip(
+                    modifier = Modifier.height(36.dp),
+                    selected = item.selected,
+                    enabled = enabled,
+                    label = {
+                        StyledText(
+                            text = item.title,
+                            style = item.textStyle(),
+                            maxLines = 1
+                        )
+                    },
+                    onClick = { onClick(item.item) },
+                )
+            }
+        }
+    )
 }

--- a/app/src/main/java/ua/acclorite/book_story/ui/common/components/settings/SegmentedButtonWithTitle.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/common/components/settings/SegmentedButtonWithTitle.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -38,7 +37,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import ua.acclorite.book_story.R
@@ -46,6 +47,13 @@ import ua.acclorite.book_story.ui.common.components.common.AnimatedVisibility
 import ua.acclorite.book_story.ui.common.components.common.StyledText
 import ua.acclorite.book_story.ui.common.model.ListItem
 import ua.acclorite.book_story.ui.settings.components.SettingsSubcategoryTitle
+
+/**
+ * What the tick in front of the selected button costs in width: the icon plus
+ * the gap after it. Exactly one button carries it at a time, so it is the whole
+ * difference between the widest and the narrowest state of the row.
+ */
+private val SELECTION_TICK_WIDTH = 18.dp + 8.dp
 
 @Composable
 fun <T> SegmentedButtonWithTitle(
@@ -66,40 +74,119 @@ fun <T> SegmentedButtonWithTitle(
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        LazyRow(Modifier.fillMaxWidth()) {
-            item {
-                Row(
-                    Modifier
-                        .clip(CircleShape)
-                        .border(
-                            width = 0.5.dp,
-                            color = SegmentedButtonDefaults.colors().activeBorderColor,
-                            shape = CircleShape
-                        )
-                        .padding(0.5.dp)
-                ) {
-                    buttons.forEachIndexed { index, item ->
-                        SegmentedButton(
-                            button = item,
-                            enabled = enabled,
-                            shape = when (index) {
-                                buttons.lastIndex -> RoundedCornerShape(
-                                    topEndPercent = 100,
-                                    bottomEndPercent = 100
-                                )
+        SegmentedButtonsOrChips(
+            buttons = buttons,
+            enabled = enabled,
+            onClick = onClick
+        )
+    }
+}
 
-                                0 -> RoundedCornerShape(
-                                    topStartPercent = 100,
-                                    bottomStartPercent = 100
-                                )
+/**
+ * The segmented row where it fits, the chips where it does not.
+ *
+ * The row is laid out at the natural width of its labels, and that width is not
+ * a property of the setting but of the translation and the reader's font scale:
+ * the four alignment options fit English with 5 dp to spare, and neither German
+ * nor Ukrainian. What used to happen then was the worst of the options — the row
+ * scrolled, with nothing to say so, and what fell off the right edge could be
+ * the selected value itself, leaving a setting that reads as if nothing were
+ * chosen. Chips wrap instead, which is the one thing a row of fixed height
+ * cannot do.
+ *
+ * The fit is measured with **no button selected, plus the width of the tick**,
+ * rather than as the row currently stands. Measuring the current state would
+ * make the decision depend on which label happens to be selected, and a settings
+ * row that turns into chips because you tapped a longer option — and back when
+ * you tap a shorter one — is worse than the overflow it fixes.
+ */
+@Composable
+private fun <T> SegmentedButtonsOrChips(
+    buttons: List<ListItem<T>>,
+    enabled: Boolean,
+    onClick: (T) -> Unit
+) {
+    val unselected = buttons.map { it.copy(selected = false) }
 
-                                else -> RoundedCornerShape(0)
-                            },
-                            onClick = { onClick(item.item) }
-                        )
-                    }
-                }
+    SubcomposeLayout(Modifier.fillMaxWidth()) { constraints ->
+        val widest = subcompose(SlotId.Measure) {
+            SegmentedButtons(buttons = unselected, enabled = enabled, onClick = {})
+        }.first().measure(Constraints()).width + SELECTION_TICK_WIDTH.roundToPx()
+
+        val fits = widest <= constraints.maxWidth
+
+        // `minWidth` is dropped on the way down: the row is as wide as its
+        // buttons and no wider, and passing the incoming minimum on would
+        // stretch the pill across the whole line.
+        val content = subcompose(if (fits) SlotId.Buttons else SlotId.Chips) {
+            when (fits) {
+                true -> SegmentedButtons(
+                    buttons = buttons,
+                    enabled = enabled,
+                    onClick = onClick
+                )
+
+                false -> ChipsFlow(
+                    chips = buttons,
+                    enabled = enabled,
+                    onClick = onClick
+                )
             }
+        }.first().measure(constraints.copy(minWidth = 0))
+
+        // Reported back at the width that was asked for, even though the row
+        // is narrower: a node that reports less than the incoming minimum has
+        // its content centred, which would push the whole control off to the
+        // middle of the line. Placed relatively, so that a row narrower than
+        // the line still starts where the title does — the right edge in a
+        // right-to-left locale.
+        layout(content.width.coerceAtLeast(constraints.minWidth), content.height) {
+            content.placeRelative(0, 0)
+        }
+    }
+}
+
+/**
+ * The slots [SegmentedButtonsOrChips] subcomposes. [SlotId.Measure] is measured
+ * and never placed; it exists only to ask the row how wide it wants to be.
+ */
+private enum class SlotId { Measure, Buttons, Chips }
+
+@Composable
+private fun <T> SegmentedButtons(
+    buttons: List<ListItem<T>>,
+    enabled: Boolean,
+    onClick: (T) -> Unit
+) {
+    Row(
+        Modifier
+            .clip(CircleShape)
+            .border(
+                width = 0.5.dp,
+                color = SegmentedButtonDefaults.colors().activeBorderColor,
+                shape = CircleShape
+            )
+            .padding(0.5.dp)
+    ) {
+        buttons.forEachIndexed { index, item ->
+            SegmentedButton(
+                button = item,
+                enabled = enabled,
+                shape = when (index) {
+                    buttons.lastIndex -> RoundedCornerShape(
+                        topEndPercent = 100,
+                        bottomEndPercent = 100
+                    )
+
+                    0 -> RoundedCornerShape(
+                        topStartPercent = 100,
+                        bottomStartPercent = 100
+                    )
+
+                    else -> RoundedCornerShape(0)
+                },
+                onClick = { onClick(item.item) }
+            )
         }
     }
 }

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/library/display/components/LibraryTitlePositionOption.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/library/display/components/LibraryTitlePositionOption.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.res.stringResource
 import ua.acclorite.book_story.R
 import ua.acclorite.book_story.presentation.library.model.LibraryLayout
 import ua.acclorite.book_story.presentation.library.model.LibraryTitlePosition
-import ua.acclorite.book_story.ui.common.components.settings.ChipsWithTitle
+import ua.acclorite.book_story.ui.common.components.settings.SegmentedButtonWithTitle
 import ua.acclorite.book_story.ui.common.helpers.LocalSettings
 import ua.acclorite.book_story.ui.common.model.ListItem
 import ua.acclorite.book_story.ui.theme.ExpandingTransition
@@ -21,9 +21,9 @@ fun LibraryTitlePositionOption() {
     val settings = LocalSettings.current
 
     ExpandingTransition(visible = settings.libraryLayout.value == LibraryLayout.GRID) {
-        ChipsWithTitle(
+        SegmentedButtonWithTitle(
             title = stringResource(id = R.string.title_position_option),
-            chips = LibraryTitlePosition.entries.map { item ->
+            buttons = LibraryTitlePosition.entries.map { item ->
                 ListItem(
                     item = item,
                     title = stringResource(id = item.title),

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/reader/images/components/ImagesColorEffectsOption.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/reader/images/components/ImagesColorEffectsOption.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import ua.acclorite.book_story.R
 import ua.acclorite.book_story.presentation.reader.model.ReaderColorEffects
-import ua.acclorite.book_story.ui.common.components.settings.ChipsWithTitle
+import ua.acclorite.book_story.ui.common.components.settings.SegmentedButtonWithTitle
 import ua.acclorite.book_story.ui.common.helpers.LocalSettings
 import ua.acclorite.book_story.ui.common.model.ListItem
 import ua.acclorite.book_story.ui.theme.ExpandingTransition
@@ -20,9 +20,9 @@ fun ImagesColorEffectsOption() {
     val settings = LocalSettings.current
 
     ExpandingTransition(visible = settings.images.value) {
-        ChipsWithTitle(
+        SegmentedButtonWithTitle(
             title = stringResource(id = R.string.images_color_effects_option),
-            chips = ReaderColorEffects.entries.map { item ->
+            buttons = ReaderColorEffects.entries.map { item ->
                 ListItem(
                     item = item,
                     title = stringResource(id = item.title),

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/reader/reading_mode/components/HorizontalGestureOption.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/reader/reading_mode/components/HorizontalGestureOption.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import ua.acclorite.book_story.R
 import ua.acclorite.book_story.presentation.reader.model.ReaderHorizontalGesture
-import ua.acclorite.book_story.ui.common.components.settings.ChipsWithTitle
+import ua.acclorite.book_story.ui.common.components.settings.SegmentedButtonWithTitle
 import ua.acclorite.book_story.ui.common.helpers.LocalSettings
 import ua.acclorite.book_story.ui.common.model.ListItem
 
@@ -18,9 +18,9 @@ import ua.acclorite.book_story.ui.common.model.ListItem
 fun HorizontalGestureOption() {
     val settings = LocalSettings.current
 
-    ChipsWithTitle(
+    SegmentedButtonWithTitle(
         title = stringResource(id = R.string.horizontal_gesture_option),
-        chips = ReaderHorizontalGesture.entries.map { item ->
+        buttons = ReaderHorizontalGesture.entries.map { item ->
             ListItem(
                 item = item,
                 title = stringResource(id = item.title),

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/reader/reading_mode/components/TapPagingOption.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/reader/reading_mode/components/TapPagingOption.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import ua.acclorite.book_story.R
 import ua.acclorite.book_story.presentation.reader.model.ReaderTapPaging
-import ua.acclorite.book_story.ui.common.components.settings.ChipsWithTitle
+import ua.acclorite.book_story.ui.common.components.settings.SegmentedButtonWithTitle
 import ua.acclorite.book_story.ui.common.helpers.LocalSettings
 import ua.acclorite.book_story.ui.common.model.ListItem
 
@@ -19,9 +19,9 @@ import ua.acclorite.book_story.ui.common.model.ListItem
 fun TapPagingOption() {
     val settings = LocalSettings.current
 
-    ChipsWithTitle(
+    SegmentedButtonWithTitle(
         title = stringResource(id = R.string.tap_paging_option),
-        chips = ReaderTapPaging.entries.map { item ->
+        buttons = ReaderTapPaging.entries.map { item ->
             ListItem(
                 item = item,
                 title = stringResource(id = item.title),


### PR DESCRIPTION
Closes #99. Closes #102.

`SegmentedButtonWithTitle` laid its buttons out at the natural width of their labels inside a `LazyRow`, so a row too wide for the screen scrolled — with no fade, no indicator and no scroll to the selection. What fell off the right edge could be the selected value itself: on a 360 dp screen at `font_scale` 1.3, `Text alignment` in Ukrainian showed `Старт | Рівномірно | Центр` and no selection mark anywhere, so the setting read as if nothing were chosen.

**The width is a property of the translation and the reader's font scale, not of the setting.** The same four options fit English with 5 dp to spare and do not fit German. So the component now measures itself: `SubcomposeLayout` asks the row how wide it wants to be, and where that does not fit it renders the same options as the `ChipsWithTitle` `FlowRow`, which wraps. Both take `List<ListItem<T>>` and `onClick`, so no call site changes and no strings, enums or stored keys move.

**The fit is measured with no button selected, plus the width of the tick.** Measuring the row as it currently stands would make the decision depend on which label happens to be selected — and a settings row that turns into chips because you tapped a longer option, and back when you tap a shorter one, is worse than the overflow it fixes.

The chips themselves are factored out of `ChipsWithTitle` as `ChipsFlow` so the two components share one implementation; `ChipsWithTitle` keeps its signature and its behaviour, gaining only the `enabled` pass-through the segmented version already had.

**Two defects found on the device that neither the diff nor the tests show**, both from how the `SubcomposeLayout` reports and places its content:

- passing the incoming `constraints` straight down carries `minWidth == maxWidth`, which stretched the pill across the whole line instead of letting it hug its buttons;
- reporting a width *smaller* than the incoming minimum makes Compose centre the content, which moved the chips 91 px to the right — and once that was reported at full width, `place(0, 0)` pinned a narrow row to the physical left edge, which in Arabic is the wrong end of the line. It places relatively now.

### And then the four rows that were still chips (#102)

**Title position**, **Color effects**, **Horizontal gesture** and **Tap to turn page** each offer a small fixed set of values, and each was the odd row in its own screen: dark theme, text alignment, font style, library layout and progress count were already pills. In *Library → Display*, `Display mode` and `Title position` sit one under the other and looked like two different kinds of control.

This is safe to do now and was not before. `Ввімкнений (Інвертований)` alone needs more than a 360 dp line, so without the first commit these rows would have lost options on a phone; with it they fall back to the chips they used to be. The visible change is on wide screens, and on a narrow one they look as they always did.

Font family, app language, screen orientation, font thickness and parse cache size stay chips — long or unbounded lists, and not what a segmented button is for.

### QA on the tablet (TB128FU, debug build)

Driven to 360×640 dp with `wm size 1080x1920` + `wm density 480`, 324 dp of content width:

| Case | Result |
| --- | --- |
| `en`, `font_scale` 1.0 | `Text alignment` segmented, unchanged |
| `de`, `font_scale` 1.0 | chips, `Ende` wraps to a second line, all four visible |
| `uk`, `font_scale` 1.3 | chips, `Рівномірно` marked — the reported defect is gone |
| `ar` (RTL), `font_scale` 1.3 | segmented, pill hugs the right edge, caps on the correct ends |
| selection cycled on a row that only just fits | right edge did not move, no flip between the two forms |
| reader settings bottom sheet, `en`, `font_scale` 1.3 | chips, all four visible |
| tablet's native 800 dp | no visible change to any pre-existing row |
| the four new rows, native 800 dp | all segmented; `Display mode` and `Title position` now match |
| the four new rows, 360 dp, `font_scale` 1.3 | `Color effects` and Ukrainian `Horizontal gesture` fall back to chips; `Title position` and English `Tap to turn page` stay pills |

Unit tests and `lintDebug` green.
