### PR TITLE
Turn pages with the volume keys

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/data/settings/SettingsManager.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/settings/SettingsManager.kt
@@ -40,6 +40,7 @@ import ua.acclorite.book_story.presentation.reader.model.ReaderProgressCount
 import ua.acclorite.book_story.presentation.reader.model.ReaderScreenOrientation
 import ua.acclorite.book_story.presentation.reader.model.ReaderTapPaging
 import ua.acclorite.book_story.presentation.reader.model.ReaderTextAlignment
+import ua.acclorite.book_story.presentation.reader.model.ReaderVolumePaging
 import ua.acclorite.book_story.ui.reader.data.ReaderData
 import ua.acclorite.book_story.ui.reader.model.FontWithName
 import ua.acclorite.book_story.ui.theme.model.DarkTheme
@@ -253,6 +254,10 @@ class SettingsManager @Inject constructor(
         key = stringPreferencesKey("tap_paging"), default = ReaderTapPaging.OFF,
         serialize = { it.name }, deserialize = { ReaderTapPaging.valueOf(it) }
     )
+    val volumePaging = setting<ReaderVolumePaging, String>(
+        key = stringPreferencesKey("volume_paging"), default = ReaderVolumePaging.OFF,
+        serialize = { it.name }, deserialize = { ReaderVolumePaging.valueOf(it) }
+    )
     /**
      * Lines of the page just read that stay on screen after a turn, which is
      * what decides the step: a screenful, less these. Chosen in halves, because
@@ -293,12 +298,14 @@ class SettingsManager @Inject constructor(
 
     /**
      * Whether anything can turn a page. The step and the animation belong to the
-     * turn itself rather than to the gesture that asked for it, so either
-     * trigger being on is enough for their settings to matter.
+     * turn itself rather than to the trigger that asked for it, so any one of
+     * the three being on is enough for their settings to matter — and the third
+     * is not a gesture at all, which is exactly why it is easy to forget here.
      */
     val pageTurnEnabled: Boolean
         @Composable get() = horizontalGesture.value != ReaderHorizontalGesture.OFF ||
-                tapPaging.value != ReaderTapPaging.OFF
+                tapPaging.value != ReaderTapPaging.OFF ||
+                volumePaging.value != ReaderVolumePaging.OFF
     val bottomBarPadding = setting<Int, Int>(
         key = intPreferencesKey("bottom_bar_padding"), default = 0
     )

--- a/app/src/main/java/ua/acclorite/book_story/presentation/main/MainActivity.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/main/MainActivity.kt
@@ -13,6 +13,7 @@ import android.content.Intent
 import android.database.CursorWindow
 import android.os.Bundle
 import android.view.ActionMode
+import android.view.KeyEvent
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -42,6 +43,7 @@ import ua.acclorite.book_story.ui.common.components.navigation_rail.NavigationRa
 import ua.acclorite.book_story.ui.common.helpers.ProvideSettings
 import ua.acclorite.book_story.ui.main.MainActivityKeyboardManager
 import ua.acclorite.book_story.ui.main.TextActionMode
+import ua.acclorite.book_story.ui.main.VolumeKeyPaging
 import ua.acclorite.book_story.ui.main.MainFileOpenEffects
 import ua.acclorite.book_story.ui.navigator.Navigator
 import ua.acclorite.book_story.ui.navigator.NavigatorTabs
@@ -219,6 +221,16 @@ class MainActivity : AppCompatActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         receiveFile(intent)
+    }
+
+    // Volume keys turn pages while the reader asks for them, and it asks here
+    // rather than through a modifier because a key event reaching the view
+    // hierarchy has already passed the window that handles the volume; see
+    // [VolumeKeyPaging]. Nothing else in the app takes a hardware key, so the
+    // question is only ever asked of one listener.
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (VolumeKeyPaging.intercept(event)) return true
+        return super.dispatchKeyEvent(event)
     }
 
     // The text-selection toolbar is an action mode on the window, whoever put it

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderScreen.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/ReaderScreen.kt
@@ -464,6 +464,7 @@ data class ReaderScreen(val bookId: Int) : Screen, Parcelable {
                 horizontalGestureAlphaAnim = settings.horizontalGestureAlphaAnim.value,
                 horizontalGesturePullAnim = settings.horizontalGesturePullAnim.value,
                 tapPaging = settings.tapPaging.value,
+                volumePaging = settings.volumePaging.value,
                 disableScrolling = settings.disableScrolling.value,
                 pageTurnOverlap = settings.pageTurnOverlap.value,
                 pageTurnAnimation = settings.pageTurnAnimation.value,

--- a/app/src/main/java/ua/acclorite/book_story/presentation/reader/model/ReaderVolumePaging.kt
+++ b/app/src/main/java/ua/acclorite/book_story/presentation/reader/model/ReaderVolumePaging.kt
@@ -1,0 +1,27 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.presentation.reader.model
+
+import androidx.annotation.StringRes
+import ua.acclorite.book_story.R
+
+/**
+ * Whether the volume keys turn pages, and which key goes forward. `ON` reads the
+ * keys the way the text moves — volume down goes further down the book — and
+ * `INVERSE` swaps them, because readers genuinely disagree about which key is
+ * forward and neither convention is more right than the other.
+ *
+ * Off by default, and for a reason that is not caution: while this is on the
+ * reader has no way to change the volume, which the reader who never asked for
+ * page keys would experience purely as a loss.
+ */
+enum class ReaderVolumePaging(@StringRes val title: Int) {
+    OFF(R.string.volume_paging_off),
+    ON(R.string.volume_paging_on),
+    INVERSE(R.string.volume_paging_inverse)
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/main/VolumeKeyPaging.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/main/VolumeKeyPaging.kt
@@ -1,0 +1,104 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.main
+
+import android.view.KeyEvent
+
+/**
+ * The volume keys, while the reader is asking for them.
+ *
+ * A hardware key is not a Compose gesture: `onKeyEvent` needs focus, and the
+ * reader has none to give — nothing in it is focusable. Volume keys are also
+ * handled by the window itself, above the view hierarchy, so the only place
+ * early enough to take them is the activity's own
+ * [dispatchKeyEvent][android.app.Activity.dispatchKeyEvent]. Hence a listener
+ * the reader hangs here while it wants them, and window state, hence a single
+ * value for the process: there is exactly one window. The same shape as
+ * [TextActionMode], and for the same reason.
+ *
+ * Nothing listens by default, so with the setting off — and while the menu, a
+ * text selection or an overlay is up — the keys are the system's and change the
+ * volume, which is the only way to change it while page keys are on.
+ */
+object VolumeKeyPaging {
+
+    private var listener: ((volumeUp: Boolean) -> Unit)? = null
+
+    /** Takes the keys, until [stopListening] with the same [onVolumeKey]. */
+    fun listen(onVolumeKey: (volumeUp: Boolean) -> Unit) {
+        listener = onVolumeKey
+    }
+
+    /**
+     * Gives them back — but only if [onVolumeKey] is still the one holding them.
+     * A listener that has already been replaced must not clear its successor:
+     * the reader re-registers on a setting change before the old effect is
+     * disposed, and the identity check is what keeps that from ending in
+     * silence.
+     */
+    fun stopListening(onVolumeKey: (volumeUp: Boolean) -> Unit) {
+        if (listener === onVolumeKey) listener = null
+    }
+
+    /** Whether [event] was ours; called from the activity's key dispatch. */
+    fun intercept(event: KeyEvent): Boolean {
+        val onVolumeKey = listener ?: return false
+
+        return when (val outcome = volumeKeyOutcome(
+            keyCode = event.keyCode,
+            action = event.action,
+            repeatCount = event.repeatCount
+        )) {
+            is VolumeKeyOutcome.Ignore -> false
+            is VolumeKeyOutcome.Swallow -> true
+            is VolumeKeyOutcome.Turn -> {
+                onVolumeKey(outcome.volumeUp)
+                true
+            }
+        }
+    }
+}
+
+/** What one key event means to a reader listening for the volume keys. */
+internal sealed interface VolumeKeyOutcome {
+
+    /** Not a volume key: it goes on its way untouched. */
+    data object Ignore : VolumeKeyOutcome
+
+    /** Ours, but not a page turn — eaten all the same; see [volumeKeyOutcome]. */
+    data object Swallow : VolumeKeyOutcome
+
+    /** A page, in the direction [volumeUp] asks for. */
+    data class Turn(val volumeUp: Boolean) : VolumeKeyOutcome
+}
+
+/**
+ * A press turns one page; everything else about the key is swallowed.
+ *
+ * Both halves matter. The **lift** has to be eaten because the system's volume
+ * panel is raised from `ACTION_UP` as much as from the press — consume only the
+ * down and the slider still flashes over the text on every page turn. And the
+ * auto-**repeat** of a held key is eaten rather than acted on: a key held down
+ * would otherwise fly through the book at the repeat rate, which is not a page
+ * turn but a scroll nobody asked for. One press, one page.
+ */
+internal fun volumeKeyOutcome(keyCode: Int, action: Int, repeatCount: Int): VolumeKeyOutcome {
+    val volumeUp = when (keyCode) {
+        KeyEvent.KEYCODE_VOLUME_UP -> true
+        KeyEvent.KEYCODE_VOLUME_DOWN -> false
+        // The mute key is left alone: it is not a direction, so it cannot be a
+        // page, and taking it would leave no way to silence the device at all.
+        else -> return VolumeKeyOutcome.Ignore
+    }
+
+    return when {
+        action != KeyEvent.ACTION_DOWN -> VolumeKeyOutcome.Swallow
+        repeatCount > 0 -> VolumeKeyOutcome.Swallow
+        else -> VolumeKeyOutcome.Turn(volumeUp = volumeUp)
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderContent.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderContent.kt
@@ -33,6 +33,7 @@ import ua.acclorite.book_story.presentation.reader.model.ReaderHorizontalGesture
 import ua.acclorite.book_story.presentation.reader.model.ReaderSearch
 import ua.acclorite.book_story.presentation.reader.model.ReaderTapPaging
 import ua.acclorite.book_story.presentation.reader.model.ReaderTextAlignment
+import ua.acclorite.book_story.presentation.reader.model.ReaderVolumePaging
 import ua.acclorite.book_story.presentation.settings.SettingsEvent
 import ua.acclorite.book_story.ui.reader.model.FontWithName
 import ua.acclorite.book_story.ui.theme.model.HorizontalAlignment
@@ -73,6 +74,7 @@ fun ReaderContent(
     horizontalGestureAlphaAnim: Boolean,
     horizontalGesturePullAnim: Boolean,
     tapPaging: ReaderTapPaging,
+    volumePaging: ReaderVolumePaging,
     disableScrolling: Boolean,
     pageTurnOverlap: Float,
     pageTurnAnimation: Boolean,
@@ -168,6 +170,18 @@ fun ReaderContent(
             horizontalGestureAlphaAnim = horizontalGestureAlphaAnim,
             horizontalGesturePullAnim = horizontalGesturePullAnim,
             tapPaging = tapPaging,
+            // Anything drawn over the reader takes the keys back with it. The
+            // image viewer and a note's sheet both open with the menu hidden,
+            // so the menu alone does not answer for them, and turning pages
+            // under a picture the reader is looking at is a page turn nobody
+            // sees — while the volume, which the overlay leaves alone, is what
+            // the keys are expected to do there.
+            volumePaging = when {
+                bottomSheet != null || drawer != null || fullscreenImage != null ->
+                    ReaderVolumePaging.OFF
+
+                else -> volumePaging
+            },
             disableScrolling = disableScrolling,
             pageTurnOverlap = pageTurnOverlap,
             pageTurnAnimation = pageTurnAnimation,

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderLayout.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderLayout.kt
@@ -47,6 +47,7 @@ import ua.acclorite.book_story.presentation.reader.model.ReaderFontThickness
 import ua.acclorite.book_story.presentation.reader.model.ReaderHorizontalGesture
 import ua.acclorite.book_story.presentation.reader.model.ReaderTapPaging
 import ua.acclorite.book_story.presentation.reader.model.ReaderTextAlignment
+import ua.acclorite.book_story.presentation.reader.model.ReaderVolumePaging
 import ua.acclorite.book_story.ui.common.components.common.AnimatedVisibility
 import ua.acclorite.book_story.ui.common.components.common.LazyColumnWithScrollbar
 import ua.acclorite.book_story.ui.common.components.common.SelectionContainer
@@ -67,6 +68,7 @@ fun ReaderLayout(
     horizontalGestureAlphaAnim: Boolean,
     horizontalGesturePullAnim: Boolean,
     tapPaging: ReaderTapPaging,
+    volumePaging: ReaderVolumePaging,
     disableScrolling: Boolean,
     pageTurnOverlap: Float,
     pageTurnAnimation: Boolean,
@@ -154,8 +156,9 @@ fun ReaderLayout(
         with(density) { lineHeightPx.toDp() }
     }
 
-    // Both triggers of a page turn — the tap zones and the horizontal swipe —
-    // go through one pager, so the same action cannot behave two ways.
+    // Every trigger of a page turn — the tap zones, the horizontal swipe and
+    // the volume keys — goes through one pager, so the same action cannot
+    // behave two ways.
     val pager = rememberReaderPager(
         listState = listState,
         overlap = lineHeightPx * pageTurnOverlap,
@@ -200,6 +203,15 @@ fun ReaderLayout(
             )
         },
     ) { toolbarHidden ->
+        // The keys are attached on the same terms as the tap zones, and on one
+        // more: while the menu is open they belong to the system again, which
+        // is the only way to change the volume with this on.
+        ReaderVolumeKeys(
+            enabled = !isLoading && toolbarHidden && !showMenu,
+            volumePaging = volumePaging,
+            pager = pager
+        )
+
         Column(
             Modifier
                 .fillMaxSize()
@@ -260,7 +272,12 @@ fun ReaderLayout(
                     // to nothing until the selection was dismissed — the same
                     // dead end this guard exists for, only lasting a moment.
                     canTurnPage = horizontalGesture != ReaderHorizontalGesture.OFF ||
-                            (tapZones != null && toolbarHidden)
+                            (tapZones != null && toolbarHidden) ||
+                            // The menu is not counted here, unlike above: it is
+                            // dismissed by the same tap that would have turned a
+                            // page, so the reader is one tap from the trigger
+                            // rather than stranded without one.
+                            (volumePaging != ReaderVolumePaging.OFF && toolbarHidden)
                 ),
                 contentPadding = PaddingValues(
                     top = (WindowInsets.displayCutout.asPaddingValues()

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderScaffold.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderScaffold.kt
@@ -45,6 +45,7 @@ import ua.acclorite.book_story.presentation.reader.model.ReaderSearch
 import ua.acclorite.book_story.presentation.reader.model.ReaderHorizontalGesture
 import ua.acclorite.book_story.presentation.reader.model.ReaderTapPaging
 import ua.acclorite.book_story.presentation.reader.model.ReaderTextAlignment
+import ua.acclorite.book_story.presentation.reader.model.ReaderVolumePaging
 import ua.acclorite.book_story.presentation.settings.SettingsEvent
 import ua.acclorite.book_story.ui.common.components.common.AnimatedVisibility
 import ua.acclorite.book_story.ui.reader.model.FontWithName
@@ -82,6 +83,7 @@ fun ReaderScaffold(
     horizontalGestureAlphaAnim: Boolean,
     horizontalGesturePullAnim: Boolean,
     tapPaging: ReaderTapPaging,
+    volumePaging: ReaderVolumePaging,
     disableScrolling: Boolean,
     pageTurnOverlap: Float,
     pageTurnAnimation: Boolean,
@@ -229,6 +231,7 @@ fun ReaderScaffold(
             horizontalGestureAlphaAnim = horizontalGestureAlphaAnim,
             horizontalGesturePullAnim = horizontalGesturePullAnim,
             tapPaging = tapPaging,
+            volumePaging = volumePaging,
             disableScrolling = disableScrolling,
             pageTurnOverlap = pageTurnOverlap,
             pageTurnAnimation = pageTurnAnimation,

--- a/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderVolumeKeys.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/reader/ReaderVolumeKeys.kt
@@ -1,0 +1,48 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.reader
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import ua.acclorite.book_story.presentation.reader.model.ReaderVolumePaging
+import ua.acclorite.book_story.ui.main.VolumeKeyPaging
+
+/**
+ * The reader's third page-turn trigger, beside the swipe and the tap zones, and
+ * the only one that is not a gesture — see [VolumeKeyPaging] for why it is taken
+ * on the activity rather than by a modifier here.
+ *
+ * It goes through the same [ReaderPager] as the other two, so a page turned by a
+ * key is the same page turn in every respect.
+ *
+ * [enabled] is what hands the keys back to the system, and it must, because
+ * while they are held the reader cannot change the volume: an open menu, a text
+ * selection and a book still loading all give them up.
+ */
+@Composable
+internal fun ReaderVolumeKeys(
+    enabled: Boolean,
+    volumePaging: ReaderVolumePaging,
+    pager: ReaderPager
+) {
+    if (!enabled || volumePaging == ReaderVolumePaging.OFF) return
+
+    DisposableEffect(volumePaging, pager) {
+        val onVolumeKey: (Boolean) -> Unit = { volumeUp ->
+            pager.turn(
+                forward = when (volumePaging) {
+                    ReaderVolumePaging.INVERSE -> volumeUp
+                    else -> !volumeUp
+                }
+            )
+        }
+
+        VolumeKeyPaging.listen(onVolumeKey)
+        onDispose { VolumeKeyPaging.stopListening(onVolumeKey) }
+    }
+}

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/reader/reading_mode/ReadingModeSubcategory.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/reader/reading_mode/ReadingModeSubcategory.kt
@@ -23,6 +23,7 @@ import ua.acclorite.book_story.ui.settings.reader.reading_mode.components.Horizo
 import ua.acclorite.book_story.ui.settings.reader.reading_mode.components.PageTurnAnimationOption
 import ua.acclorite.book_story.ui.settings.reader.reading_mode.components.PageTurnOverlapOption
 import ua.acclorite.book_story.ui.settings.reader.reading_mode.components.TapPagingOption
+import ua.acclorite.book_story.ui.settings.reader.reading_mode.components.VolumePagingOption
 
 fun LazyListScope.ReadingModeSubcategory(
     titleColor: @Composable () -> Color = { MaterialTheme.colorScheme.primary },
@@ -44,9 +45,13 @@ fun LazyListScope.ReadingModeSubcategory(
             TapPagingOption()
         }
 
+        item {
+            VolumePagingOption()
+        }
+
         // The overlap, the animation and giving up the scroll describe the page
-        // turn itself, so they sit under both of the gestures that ask for one;
-        // what follows belongs to the swipe alone.
+        // turn itself, so they sit under every trigger that asks for one; what
+        // follows belongs to the swipe alone.
         item {
             PageTurnOverlapOption()
         }

--- a/app/src/main/java/ua/acclorite/book_story/ui/settings/reader/reading_mode/components/VolumePagingOption.kt
+++ b/app/src/main/java/ua/acclorite/book_story/ui/settings/reader/reading_mode/components/VolumePagingOption.kt
@@ -1,0 +1,35 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.settings.reader.reading_mode.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import ua.acclorite.book_story.R
+import ua.acclorite.book_story.presentation.reader.model.ReaderVolumePaging
+import ua.acclorite.book_story.ui.common.components.settings.SegmentedButtonWithTitle
+import ua.acclorite.book_story.ui.common.helpers.LocalSettings
+import ua.acclorite.book_story.ui.common.model.ListItem
+
+@Composable
+fun VolumePagingOption() {
+    val settings = LocalSettings.current
+
+    SegmentedButtonWithTitle(
+        title = stringResource(id = R.string.volume_paging_option),
+        buttons = ReaderVolumePaging.entries.map { item ->
+            ListItem(
+                item = item,
+                title = stringResource(id = item.title),
+                selected = item == settings.volumePaging.value
+            )
+        },
+        onClick = { item ->
+            settings.volumePaging.update(item)
+        }
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -340,6 +340,7 @@
     <string name="horizontal_gesture_disable_scrolling_option">Disable scrolling</string>
     <string name="horizontal_gesture_disable_scrolling_option_desc">Completely disable reader scrolling</string>
     <string name="tap_paging_option">Tap to turn page</string>
+    <string name="volume_paging_option">Volume keys turn page</string>
     <string name="page_turn_overlap_option">Overlap (lines)</string>
     <string name="page_turn_animation_option">Page turn animation</string>
     <string name="page_turn_animation_option_desc">
@@ -449,6 +450,11 @@
     <string name="tap_paging_off">Off</string>
     <string name="tap_paging_on">On</string>
     <string name="tap_paging_inverse">On (Inverse)</string>
+
+    <!-- Volume paging properties -->
+    <string name="volume_paging_off">Off</string>
+    <string name="volume_paging_on">On</string>
+    <string name="volume_paging_inverse">On (Inverse)</string>
 
     <!-- Highlighted Reading properties -->
     <string name="highlighted_reading_level">level</string>

--- a/app/src/test/java/ua/acclorite/book_story/ui/main/VolumeKeyPagingTest.kt
+++ b/app/src/test/java/ua/acclorite/book_story/ui/main/VolumeKeyPagingTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Book's Story — free and open-source Material You eBook reader.
+ * Copyright (C) 2026 derand
+ * Copyright (C) 2024-2026 Acclorite
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package ua.acclorite.book_story.ui.main
+
+import android.view.KeyEvent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** What a volume key means to a reader that has asked for them. */
+class VolumeKeyPagingTest {
+
+    private fun outcome(
+        keyCode: Int,
+        action: Int = KeyEvent.ACTION_DOWN,
+        repeatCount: Int = 0
+    ) = volumeKeyOutcome(keyCode = keyCode, action = action, repeatCount = repeatCount)
+
+    @Test
+    fun aPressOfEitherKeyTurnsAPage() {
+        assertEquals(
+            VolumeKeyOutcome.Turn(volumeUp = true),
+            outcome(KeyEvent.KEYCODE_VOLUME_UP)
+        )
+        assertEquals(
+            VolumeKeyOutcome.Turn(volumeUp = false),
+            outcome(KeyEvent.KEYCODE_VOLUME_DOWN)
+        )
+    }
+
+    @Test
+    fun theLiftIsEatenTooOrTheVolumePanelStillAppears() {
+        assertEquals(
+            VolumeKeyOutcome.Swallow,
+            outcome(KeyEvent.KEYCODE_VOLUME_DOWN, action = KeyEvent.ACTION_UP)
+        )
+    }
+
+    @Test
+    fun aHeldKeyTurnsOnePageAndNoMore() {
+        // The auto-repeat is consumed rather than acted on: at the repeat rate
+        // it would be a scroll through the book, not a page turn.
+        assertEquals(
+            VolumeKeyOutcome.Swallow,
+            outcome(KeyEvent.KEYCODE_VOLUME_UP, repeatCount = 3)
+        )
+    }
+
+    @Test
+    fun everyOtherKeyIsLeftAlone() {
+        // The mute key included: it is not a direction, and taking it would
+        // leave no way to silence the device from the reader at all.
+        assertEquals(VolumeKeyOutcome.Ignore, outcome(KeyEvent.KEYCODE_VOLUME_MUTE))
+        assertEquals(VolumeKeyOutcome.Ignore, outcome(KeyEvent.KEYCODE_BACK))
+        assertEquals(
+            VolumeKeyOutcome.Ignore,
+            outcome(KeyEvent.KEYCODE_MEDIA_NEXT, action = KeyEvent.ACTION_UP)
+        )
+    }
+}


### PR DESCRIPTION
Closes #100.

A third page-turn trigger beside the horizontal swipe and the tap zones, off by default, with the same `Off / On / Inverse` shape as `Tap to turn page`. `On` reads the keys the way the text moves — volume down goes further down the book — and `Inverse` swaps them, because which key is forward is not a settled convention.

## What it does

- **One pager.** The keys go through the same `ReaderPager` as the swipe and the tap zones, so a page turned by a key is the same page turn — same step, same overlap, same animation.
- **The key itself is the new part.** Nothing in the app took a hardware key before. A Compose modifier cannot: `onKeyEvent` needs focus and the reader has none to give, and the window handles the volume above the view hierarchy anyway. So the reader hangs a listener on `VolumeKeyPaging` while it wants the keys, and `MainActivity.dispatchKeyEvent` asks it first.
- **Press, repeat and lift are all consumed.** Consume only the down and the system's volume panel still flashes over the text; act on the auto-repeat and a held key flies through the book at the repeat rate. One press, one page.
- **Everything that takes the reader's attention hands the keys back** — the menu, a text selection, and anything drawn over the reader (the image viewer and a note's sheet both open with the menu hidden, so the menu alone does not answer for them). That is the escape hatch: opening the menu is how the volume is changed while this is on.
- **`pageTurnEnabled` counts the third trigger**, or the overlap, animation and disable-scrolling rows vanish when the keys are the only one switched on. `canTurnPage` counts it too, so giving up free scrolling stays honoured.

## Tested

4 new JVM tests for what one key event means (press / lift / auto-repeat / every other key, mute included); the whole suite is 354 green, `lintDebug` clean.

Device QA on the tablet, debug build, comparing screenshots pixel for pixel:

| Case | Result |
|---|---|
| Setting `Off` (default), volume down | system volume panel, text unmoved |
| `On`, volume down | one page forward, no panel |
| `On`, volume up | back to the previous page, pixel-identical |
| Key held down | exactly one page, identical to a single press |
| Menu open | volume panel — keys are the system's again |
| Settings sheet open (the overlay gate) | volume panel |
| Text selection active | volume panel |
| `Inverse` | down goes back, up goes forward |
| Keys the only trigger switched on | `Overlap (lines)` and `Page turn animation` still shown |

The image viewer and the note sheet are the same one expression as the settings sheet, which is the case that was walked.

Out of scope, as the issue says: any other hardware key, and remapping.
